### PR TITLE
feat: cli subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 Cargo.lock
 data
+*.pf
 *~
 \#*\#

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note that the library requires a nightly version of the rust toolchain. You can 
 rustup override set nightly         
 ```
 
-## `ezkl` command line interface
+## command line interface
 
 The `ezkl` cli provides a simple interface to load ONNX neural networks, convert them into a Halo2 circuit, then run a proof (given a public input).
 
@@ -31,15 +31,32 @@ Usage:
 Usage: ezkl [OPTIONS] --scale <SCALE> --bits <BITS>
 
 Options:
-  -D, --data <DATA>       The path to the .json data file [default: ]
-  -M, --model <MODEL>     The path to the .onnx model file [default: ]
-  -S, --scale <SCALE>     The denominator in the fixed point representation used when quantizing
-  -B, --bits <BITS>       The number of bits used in lookup tables
-  -K, --logrows <LOGROWS> 2^LOGROWS is the number of rows in the circuit
-  -h, --help              Print help information
-  -V, --version           Print version information
+Usage: ezkl [OPTIONS] <COMMAND>
+
+Commands:
+  table      Loads model and prints model table
+  mock       Loads model and input and runs mock prover (for testing)
+  fullprove  Loads model and input and runs full prover (for testing)
+  prove      Loads model and data, prepares vk and pk, and creates proof, saving proof in --output
+  verify     Verifies a proof, returning accept or reject
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+  -S, --scale <SCALE>      The denominator in the fixed point representation used when quantizing [default: 7]
+  -B, --bits <BITS>        The number of bits used in lookup tables [default: 14]
+  -K, --logrows <LOGROWS>  The log_2 number of rows [default: 16]
+  -h, --help               Print help information
+  -V, --version            Print version information
 ```
