### PR TITLE
fix: change defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We also provide an example which runs an MLP on input data with four dimensions.
 ```bash
 cargo run --release --example mlp_4d
 ```
-We also provide onnx model files and their corresponding input json files in `examples/onnx_models`. These can be run using the cli commands listed above. 
+We also provide onnx model files and their corresponding input json files in `examples/onnx_models`. These can be run using the cli commands listed above.
 
 ## python tutorial
 
@@ -189,7 +189,7 @@ If you run the following command on the generated files:
 ```bash
 cargo run --bin ezkl -- --scale 4 --bits 16 -K 17 table  -M ./network.onnx
 ```
-you should see the following table being displayed. This is a tabular representation of the Onnx graph, with some additional information required for circuit construction (like the number of advices to use, the fixed point representation denominator at the operation's input and output). You should see all the operations we created in `Circuit(nn.Module)` represented. Nodes 14 and 17 correspond to the output nodes here. 
+you should see the following table being displayed. This is a tabular representation of the Onnx graph, with some additional information required for circuit construction (like the number of advices to use, the fixed point representation denominator at the operation's input and output). You should see all the operations we created in `Circuit(nn.Module)` represented. Nodes 14 and 17 correspond to the output nodes here.
 
 ```bash
 | node           | output_max | min_cols | in_scale | out_scale | is_output | const_value | inputs     | in_dims   | out_dims     | idx  | Bucket |
@@ -212,7 +212,7 @@ you should see the following table being displayed. This is a tabular representa
 | Div            | 85.333336  | 12       | 4        | 4         | true      |             | [15]       | [3, 2, 2] | [3, 2, 2]    | 17   | 2      |
 ```
 
-From there we can run proofs on the generated files, but note that because of quantization errors the public inputs may need to be tweaked to match the output of the circuit and generate a valid proof. The types of claims we can make with the setup of this tutorial are ones such as: "I ran my private model on data and produced the expected outputs (as dictated by the public inputs to the circuit)". 
+From there we can run proofs on the generated files, but note that because of quantization errors the public inputs may need to be tweaked to match the output of the circuit and generate a valid proof. The types of claims we can make with the setup of this tutorial are ones such as: "I ran my private model on data and produced the expected outputs (as dictated by the public inputs to the circuit)".
 
 ``` bash
  RUST_LOG=debug cargo run --bin ezkl -- --scale 4 --bits 16 -K 17 mock  -D ./input.json -M ./network.onnx

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,10 +13,10 @@ pub struct Cli {
     #[arg(short = 'S', long, default_value = "7")]
     pub scale: i32,
     /// The number of bits used in lookup tables
-    #[arg(short = 'B', long, default_value = "14")]
+    #[arg(short = 'B', long, default_value = "16")]
     pub bits: usize,
     /// The log_2 number of rows
-    #[arg(short = 'K', long, default_value = "16")]
+    #[arg(short = 'K', long, default_value = "17")]
     pub logrows: u32,
 }
 


### PR DESCRIPTION
- Run examples in the README without having to manipulate logrows and bits params