### PR TITLE
chore: helpful error messages for mock proving

### DIFF
--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -57,7 +57,7 @@ fn format_verify_errors(f: &VerifyFailure) {
             lookup_index,
         } => {
             error!(
-                "lookup lk {:?} is out of range, try increasing 'bits' or reducing 'scale'",
+                "lookup {:?} is out of range, try increasing 'bits' or reducing 'scale'",
                 name
             );
             debug!("location {:?} at lookup index {:?}", location, lookup_index);

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -109,7 +109,7 @@ pub fn main() {
                 }
                 Err(v) => {
                     for e in v.iter() {
-                        format_verify_errors(e)
+                        parse_prover_errors(e)
                     }
                 }
             }

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -49,8 +49,8 @@ struct Proof {
     proof: Vec<u8>,
 }
 
-/// Helper function for printing helpful error messages after verification failed.
-fn format_verify_errors(f: &VerifyFailure) {
+/// Helper function to print helpful error messages after verification has failed.
+fn parse_prover_errors(f: &VerifyFailure) {
     match f {
         VerifyFailure::Lookup {
             name,

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -49,6 +49,7 @@ struct Proof {
     proof: Vec<u8>,
 }
 
+/// Helper function for printing helpful error messages after verification failed.
 fn format_verify_errors(f: &VerifyFailure) {
     match f {
         VerifyFailure::Lookup {
@@ -126,8 +127,7 @@ pub fn main() {
             let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
             trace!("params computed");
 
-            let (pk, proof, _dims) =
-                create_ipa_proof(circuit.clone(), public_inputs.clone(), &params);
+            let (pk, proof, _dims) = create_ipa_proof(circuit, public_inputs.clone(), &params);
 
             let pi_inner: Vec<Vec<F>> = public_inputs
                 .iter()
@@ -205,7 +205,7 @@ fn prepare_circuit_and_public_input<F: FieldExt>(
     let onnx_model = OnnxModel::from_arg();
     let out_scales = onnx_model.get_output_scales();
     colog::init();
-    let circuit = prepare_circuit(&data);
+    let circuit = prepare_circuit(data);
 
     // quantize the supplied data using the provided scale.
     let public_inputs = data


### PR DESCRIPTION
- Gives user suggestions on how to fix common OOR Lookup or Permutation errors. 
- `debug` logs give additional information to those errors

eg. 
<img width="533" alt="image" src="https://user-images.githubusercontent.com/45801863/198828357-7ba1bb32-d23b-4fc4-baaa-80d18a2c3f42.png">