-If `-D` and `-M` are not provided the cli will query the user to manually enter the path(s). Bits, scale, and logrows have default values. `.onnx` can be generated using pytorch or tensorflow. The data json file is structured as follows:
+Bits, scale, and logrows have default values. `prove`, `mock`, `fullprove` all require `-D` and `-M` parameters, which if not provided, the cli will query the user to manually enter the path(s).
+```bash
+Usage: ezkl mock [OPTIONS]
+
+Options:
+  -D, --data <DATA>    The path to the .json data file [default: ]
+  -M, --model <MODEL>  The path to the .onnx model file [default: ]
+```
+The `.onnx` file can be generated using pytorch or tensorflow. The data json file is structured as follows:
 
 ```json
 {

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -15,22 +15,9 @@ use serde_json;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
-//use std::path::Path;
-
-//use ezkl::fieldutils;
-//use ezkl::tensor::*;
 use halo2_proofs::{
     arithmetic::FieldExt,
-    //    circuit::{Layouter, SimpleFloorPlanner, Value},
-    plonk::{
-        create_proof,
-        keygen_pk,
-        keygen_vk,
-        verify_proof,
-        Circuit, //Column, ConstraintSystem, Error,
-                 // Fixed,
-                 // Instance,
-    },
+    plonk::{create_proof, keygen_pk, keygen_vk, verify_proof, Circuit},
     poly::{
         commitment::ParamsProver,
         ipa::{
@@ -92,11 +79,11 @@ pub fn main() {
             model: _,
             pfsys,
         } => {
-            info!("Full proof with {}", pfsys);
+            info!("full proof with {}", pfsys);
             let args = Cli::parse();
             let (circuit, public_input) = prepare_circuit_and_public_input(data);
             let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
-            trace!("Params computed");
+            trace!("params computed");
 
             let (pk, proof, _dims) = create_ipa_proof(circuit, public_input.clone(), &params);
 
@@ -114,7 +101,7 @@ pub fn main() {
                 &mut transcript
             )
             .is_ok());
-            info!("Verify took {}", now.elapsed().as_secs());
+            info!("verify took {}", now.elapsed().as_secs());
         }
         Commands::Prove {
             data,
@@ -122,11 +109,11 @@ pub fn main() {
             output,
             pfsys,
         } => {
-            info!("Proof with {}", pfsys);
+            info!("proof with {}", pfsys);
             let args = Cli::parse();
             let (circuit, public_input) = prepare_circuit_and_public_input(data);
             let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
-            trace!("Params computed");
+            trace!("params computed");
 
             let (_pk, proof, _input_dims) =
                 create_ipa_proof(circuit.clone(), public_input.clone(), &params);
@@ -156,7 +143,7 @@ pub fn main() {
             let proof: Proof = serde_json::from_str(&data).expect("JSON was not well-formatted");
 
             let result = verify_ipa_proof(proof);
-            println!("Verified: {}", result)
+            info!("verified: {}", result)
         }
     }
 }
@@ -216,7 +203,7 @@ fn create_ipa_proof(
 
     // Initialize the proving key
     let now = Instant::now();
-    trace!("Preparing VK");
+    trace!("preparing VK");
     let vk = keygen_vk(params, &empty_circuit).expect("keygen_vk should not fail");
     info!("VK took {}", now.elapsed().as_secs());
     let now = Instant::now();
@@ -277,7 +264,7 @@ fn verify_ipa_proof(proof: Proof) -> bool {
     let strategy = SingleStrategy::new(&params);
     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof.proof[..]);
 
-    trace!("Params computed");
+    trace!("params computed");
 
     let result = verify_proof(
         &params,
@@ -287,7 +274,7 @@ fn verify_ipa_proof(proof: Proof) -> bool {
         &mut transcript,
     )
     .is_ok();
-    info!("Verify took {}", now.elapsed().as_secs());
+    info!("verify took {}", now.elapsed().as_secs());
     result
 }
 

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -1,14 +1,52 @@
 use clap::Parser;
+use colog;
+use ezkl::commands::{data_path, Cli, Commands};
 use ezkl::fieldutils::i32_to_felt;
-use ezkl::onnx::{utilities::vector_to_quantized, Cli, OnnxCircuit};
+use ezkl::onnx::{utilities::vector_to_quantized, OnnxCircuit, OnnxModel};
+use ezkl::tensor::Tensor;
 use halo2_proofs::dev::MockProver;
 use halo2curves::pasta::Fp as F;
-use log::{info, trace};
+use log::{debug, info, trace};
+use serde;
 use serde::Deserialize;
+use serde_json;
 use std::fs::File;
-use std::io::{stdin, stdout, Read, Write};
+use std::io::{Read, Write};
 use std::marker::PhantomData;
-use std::path::Path;
+//use std::path::Path;
+
+//use ezkl::fieldutils;
+//use ezkl::tensor::*;
+use halo2_proofs::{
+    //    arithmetic::FieldExt,
+    //    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{
+        create_proof,
+        keygen_pk,
+        keygen_vk,
+        verify_proof,
+        Circuit, //Column, ConstraintSystem, Error,
+                 // Fixed,
+                 // Instance,
+    },
+    poly::{
+        commitment::ParamsProver,
+        ipa::{
+            commitment::{IPACommitmentScheme, ParamsIPA},
+            multiopen::ProverIPA,
+            strategy::SingleStrategy,
+        },
+        VerificationStrategy,
+    },
+    transcript::{
+        Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
+    },
+};
+use halo2curves::pasta::vesta;
+use rand::rngs::OsRng;
+use rand::seq::SliceRandom;
+use std::time::Instant;
+use tabled::Table;
 
 #[derive(Debug, Deserialize)]
 struct OnnxInput {
@@ -19,9 +57,230 @@ struct OnnxInput {
 
 pub fn main() {
     colog::init();
+    let args = Cli::parse();
+    banner();
 
+    match args.command {
+        Commands::Table { model: _ } => {
+            let om = OnnxModel::from_arg();
+            println!("{}", Table::new(om.onnx_nodes.clone()).to_string());
+        }
+        Commands::Mock { data, model: _ } => {
+            let args = Cli::parse();
+            let k = args.logrows;
+            let mut file = File::open(data_path(data)).unwrap();
+            let mut data = String::new();
+            file.read_to_string(&mut data).unwrap();
+            let data: OnnxInput = serde_json::from_str(&data).expect("JSON was not well-formatted");
+
+            // quantize the supplied data using the provided scale.
+            let input =
+                vector_to_quantized(&data.input_data, &data.input_shape, 0.0, args.scale).unwrap();
+            info!(
+                "public input length (network output) {:?}",
+                data.public_input.len()
+            );
+            // quantize the supplied data using the provided scale.
+            let public_input = vector_to_quantized(
+                &data.public_input,
+                &Vec::from([data.public_input.len()]),
+                0.0,
+                args.scale,
+            )
+            .unwrap();
+
+            trace!("{:?}", public_input);
+
+            let circuit = OnnxCircuit::<F> {
+                input,
+                _marker: PhantomData,
+            };
+
+            let prover = MockProver::run(
+                k,
+                &circuit,
+                vec![public_input.iter().map(|x| i32_to_felt::<F>(*x)).collect()],
+            )
+            .unwrap();
+            prover.assert_satisfied();
+        }
+        Commands::Fullprove {
+            data,
+            model: _,
+            pfsys,
+        } => {
+            info!("Full proof with {}", pfsys);
+            //            let proof = create_ipa_proof();
+            let args = Cli::parse();
+            // load
+            let k = args.logrows;
+            let mut file = File::open(data_path(data)).unwrap();
+            let mut data = String::new();
+            file.read_to_string(&mut data).unwrap();
+
+            let data: OnnxInput = serde_json::from_str(&data).expect("JSON was not well-formatted");
+
+            // quantize the supplied data using the provided scale.
+            let input =
+                vector_to_quantized(&data.input_data, &data.input_shape, 0.0, args.scale).unwrap();
+            info!(
+                "public input length (network output) {:?}",
+                data.public_input.len()
+            );
+            // quantize the supplied data using the provided scale.
+            let public_input = vector_to_quantized(
+                &data.public_input,
+                &Vec::from([data.public_input.len()]),
+                0.0,
+                args.scale,
+            )
+            .unwrap();
+
+            trace!("{:?}", public_input);
+
+            let circuit = OnnxCircuit::<F> {
+                input,
+                _marker: PhantomData,
+            };
+
+            //	Real proof
+            let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(k);
+            trace!("params computed");
+            let empty_circuit = circuit.without_witnesses();
+            trace!("without witnesses done:");
+            trace!("{:?}", empty_circuit);
+            // Initialize the proving key
+            let now = Instant::now();
+            trace!("Preparing VK");
+            let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
+            println!("VK took {}", now.elapsed().as_secs());
+            let now = Instant::now();
+            let pk =
+                keygen_pk(&params, vk.clone(), &empty_circuit).expect("keygen_pk should not fail");
+            println!("PK took {}", now.elapsed().as_secs());
+            let now = Instant::now();
+            let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+            let mut rng = OsRng;
+
+            let pi_inner: Tensor<F> = public_input.map(|x| i32_to_felt::<F>(x).into());
+            trace!("filling {:?}", pi_inner);
+            let pi_for_real_prover: &[&[&[F]]] = &[&[&pi_inner.into_iter().collect::<Vec<F>>()]];
+            trace!("pi for real prover {:?}", pi_for_real_prover);
+
+            create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
+                &params,
+                &pk,
+                &[circuit],
+                pi_for_real_prover,
+                &mut rng,
+                &mut transcript,
+            )
+            .expect("proof generation should not fail");
+            let proof = transcript.finalize();
+            //println!("{:?}", proof);
+            println!("Proof took {}", now.elapsed().as_secs());
+
+            let now = Instant::now();
+            let strategy = SingleStrategy::new(&params);
+            let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+            assert!(verify_proof(
+                &params,
+                pk.get_vk(),
+                strategy,
+                pi_for_real_prover,
+                &mut transcript
+            )
+            .is_ok());
+            println!("Verify took {}", now.elapsed().as_secs());
+        }
+        _ => todo!(),
+    }
+}
+
+// fn create_ipa_proof() -> Vec<u8> {
+//     let args = Cli::parse();
+//     // load
+//     let k = args.logrows;
+//     let mut file = File::open(data_path(data)).unwrap();
+//     let mut data = String::new();
+//     file.read_to_string(&mut data).unwrap();
+
+//     let data: OnnxInput = serde_json::from_str(&data).expect("JSON was not well-formatted");
+
+//     // quantize the supplied data using the provided scale.
+//     let input = vector_to_quantized(&data.input_data, &data.input_shape, 0.0, args.scale).unwrap();
+//     info!(
+//         "public input length (network output) {:?}",
+//         data.public_input.len()
+//     );
+//     // quantize the supplied data using the provided scale.
+//     let public_input = vector_to_quantized(
+//         &data.public_input,
+//         &Vec::from([data.public_input.len()]),
+//         0.0,
+//         args.scale,
+//     )
+//     .unwrap();
+
+//     trace!("{:?}", public_input);
+
+//     let circuit = OnnxCircuit::<F> {
+//         input,
+//         _marker: PhantomData,
+//     };
+
+//     //	Real proof
+//     let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(k);
+//     trace!("params computed");
+//     let empty_circuit = circuit.without_witnesses();
+//     trace!("without witnesses done:");
+//     trace!("{:?}", empty_circuit);
+//     // Initialize the proving key
+//     let now = Instant::now();
+//     trace!("Preparing VK");
+//     let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
+//     println!("VK took {}", now.elapsed().as_secs());
+//     let now = Instant::now();
+//     let pk = keygen_pk(&params, vk.clone(), &empty_circuit).expect("keygen_pk should not fail");
+//     println!("PK took {}", now.elapsed().as_secs());
+//     let now = Instant::now();
+//     let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+//     let mut rng = OsRng;
+
+//     let pi_inner: Tensor<F> = public_input.map(|x| i32_to_felt::<F>(x).into());
+//     trace!("filling {:?}", pi_inner);
+//     let pi_for_real_prover: &[&[&[F]]] = &[&[&pi_inner.into_iter().collect::<Vec<F>>()]];
+//     trace!("pi for real prover {:?}", pi_for_real_prover);
+
+//     create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
+//         &params,
+//         &pk,
+//         &[circuit],
+//         pi_for_real_prover,
+//         &mut rng,
+//         &mut transcript,
+//     )
+//     .expect("proof generation should not fail");
+//     let proof = transcript.finalize();
+//     //println!("{:?}", proof);
+//     println!("Proof took {}", now.elapsed().as_secs());
+//     proof
+// }
+
+fn banner() {
+    let ell: Vec<&str> = vec![
+        "for Neural Networks",
+        "Linear Algebra",
+        "for Layers",
+        "for the Laconic",
+        "Learning",
+        "for Liberty",
+        "for the Lyrical",
+    ];
     info!(
-        "
+        "{}",
+        format!(
+            "
         ███████╗███████╗██╗  ██╗██╗
         ██╔════╝╚══███╔╝██║ ██╔╝██║
         █████╗    ███╔╝ █████╔╝ ██║
@@ -30,65 +289,10 @@ pub fn main() {
         ╚══════╝╚══════╝╚═╝  ╚═╝╚══════╝
 
         -----------------------------------------------------------
-        Easy Zero Knowledge for Neural Networks.
+        Easy Zero Knowledge {}.
         -----------------------------------------------------------
-        "
+        ",
+            ell.choose(&mut rand::thread_rng()).unwrap()
+        )
     );
-
-    let mut args = Cli::parse();
-    // load
-    let mut s = String::new();
-    let k = args.logrows;
-    let data_path = match args.data.is_empty() {
-        false => {
-            info!("loading data from {}", args.data.clone());
-            args.data = args.data.replace(' ', "");
-            Path::new(&args.data)
-        }
-        true => {
-            info!("please enter a path to a .json file containing inputs for the model: ");
-            let _ = stdout().flush();
-            let _ = &stdin()
-                .read_line(&mut s)
-                .expect("did not enter a correct string");
-            s.truncate(s.len() - 1);
-            Path::new(&s)
-        }
-    };
-    assert!(data_path.exists());
-    let mut file = File::open(data_path).unwrap();
-    let mut data = String::new();
-    file.read_to_string(&mut data).unwrap();
-
-    let data: OnnxInput = serde_json::from_str(&data).expect("JSON was not well-formatted");
-
-    // quantize the supplied data using the provided scale.
-    let input = vector_to_quantized(&data.input_data, &data.input_shape, 0.0, args.scale).unwrap();
-    info!(
-        "public input length (network output) {:?}",
-        data.public_input.len()
-    );
-    // quantize the supplied data using the provided scale.
-    let public_input = vector_to_quantized(
-        &data.public_input,
-        &Vec::from([data.public_input.len()]),
-        0.0,
-        args.scale,
-    )
-    .unwrap();
-
-    trace!("{:?}", public_input);
-
-    let circuit = OnnxCircuit::<F> {
-        input,
-        _marker: PhantomData,
-    };
-
-    let prover = MockProver::run(
-        k,
-        &circuit,
-        vec![public_input.iter().map(|x| i32_to_felt::<F>(*x)).collect()],
-    )
-    .unwrap();
-    prover.assert_satisfied();
 }

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -4,12 +4,11 @@ use ezkl::commands::{data_path, Cli, Commands};
 use ezkl::fieldutils::i32_to_felt;
 use ezkl::onnx::{utilities::vector_to_quantized, OnnxCircuit, OnnxModel};
 use ezkl::tensor::Tensor;
-use halo2_proofs::circuit;
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::plonk::ProvingKey;
 use halo2curves::pasta::Fp;
 use halo2curves::pasta::{EqAffine, Fp as F};
-use log::{debug, info, trace};
+use log::{info, trace};
 use serde;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -99,7 +98,7 @@ pub fn main() {
             let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
             trace!("Params computed");
 
-            let (pk, proof, dims) = create_ipa_proof(circuit, public_input.clone(), &params);
+            let (pk, proof, _dims) = create_ipa_proof(circuit, public_input.clone(), &params);
 
             let pi_inner: Tensor<F> = public_input.map(|x| i32_to_felt::<F>(x).into());
             let pi_for_real_prover: &[&[&[F]]] = &[&[&pi_inner.into_iter().collect::<Vec<F>>()]];
@@ -119,7 +118,7 @@ pub fn main() {
         }
         Commands::Prove {
             data,
-            model,
+            model: _,
             output,
             pfsys,
         } => {
@@ -129,7 +128,7 @@ pub fn main() {
             let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
             trace!("Params computed");
 
-            let (pk, proof, input_dims) =
+            let (_pk, proof, _input_dims) =
                 create_ipa_proof(circuit.clone(), public_input.clone(), &params);
 
             let pi: Vec<_> = public_input.clone().into_iter().collect();
@@ -159,8 +158,6 @@ pub fn main() {
             let result = verify_ipa_proof(proof);
             println!("Verified: {}", result)
         }
-
-        _ => todo!(),
     }
 }
 
@@ -213,7 +210,7 @@ fn create_ipa_proof(
     public_input: Tensor<i32>,
     params: &ParamsIPA<vesta::Affine>,
 ) -> (ProvingKey<EqAffine>, Vec<u8>, Vec<usize>) {
-    let args = Cli::parse();
+    //let args = Cli::parse();
     //	Real proof
     let empty_circuit = circuit.without_witnesses();
 
@@ -290,7 +287,7 @@ fn verify_ipa_proof(proof: Proof) -> bool {
         &mut transcript,
     )
     .is_ok();
-    println!("Verify took {}", now.elapsed().as_secs());
+    info!("Verify took {}", now.elapsed().as_secs());
     result
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,10 +90,9 @@ pub enum Commands {
         #[arg(short = 'O', long, default_value = "")]
         output: PathBuf,
 
-        /// The path to the Params for the proof system
-        #[arg(short = 'P', long, default_value = "")]
-        params: PathBuf,
-
+        // /// The path to the Params for the proof system
+        // #[arg(short = 'P', long, default_value = "")]
+        // params: PathBuf,
         #[arg(
             long,
 	    short = 'B',
@@ -108,18 +107,17 @@ pub enum Commands {
     },
     /// Verifies a proof, returning accept or reject
     Verify {
-        /// The path to the .json data file, which should include only the network output as public input to the proof
-        #[arg(short = 'D', long, default_value = "")]
-        data: String,
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long, default_value = "")]
+        model: String,
 
-        /// The path to the VerificationKey
-        #[arg(short = 'V', long, default_value = "")]
-        vkey: PathBuf,
-
-        /// The path to the Params for the proof system
+        /// The path to the proof file
         #[arg(short = 'P', long, default_value = "")]
-        params: PathBuf,
+        proof: PathBuf,
 
+        // /// The path to the Params for the proof system
+        // #[arg(short = 'P', long, default_value = "")]
+        // params: PathBuf,
         #[arg(
             long,
 	    short = 'B',

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,226 @@
+//use crate::onnx::OnnxModel;
+use clap::{Parser, Subcommand, ValueEnum};
+use log::info;
+use std::io::{stdin, stdout, Write};
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+    /// The denominator in the fixed point representation used when quantizing
+    #[arg(short = 'S', long, default_value = "7")]
+    pub scale: i32,
+    /// The number of bits used in lookup tables
+    #[arg(short = 'B', long, default_value = "14")]
+    pub bits: usize,
+    /// The log_2 number of rows
+    #[arg(short = 'K', long, default_value = "16")]
+    pub logrows: u32,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ProofSystem {
+    IPA,
+    KZG,
+}
+impl std::fmt::Display for ProofSystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Loads model and prints model table
+    #[command(arg_required_else_help = true)]
+    Table {
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long, default_value = "")]
+        model: String,
+    },
+
+    /// Loads model and input and runs mock prover (for testing)
+    #[command(arg_required_else_help = true)]
+    Mock {
+        /// The path to the .json data file
+        #[arg(short = 'D', long, default_value = "")]
+        data: String,
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long, default_value = "")]
+        model: String,
+    },
+
+    /// Loads model and input and runs full prover (for testing)
+    #[command(arg_required_else_help = true)]
+    Fullprove {
+        /// The path to the .json data file
+        #[arg(short = 'D', long, default_value = "")]
+        data: String,
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long, default_value = "")]
+        model: String,
+        //todo: optional Params
+        #[arg(
+            long,
+	    short = 'B',
+            require_equals = true,
+            num_args = 0..=1,
+            default_value_t = ProofSystem::IPA,
+//            default_missing_value = "always",
+            value_enum
+        )]
+        pfsys: ProofSystem,
+    },
+
+    /// Loads model and data, prepares vk and pk, and creates proof, saving proof in --output
+    Prove {
+        /// The path to the .json data file, which should include both the network input (possibly private) and the network output (public input to the proof)
+        #[arg(short = 'D', long, default_value = "")]
+        data: String,
+
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long, default_value = "")]
+        model: String,
+        /// The path to the desired output file
+        #[arg(short = 'O', long, default_value = "")]
+        output: PathBuf,
+
+        /// The path to the Params for the proof system
+        #[arg(short = 'P', long, default_value = "")]
+        params: PathBuf,
+
+        #[arg(
+            long,
+	    short = 'B',
+            require_equals = true,
+            num_args = 0..=1,
+            default_value_t = ProofSystem::IPA,
+            default_missing_value = "always",
+            value_enum
+        )]
+        pfsys: ProofSystem,
+        // todo, optionally allow supplying proving key
+    },
+    /// Verifies a proof, returning accept or reject
+    Verify {
+        /// The path to the .json data file, which should include only the network output as public input to the proof
+        #[arg(short = 'D', long, default_value = "")]
+        data: String,
+
+        /// The path to the VerificationKey
+        #[arg(short = 'V', long, default_value = "")]
+        vkey: PathBuf,
+
+        /// The path to the Params for the proof system
+        #[arg(short = 'P', long, default_value = "")]
+        params: PathBuf,
+
+        #[arg(
+            long,
+	    short = 'B',
+            require_equals = true,
+            num_args = 0..=1,
+            default_value_t = ProofSystem::IPA,
+            default_missing_value = "always",
+            value_enum
+        )]
+        pfsys: ProofSystem,
+        // todo, allow optional vkey and params when applicable
+    },
+    // Awaiting PR to stabilize VK and PK formats
+    // /// Loads model and prepares verification key, saving in --output
+    // Vkey {
+    //     /// The path to the .onnx model file
+    //     #[arg(short = 'M', long, default_value = "")]
+    //     model: String,
+    //     /// The path to the desired output file
+    //     #[arg(short = 'O', long, default_value = "")]
+    //     output: PathBuf,
+
+    //     /// The path to the Params for the proof system
+    //     #[arg(short = 'P', long, default_value = "")]
+    //     params: PathBuf,
+
+    //     #[arg(
+    //         long,
+    // 	    short = 'B',
+    //         require_equals = true,
+    //         num_args = 0..=1,
+    //         default_value_t = ProofSystem::IPA,
+    //         default_missing_value = "always",
+    //         value_enum
+    //     )]
+    //     pfsys: ProofSystem,
+    // },
+
+    // /// Loads model and prepares verification and proving key, saving proving key in --output
+    // Pkey {
+    //     /// The path to the .onnx model file
+    //     #[arg(short = 'M', long, default_value = "")]
+    //     model: String,
+    //     /// The path to the desired output file
+    //     #[arg(short = 'O', long, default_value = "")]
+    //     output: PathBuf,
+
+    //     /// The path to the Params for the proof system
+    //     #[arg(short = 'P', long, default_value = "")]
+    //     params: PathBuf,
+
+    //     #[arg(
+    //         long,
+    // 	    short = 'B',
+    //         require_equals = true,
+    //         num_args = 0..=1,
+    //         default_value_t = ProofSystem::IPA,
+    //         default_missing_value = "always",
+    //         value_enum
+    //     )]
+    //     pfsys: ProofSystem,
+    //     // todo, optionally allow supplying verification key
+    // },
+}
+
+pub fn model_path(model: String) -> PathBuf {
+    let mut s = String::new();
+    let model_path = match model.is_empty() {
+        false => {
+            info!("loading model from {}", model.clone());
+            Path::new(&model)
+        }
+        true => {
+            info!("please enter a path to a .onnx file containing a model: ");
+            let _ = stdout().flush();
+            let _ = &stdin()
+                .read_line(&mut s)
+                .expect("did not enter a correct string");
+            s.truncate(s.len() - 1);
+            Path::new(&s)
+        }
+    };
+    assert!(model_path.exists());
+    model_path.into()
+}
+
+pub fn data_path(data: String) -> PathBuf {
+    let mut s = String::new();
+    match data.is_empty() {
+        false => {
+            info!("loading data from {}", data);
+            PathBuf::from(data)
+        }
+        true => {
+            info!("please enter a path to a .json file containing inputs for the model: ");
+            let _ = stdout().flush();
+            let _ = &stdin()
+                .read_line(&mut s)
+                .expect("did not enter a correct string");
+            s.truncate(s.len() - 1);
+            PathBuf::from(&s)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(slice_flatten)]
 
+/// Commands
+pub mod commands;
 /// Utilities for converting from Halo2 Field types to integers (and vice-versa).
 pub mod fieldutils;
 /// Methods for configuring neural network layers and assigning values to them in a Halo2 circuit.

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -11,7 +11,7 @@ pub mod utilities;
 use std::cmp::max;
 pub use utilities::*;
 pub mod onnxmodel;
-use log::info;
+use log::{info, trace};
 pub use onnxmodel::*;
 
 #[derive(Clone, Debug)]
@@ -55,15 +55,17 @@ impl<F: FieldExt + TensorType> Circuit<F> for OnnxCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
+        trace!("Setting input in synthesize");
         let input = ValTensor::from(<Tensor<i32> as Into<Tensor<Value<F>>>>::into(
             self.input.clone(),
         ));
-
+        trace!("Setting output in synthesize");
         let output = config
             .model
             .layout(config.clone(), &mut layouter, input)
             .unwrap();
 
+        trace!("Laying out output in synthesize");
         match output {
             ValTensor::PrevAssigned { inner: v, dims: _ } => v.enum_map(|i, x| {
                 layouter

--- a/src/onnx/onnxmodel.rs
+++ b/src/onnx/onnxmodel.rs
@@ -356,8 +356,6 @@ impl OnnxModel {
                 proof: _,
                 pfsys: _,
             } => OnnxModel::new(model_path(model), args.scale, args.bits),
-
-            _ => todo!(),
         }
     }
 

--- a/src/onnx/onnxmodel.rs
+++ b/src/onnx/onnxmodel.rs
@@ -349,7 +349,11 @@ impl OnnxModel {
                 data: _,
                 model,
                 output: _,
-                params: _,
+                pfsys: _,
+            } => OnnxModel::new(model_path(model), args.scale, args.bits),
+            Commands::Verify {
+                model,
+                proof: _,
                 pfsys: _,
             } => OnnxModel::new(model_path(model), args.scale, args.bits),
 

--- a/src/onnx/onnxmodel.rs
+++ b/src/onnx/onnxmodel.rs
@@ -1,4 +1,5 @@
 use super::utilities::{node_output_shapes, scale_to_multiplier, vector_to_quantized};
+use crate::commands::{model_path, Cli, Commands};
 use crate::nn::affine::Affine1dConfig;
 use crate::nn::cnvrl::ConvConfig;
 use crate::nn::eltwise::{DivideBy, EltwiseConfig, ReLu, Sigmoid};
@@ -15,7 +16,6 @@ use halo2_proofs::{
 use log::{debug, error, info, trace, warn};
 use std::cmp::max;
 use std::fmt;
-use std::io::{stdin, stdout, Write};
 use std::path::Path;
 use tabled::{Table, Tabled};
 use tract_onnx;
@@ -77,26 +77,6 @@ pub struct OnnxModelConfig<F: FieldExt + TensorType> {
     configs: Vec<OnnxNodeConfig<F>>,
     pub model: OnnxModel,
     pub public_output: Column<Instance>,
-}
-
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-pub struct Cli {
-    /// The path to the .json data file
-    #[arg(short = 'D', long, default_value = "")]
-    pub data: String,
-    /// The path to the .onnx model file
-    #[arg(short = 'M', long, default_value = "")]
-    pub model: String,
-    /// The denominator in the fixed point representation used when quantizing
-    #[arg(short = 'S', long, default_value = "7")]
-    pub scale: i32,
-    /// The number of bits used in lookup tables
-    #[arg(short = 'B', long, default_value = "14")]
-    pub bits: usize,
-    /// The log_2 number of rows
-    #[arg(short = 'K', long, default_value = "16")]
-    pub logrows: u32,
 }
 
 fn display_option<T: fmt::Debug>(o: &Option<T>) -> String {
@@ -342,25 +322,39 @@ impl OnnxModel {
     }
     pub fn from_arg() -> Self {
         let args = Cli::parse();
-        let mut s = String::new();
 
-        let model_path = match args.model.is_empty() {
-            false => {
-                info!("loading model from {}", args.model.clone());
-                Path::new(&args.model)
+        match args.command {
+            Commands::Table { model } => OnnxModel::new(model_path(model), args.scale, args.bits),
+            Commands::Mock { data: _, model } => {
+                OnnxModel::new(model_path(model), args.scale, args.bits)
             }
-            true => {
-                info!("please enter a path to a .onnx file containing a model: ");
-                let _ = stdout().flush();
-                let _ = &stdin()
-                    .read_line(&mut s)
-                    .expect("did not enter a correct string");
-                s.truncate(s.len() - 1);
-                Path::new(&s)
-            }
-        };
-        assert!(model_path.exists());
-        OnnxModel::new(model_path, args.scale, args.bits)
+            Commands::Fullprove {
+                data: _,
+                model,
+                pfsys: _,
+            } => OnnxModel::new(model_path(model), args.scale, args.bits),
+            // Commands::Vkey {
+            //     model,
+            //     output: _,
+            //     params: _,
+            //     pfsys: _,
+            // } => OnnxModel::new(model_path(model), args.scale, args.bits),
+            // Commands::Pkey {
+            //     model,
+            //     output: _,
+            //     params: _,
+            //     pfsys: _,
+            // } => OnnxModel::new(model_path(model), args.scale, args.bits),
+            Commands::Prove {
+                data: _,
+                model,
+                output: _,
+                params: _,
+                pfsys: _,
+            } => OnnxModel::new(model_path(model), args.scale, args.bits),
+
+            _ => todo!(),
+        }
     }
 
     pub fn configure<F: FieldExt + TensorType>(
@@ -378,6 +372,7 @@ impl OnnxModel {
             debug!("configuring node {}", node_idx);
             configs[node_idx] =
                 self.configure_node(&node.opkind, node, meta, advices.clone(), fixeds.clone());
+            trace!("  {:?}", configs[node_idx]);
         }
 
         let public_output: Column<Instance> = meta.instance_column();
@@ -591,20 +586,17 @@ impl OnnxModel {
             );
             let node_config = &config.configs[node_idx].clone();
             assert!(self.config_matches(&node.opkind, node_config));
+            trace!(
+                " layout_config\n  node: {:?}\n  input: {:?}\n  config: {:?}",
+                node,
+                x.clone(),
+                node_config
+            );
             x = match self.layout_config(node, layouter, x.clone(), node_config)? {
                 Some(vt) => vt,
                 None => x, // Some nodes don't produce tensor output, we skip these
             };
-            match x {
-                ValTensor::PrevAssigned {
-                    inner: ref v,
-                    dims: _,
-                } => {
-                    let res: Tensor<i32> = v.clone().into();
-                    trace!("{:?}", res);
-                }
-                _ => {}
-            };
+            //            trace!("  output {}", x.show());  //only use with mock prover
         }
 
         Ok(x)

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -137,7 +137,18 @@ impl<F: FieldExt + TensorType> ValTensor<F> {
                 let r: Tensor<i32> = v.into();
                 format!("PrevAssigned {:?}", r)
             }
-            _ => "Unassigned ValTensor".into(),
+            // ValTensor::Value { inner: v, dims: d } => {
+            //     //                if let Ok(r) = v.try_into() {
+            //     format!("Value {:?}", v)
+            //     // } else {
+            //     //     format!("Value Unknown of shape {:?}", d)
+            //     // }
+            // }
+
+            // ValTensor::AssignedValue { inner: v, dims: d } => {
+            //     format!("AssignedValue {:?}", v)
+            // }
+            _ => "ValTensor not PrevAssigned".into(),
         }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,6 +8,7 @@ fn test_onnx_example(example_name: String) {
             "--bin",
             "ezkl",
             "--",
+            "mock",
             "-D",
             format!("./examples/onnx_models/{}_input.json", example_name).as_str(),
             "-M",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,5 @@
-use std::process::Command;
+use std::fs::remove_file;
+use std::process::{Command, Output};
 
 fn test_onnx_example(example_name: String) {
     let status = Command::new("cargo")
@@ -40,4 +41,48 @@ fn test_1lcnvrl_example() {
 #[test]
 fn test_2lcnvrl_example() {
     test_onnx_example("2lcnvrl_relusig".to_string());
+}
+
+fn test_onnx_prove_and_verify(example_name: String) {
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--release",
+            "--bin",
+            "ezkl",
+            "--",
+            "prove",
+            "-D",
+            format!("./examples/onnx_models/{}_input.json", example_name).as_str(),
+            "-M",
+            format!("./examples/onnx_models/{}.onnx", example_name).as_str(),
+            "-O",
+            format!("pav_{}.pf", example_name).as_str(),
+        ])
+        .status()
+        .expect("failed to execute process");
+    assert!(status.success());
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--release",
+            "--bin",
+            "ezkl",
+            "--",
+            "verify",
+            "-M",
+            format!("./examples/onnx_models/{}.onnx", example_name).as_str(),
+            "-P",
+            format!("pav_{}.pf", example_name).as_str(),
+        ])
+        .output()
+        .expect("failed to execute process");
+    let sout = String::from_utf8(output.stdout).unwrap();
+    println!("{}", sout);
+    assert_eq!("Verified: true\n", sout);
+}
+
+#[test]
+fn test_ff_pav() {
+    test_onnx_prove_and_verify("ff".to_string());
 }


### PR DESCRIPTION
Adds SubCommands:
-  table      Loads model and prints model table
-  mock       Loads model and input and runs mock prover (for testing)
-  fullprove  Loads model and input and runs full prover (for testing)
-  prove      Loads model and data, prepares vk and pk, and creates proof, saving proof in --output
-  verify     Verifies a saved proof, returning accept or reject
-  help       Print this message or the help of the given subcommand(s)
