### PR TITLE
feat: controllable circuit shape

### DIFF
--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -13,7 +13,7 @@ use rand::rngs::OsRng;
 use std::marker::PhantomData;
 
 static mut LEN: usize = 4;
-const K: usize = 8;
+const K: usize = 16;
 
 #[derive(Clone)]
 struct MyCircuit<F: FieldExt + TensorType> {
@@ -69,7 +69,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 
 fn runaffine(c: &mut Criterion) {
     let mut group = c.benchmark_group("affine");
-    for &len in [4, 8, 16, 32, 64, 128].iter() {
+    for &len in [4, 8, 16, 32, 64].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -91,7 +91,7 @@ fn runaffine(c: &mut Criterion) {
             LEN = len;
         };
 
-        let k = 15; //2^k rows
+        let k = 16; //2^k rows
                     // parameters
         let mut l0_kernel =
             Tensor::from((0..len * len).map(|_| Value::known(pallas::Base::random(OsRng))));

--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -9,7 +9,6 @@ use halo2_proofs::{
 };
 use halo2curves::pasta::pallas;
 use halo2curves::pasta::Fp as F;
-use itertools::Itertools;
 use rand::rngs::OsRng;
 use std::marker::PhantomData;
 

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -29,13 +29,20 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let len = unsafe { LEN };
-        let advices = VarTensor::from(Tensor::from((0..2).map(|_| {
+        let advices = Tensor::from((0..2).map(|_| {
             let col = cs.advice_column();
             cs.enable_equality(col);
             col
-        })));
-        let input = advices.get_slice(&[0..1], &[len]);
-        let output = advices.get_slice(&[1..2], &[len]);
+        }));
+
+        let input = VarTensor::Advice {
+            inner: advices[0],
+            dims: vec![len],
+        };
+        let output = VarTensor::Advice {
+            inner: advices[1],
+            dims: vec![len],
+        };
         let instance = {
             let l = cs.instance_column();
             cs.enable_equality(l);

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -14,6 +14,8 @@ use itertools::Itertools;
 static mut LEN: usize = 4;
 const RANGE: usize = 8; // 3-bit value
 
+const K: usize = 15; //2^k rows
+
 #[derive(Clone)]
 struct MyCircuit<F: FieldExt + TensorType> {
     input: ValTensor<F>,
@@ -29,27 +31,17 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let len = unsafe { LEN };
-        let advices = Tensor::from((0..2).map(|_| {
-            let col = cs.advice_column();
-            cs.enable_equality(col);
-            col
-        }));
+        let advices = (0..2)
+            .map(|_| VarTensor::new_advice(cs, K, len, vec![len], true))
+            .collect_vec();
 
-        let input = VarTensor::Advice {
-            inner: advices[0],
-            dims: vec![len],
-        };
-        let output = VarTensor::Advice {
-            inner: advices[1],
-            dims: vec![len],
-        };
         let instance = {
             let l = cs.instance_column();
             cs.enable_equality(l);
             l
         };
 
-        RangeCheckConfig::configure(cs, &input, &output, &instance, RANGE)
+        RangeCheckConfig::configure(cs, &advices[0], &advices[1], &instance, RANGE)
     }
 
     fn synthesize(
@@ -70,8 +62,6 @@ fn runrange(c: &mut Criterion) {
             LEN = len;
         };
 
-        let k = 15; //2^k rows
-
         let input = Tensor::from((0..len).map(|_| Value::known(pallas::Base::from(1))));
 
         let circuit = MyCircuit::<F> {
@@ -82,7 +72,7 @@ fn runrange(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, &_| {
             b.iter(|| {
                 let instances = vec![(0..len).map(|_| F::from(1)).collect_vec()];
-                let prover = MockProver::run(k, &circuit, instances).unwrap();
+                let prover = MockProver::run(K as u32, &circuit, instances).unwrap();
                 prover.assert_satisfied();
             });
         });

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -53,7 +53,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
 
 fn runrelu(c: &mut Criterion) {
     let mut group = c.benchmark_group("relu");
-    let k = 9;
+    let k = 16;
 
     let mut rng = rand::thread_rng();
 

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -33,10 +33,10 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         unsafe {
             let advices = VarTensor::Advice {
-                inner: (0..LEN).map(|_| cs.advice_column()).into(),
+                inner: cs.advice_column(),
                 dims: [LEN].to_vec(),
             };
-            Self::Config::configure(cs, &[advices], Some(&[BITS, 128]))
+            Self::Config::configure(cs, advices, Some(&[BITS, 128]))
         }
     }
 
@@ -45,7 +45,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
         config: Self::Config,
         mut layouter: impl Layouter<F>, // layouter is our 'write buffer' for the circuit
     ) -> Result<(), Error> {
-        config.layout(&mut layouter, &[self.assigned.input.clone()]);
+        config.layout(&mut layouter, self.assigned.input.clone());
 
         Ok(())
     }

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 
 const BITS: usize = 8;
 static mut LEN: usize = 4;
-const K: usize = 15;
+const K: usize = 10;
 
 #[derive(Clone)]
 struct NLCircuit<F: FieldExt + TensorType, NL: Nonlinearity<F>> {
@@ -37,7 +37,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F> + Clone> Circuit<F>
                 .map(|_| VarTensor::new_advice(cs, K, LEN, vec![LEN], true))
                 .collect::<Vec<_>>();
 
-            Self::Config::configure(cs, &advices[0], &advices[1], LEN, Some(&[BITS, 128]))
+            Self::Config::configure(cs, &advices[0], &advices[1], Some(&[BITS, 128]))
         }
     }
 
@@ -57,7 +57,7 @@ fn runrelu(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
 
-    for &len in [4, 8, 16, 32, 64, 128].iter() {
+    for &len in [128].iter() {
         unsafe {
             LEN = len;
         };

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -51,7 +51,7 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
     // This can be automated but we will sometimes want skip connections, etc. so we need the flexibility.
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let input = VarTensor::new_advice(cs, K, LEN, vec![LEN], true);
-        let kernel = VarTensor::new_advice(cs, K, LEN * LEN, vec![LEN * LEN], true);
+        let kernel = VarTensor::new_advice(cs, K, LEN * LEN, vec![LEN, LEN], true);
         let bias = VarTensor::new_advice(cs, K, LEN, vec![LEN], true);
         let output = VarTensor::new_advice(cs, K, LEN, vec![LEN], true);
         // tells the config layer to add an affine op to the circuit gate
@@ -80,11 +80,11 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
 
         // sets up a new ReLU table and resuses it for l1 and l3 non linearities
         let [l1, l3]: [EltwiseConfig<F, ReLu<F>>; 2] =
-            EltwiseConfig::configure_multiple(cs, &input, &output, LEN, Some(&[BITS, 1]));
+            EltwiseConfig::configure_multiple(cs, &input, &output, Some(&[BITS, 1]));
 
         // sets up a new Divide by table
         let l4: EltwiseConfig<F, DivideBy<F>> =
-            EltwiseConfig::configure(cs, &input, &output, LEN, Some(&[BITS, 128]));
+            EltwiseConfig::configure(cs, &input, &output, Some(&[BITS, 128]));
 
         let public_output: Column<Instance> = cs.instance_column();
         cs.enable_equality(public_output);

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -139,8 +139,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
         table: Rc<RefCell<EltwiseTable<F, NL>>>,
     ) -> Self {
         let qlookup = cs.complex_selector();
-        let input = variables.clone();
-        match &input {
+        match &variables {
             VarTensor::Advice { inner: a, dims: d } => {
                 let offset = d.iter().product::<usize>() as i32;
                 let _ = (0..offset)

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -101,6 +101,7 @@ impl<F: FieldExt, NL: Nonlinearity<F>> EltwiseTable<F, NL> {
 #[derive(Clone, Debug)]
 pub struct EltwiseConfig<F: FieldExt + TensorType, NL: Nonlinearity<F>> {
     pub input: VarTensor,
+    pub output: VarTensor,
     pub table: Rc<RefCell<EltwiseTable<F, NL>>>,
     qlookup: Selector,
     _marker: PhantomData<(NL, F)>,
@@ -110,15 +111,17 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
     /// Configures multiple element-wise non-linearities at once.
     pub fn configure_multiple<const NUM: usize>(
         cs: &mut ConstraintSystem<F>,
-        variables: VarTensor,
+        input: &VarTensor,
+        output: &VarTensor,
+        input_len: usize,
         eltwise_params: Option<&[usize]>,
     ) -> [Self; NUM] {
         let mut table: Option<Rc<RefCell<EltwiseTable<F, NL>>>> = None;
         let configs = (0..NUM)
             .map(|_| {
                 let l = match &table {
-                    None => Self::configure(cs, variables.clone(), eltwise_params),
-                    Some(t) => Self::configure_with_table(cs, variables.clone(), t.clone()),
+                    None => Self::configure(cs, input, output, input_len, eltwise_params),
+                    Some(t) => Self::configure_with_table(cs, input, output, input_len, t.clone()),
                 };
                 table = Some(l.table.clone());
                 l
@@ -135,42 +138,48 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
     /// Configures and creates an elementwise operation within a circuit using a supplied lookup table.
     fn configure_with_table(
         cs: &mut ConstraintSystem<F>,
-        variables: VarTensor,
+        input: &VarTensor,
+        output: &VarTensor,
+        input_len: usize,
         table: Rc<RefCell<EltwiseTable<F, NL>>>,
     ) -> Self {
         let qlookup = cs.complex_selector();
-        match &variables {
-            VarTensor::Advice { inner: a, dims: d } => {
-                let offset = d.iter().product::<usize>() as i32;
-                let _ = (0..offset)
-                    .map(|i| {
-                        let _ = cs.lookup("lk", |cs| {
-                            let qlookup = cs.query_selector(qlookup);
-                            let not_qlookup = Expression::Constant(F::one()) - qlookup.clone();
-                            let (default_x, default_y) =
-                                NL::default_pair(table.borrow().scaling_params.as_slice());
-
-                            vec![
-                                (
-                                    qlookup.clone() * cs.query_advice(*a, Rotation(i as i32))
-                                        + not_qlookup.clone() * default_x,
-                                    table.borrow().table_input,
-                                ),
-                                (
-                                    qlookup * cs.query_advice(*a, Rotation(offset + i as i32))
-                                        + not_qlookup * default_y,
-                                    table.borrow().table_output,
-                                ),
-                            ]
-                        });
-                    })
-                    .collect::<Vec<_>>();
-            }
+        let input_inner = match &input {
+            VarTensor::Advice { inner: advices, .. } => advices,
             _ => todo!(),
-        }
+        };
+        let output_inner = match &output {
+            VarTensor::Advice { inner: advices, .. } => advices,
+            _ => todo!(),
+        };
+
+        let _ = (0..input_len)
+            .map(|i| {
+                let _ = cs.lookup("lk", |cs| {
+                    let qlookup = cs.query_selector(qlookup);
+                    let not_qlookup = Expression::Constant(F::one()) - qlookup.clone();
+                    let (default_x, default_y) =
+                        NL::default_pair(table.borrow().scaling_params.as_slice());
+                    let (x, y) = input.cartesian_coord(i);
+                    vec![
+                        (
+                            qlookup.clone() * cs.query_advice(input_inner[x], Rotation(y as i32))
+                                + not_qlookup.clone() * default_x,
+                            table.borrow().table_input,
+                        ),
+                        (
+                            qlookup * cs.query_advice(output_inner[x], Rotation(y as i32))
+                                + not_qlookup * default_y,
+                            table.borrow().table_output,
+                        ),
+                    ]
+                });
+            })
+            .collect::<Vec<_>>();
 
         Self {
-            input: variables,
+            input: input.clone(),
+            output: output.clone(),
             table,
             qlookup,
             _marker: PhantomData,
@@ -180,10 +189,12 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
 
 impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, NL> {
     /// Configures and creates an elementwise operation within a circuit.
-    /// Variables are supplied as a 1-element array of `[input]` VarTensors.
+    /// Variables are supplied as a single VarTensors.
     pub fn configure(
         cs: &mut ConstraintSystem<F>,
-        variables: VarTensor,
+        input: &VarTensor,
+        output: &VarTensor,
+        input_len: usize,
         eltwise_params: Option<&[usize]>,
     ) -> Self {
         // will fail if not supplied
@@ -199,7 +210,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
             bits,
             &params[1..],
         )));
-        Self::configure_with_table(cs, variables, table)
+        Self::configure_with_table(cs, input, output, input_len, table)
     }
 
     /// Assigns values to the variables created when calling `configure`.
@@ -214,84 +225,22 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                 |mut region| {
                     self.qlookup.enable(&mut region, 0)?;
 
-                    let w = match &values {
-                        ValTensor::AssignedValue { inner: v, dims: _ } => match &self.input {
-                            VarTensor::Advice { inner: a, dims: _ } => v
-                                .enum_map(|i, x| {
-                                    // assign the advice
-                                    match region.assign_advice(|| "input", *a, i, || x) {
-                                        Ok(a) => a,
-                                        Err(e) => {
-                                            abort!("failed to assign input advice {:?}", e);
-                                        }
-                                    }
-                                })
-                                .unwrap(),
-                            _ => todo!(),
-                        },
-                        ValTensor::PrevAssigned { inner: v, dims: _ } => match &self.input {
-                            VarTensor::Advice { inner: a, dims: _ } =>
-                            //copy the advice
-                            {
-                                v.enum_map(|i, x| {
-                                    match x.copy_advice(|| "input", &mut region, *a, i) {
-                                        Ok(a) => a,
-                                        Err(e) => {
-                                            abort!("failed to copy input advice {:?}", e);
-                                        }
-                                    }
-                                })
-                                .unwrap()
-                            }
-                            _ => todo!(),
-                        },
-                        ValTensor::Value { inner: v, dims: _ } => match &self.input {
-                            VarTensor::Advice { inner: a, dims: _ } => v
-                                .enum_map(|i, x| {
-                                    // assign the advice
-                                    match region.assign_advice(|| "input", *a, i, || x.into()) {
-                                        Ok(a) => a,
-                                        Err(e) => {
-                                            abort!("failed to assign input advice {:?}", e);
-                                        }
-                                    }
-                                })
-                                .unwrap(),
-                            _ => todo!(),
-                        },
-                    };
+                    let w = self.input.assign(&mut region, 0, &values).unwrap();
 
-                    let output = Tensor::from(w.iter().map(|acaf| acaf.value_field()).map(|vaf| {
-                        vaf.map(|f| {
-                            <NL as Nonlinearity<F>>::nonlinearity(
-                                felt_to_i32(f.evaluate()),
-                                &self.table.borrow().scaling_params,
-                            )
-                            .into()
-                        })
-                    }));
-
-                    let offset = values.dims().iter().product::<usize>();
-
-                    match &self.input {
-                        VarTensor::Advice { inner: a, dims: _ } => Ok(output
-                            .enum_map(|i, o| {
-                                match region.assign_advice(
-                                    || format!("nl_{i}"),
-                                    *a,
-                                    offset + i,
-                                    || o,
-                                ) {
-                                    Ok(a) => a,
-                                    Err(e) => {
-                                        abort!("failed to assign non-linearity advice {:?}", e);
-                                    }
-                                }
+                    let output: Tensor<Value<F>> =
+                        Tensor::from(w.iter().map(|acaf| (*acaf).value_field()).map(|vaf| {
+                            vaf.map(|f| {
+                                <NL as Nonlinearity<F>>::nonlinearity(
+                                    felt_to_i32(f.evaluate()),
+                                    &self.table.borrow().scaling_params,
+                                )
                             })
-                            .unwrap()),
+                        }));
 
-                        _ => todo!(),
-                    }
+                    Ok(self
+                        .output
+                        .assign(&mut region, 0, &ValTensor::from(output))
+                        .unwrap())
                 },
             ) {
                 Ok(a) => a,

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -170,7 +170,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
         }
 
         Self {
-            input,
+            input: variables,
             table,
             qlookup,
             _marker: PhantomData,

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -228,7 +228,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                         abort!("failed to assign input advice {:?}", e);
                                     }
                                 }
-                            }),
+                            }).unwrap(),
                             _ => todo!(),
                         },
                         ValTensor::PrevAssigned { inner: v, dims: _ } => match &self.input {
@@ -246,7 +246,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                             abort!("failed to copy input advice {:?}", e);
                                         }
                                     }
-                                })
+                                }).unwrap()
                             }
                             _ => todo!(),
                         },
@@ -267,7 +267,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                         abort!("failed to assign input advice {:?}", e);
                                     }
                                 }
-                            }),
+                            }).unwrap(),
                             _ => todo!(),
                         },
                     };
@@ -293,7 +293,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                     abort!("failed to assign non-linearity advice {:?}", e);
                                 }
                             }
-                        })),
+                        }).unwrap()),
 
                         _ => todo!(),
                     }

--- a/src/circuit/fused.rs
+++ b/src/circuit/fused.rs
@@ -149,7 +149,9 @@ impl<F: FieldExt + TensorType> FusedConfig<F> {
                 }
             };
 
-            let constraints = witnessed_output.enum_map(|i, o| o - expected_output[i].clone()).unwrap();
+            let constraints = witnessed_output
+                .enum_map(|i, o| o - expected_output[i].clone())
+                .unwrap();
 
             Constraints::with_selector(selector, constraints)
         });

--- a/src/circuit/fused.rs
+++ b/src/circuit/fused.rs
@@ -149,7 +149,7 @@ impl<F: FieldExt + TensorType> FusedConfig<F> {
                 }
             };
 
-            let constraints = witnessed_output.enum_map(|i, o| o - expected_output[i].clone());
+            let constraints = witnessed_output.enum_map(|i, o| o - expected_output[i].clone()).unwrap();
 
             Constraints::with_selector(selector, constraints)
         });

--- a/src/circuit/range.rs
+++ b/src/circuit/range.rs
@@ -71,7 +71,7 @@ impl<F: FieldExt + TensorType> RangeCheckConfig<F> {
             };
 
             let constraints =
-                witnessed.enum_map(|i, o| range_check(tol as i32, o - expected[i].clone()));
+                witnessed.enum_map(|i, o| range_check(tol as i32, o - expected[i].clone())).unwrap();
             Constraints::with_selector(q, constraints)
         });
 
@@ -104,11 +104,8 @@ impl<F: FieldExt + TensorType> RangeCheckConfig<F> {
                 // assigns the instance to the "expected" advice.
                 match self.expected.clone() {
                     VarTensor::Advice { inner, dims: d } => {
-                        let mut outer_loop = 1;
-                        if d.len() > 1 {
-                            outer_loop = d[0..d.len() - 1].iter().product();
-                        }
-                        let inner_loop = d[d.len() - 1];
+                        let outer_loop = 1;
+                        let inner_loop =  d.iter().product();
                         for i in 0..outer_loop {
                             for j in 0..inner_loop {
                                 region

--- a/src/circuit/utils.rs
+++ b/src/circuit/utils.rs
@@ -10,8 +10,8 @@ pub fn value_muxer<F: FieldExt + TensorType>(
     input: &ValTensor<F>,
 ) -> Tensor<Value<F>> {
     match variable {
-        VarTensor::Advice { inner: _, dims: _ } => assigned.clone(),
-        VarTensor::Fixed { inner: _, dims: _ } => match input {
+        VarTensor::Advice { .. } => assigned.clone(),
+        VarTensor::Fixed { .. } => match input {
             ValTensor::Value {
                 inner: val,
                 dims: _,

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -1,5 +1,5 @@
 use crate::tensor::TensorType;
-use crate::tensor::{Tensor, ValTensor, VarTensor};
+use crate::tensor::{Tensor, ValTensor};
 use anyhow::Result;
 use halo2_proofs::{
     arithmetic::FieldExt,
@@ -8,7 +8,6 @@ use halo2_proofs::{
 };
 use std::marker::PhantomData;
 pub mod utilities;
-use std::cmp::max;
 pub use utilities::*;
 pub mod model;
 pub mod node;
@@ -32,16 +31,13 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
 
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         let onnx_model = Model::from_arg();
-        let num_advices = max(
-            onnx_model.max_node_advices(),
-            onnx_model.max_advices_width().unwrap(),
-        );
+        let num_advices = onnx_model.max_node_advices();
         info!("number of advices used: {:?}", num_advices);
-        let advices = VarTensor::from(Tensor::from((0..num_advices + 3).map(|_| {
+        let advices = Tensor::from((0..num_advices).map(|_| {
             let col = meta.advice_column();
             meta.enable_equality(col);
             col
-        })));
+        }));
 
         onnx_model.configure(meta, advices).unwrap()
     }

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -32,10 +32,9 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
 
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let onnx_model = Model::from_arg();
-        let num_advices = onnx_model.max_node_advices();
+        let num_variables = onnx_model.max_node_vars();
         let max_node_size = onnx_model.max_node_size();
-        info!("number of advices used: {:?}", num_advices);
-        let advices = (0..num_advices)
+        let advices = (0..num_variables)
             .map(|_| {
                 VarTensor::new_advice(
                     cs,
@@ -47,6 +46,10 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
             })
             .collect_vec();
 
+        info!(
+            "number of advices used: {:?}",
+            advices.iter().map(|a| a.num_cols()).sum::<usize>()
+        );
         onnx_model.configure(cs, advices).unwrap()
     }
 

--- a/src/onnx/model.rs
+++ b/src/onnx/model.rs
@@ -233,10 +233,7 @@ impl Model {
             .collect_vec();
         for (i, instance) in public_outputs.iter().enumerate() {
             let s = output_shapes[i].clone();
-            let mut end = 1;
-            if s.len() > 1 {
-                end = s[0..s.len() - 1].iter().product();
-            }
+            let end = 1;
             let input = advices.get_slice(&[0..end], &s);
             let output = advices.get_slice(&[end..2 * end], &s);
             configs.push(RangeCheckConfig::configure(
@@ -296,10 +293,7 @@ impl Model {
                     .filter(|i| !nodes.contains_key(&i.idx) && seen.insert(i.idx))
                     .map(|f| {
                         let s = f.out_dims.clone();
-                        let mut end = 1;
-                        if s.len() > 1 {
-                            end = s[0..s.len() - 1].iter().product();
-                        }
+                        let end = 1;
                         let a = (f.idx, advices.get_slice(&[start..start + end], &s));
                         start += end;
                         a
@@ -311,10 +305,7 @@ impl Model {
         // output node
         let output_shape = self.nodes.filter(**nodes.keys().max().unwrap()).out_dims;
 
-        let mut end = 1;
-        if output_shape.len() > 1 {
-            end = output_shape[0..output_shape.len() - 1].iter().product();
-        }
+        let end = 1;
         let output = advices.get_slice(&[start..start + end], &output_shape);
 
         let mut inter_counter = 0;

--- a/src/onnx/model.rs
+++ b/src/onnx/model.rs
@@ -368,24 +368,14 @@ impl Model {
         let output = &advices[1].reshape(&[input_len]);
         match &node.opkind {
             OpKind::Div(s) => {
-                let conf: EltwiseConfig<F, DivideBy<F>> = EltwiseConfig::configure(
-                    meta,
-                    input,
-                    output,
-                    input_len,
-                    Some(&[self.bits, *s]),
-                );
+                let conf: EltwiseConfig<F, DivideBy<F>> =
+                    EltwiseConfig::configure(meta, input, output, Some(&[self.bits, *s]));
                 let inputs = node.inputs.iter().map(|e| e.node).collect();
                 NodeConfigTypes::Divide(conf, inputs)
             }
             OpKind::ReLU(s) => {
-                let conf: EltwiseConfig<F, ReLu<F>> = EltwiseConfig::configure(
-                    meta,
-                    input,
-                    output,
-                    input_len,
-                    Some(&[self.bits, *s]),
-                );
+                let conf: EltwiseConfig<F, ReLu<F>> =
+                    EltwiseConfig::configure(meta, input, output, Some(&[self.bits, *s]));
                 let inputs = node.inputs.iter().map(|e| e.node).collect();
                 NodeConfigTypes::ReLU(conf, inputs)
             }
@@ -394,7 +384,6 @@ impl Model {
                     meta,
                     input,
                     output,
-                    input_len,
                     Some(&[
                         self.bits,
                         *denominator,

--- a/src/onnx/model.rs
+++ b/src/onnx/model.rs
@@ -631,11 +631,11 @@ impl Model {
         )
     }
 
-    pub fn max_node_advices(&self) -> usize {
+    pub fn max_node_vars(&self) -> usize {
         self.nodes
             .flatten()
             .iter()
-            .map(|e| e.min_cols)
+            .map(|e| e.num_var)
             .max()
             .unwrap()
     }

--- a/src/onnx/node.rs
+++ b/src/onnx/node.rs
@@ -221,7 +221,7 @@ fn display_tensorf32(o: &Option<Tensor<f32>>) -> String {
 pub struct Node {
     pub opkind: OpKind,
     pub output_max: f32,
-    pub min_cols: usize,
+    pub num_var: usize,
     pub in_scale: i32,
     pub out_scale: i32,
     #[tabled(display_with = "display_tensor")]
@@ -273,7 +273,7 @@ impl Node {
             opkind: OpKind::new(node.op().name().as_ref()), // parses the op name
             inputs: node.inputs.clone(),
             in_scale: scale,
-            min_cols: 2,
+            num_var: 2,
             idx,
             ..Default::default()
         };
@@ -339,7 +339,7 @@ impl Node {
                 let input_node = &inputs[0];
                 mn.in_dims = input_node.out_dims.clone();
                 mn.out_dims = input_node.out_dims.clone();
-                mn.min_cols = 4;
+                mn.num_var = 4;
 
                 inputs
                     .iter()

--- a/src/onnx/node.rs
+++ b/src/onnx/node.rs
@@ -273,7 +273,7 @@ impl Node {
             opkind: OpKind::new(node.op().name().as_ref()), // parses the op name
             inputs: node.inputs.clone(),
             in_scale: scale,
-            min_cols: 1,
+            min_cols: 2,
             idx,
             ..Default::default()
         };

--- a/src/onnx/node.rs
+++ b/src/onnx/node.rs
@@ -343,10 +343,7 @@ impl Node {
                 let input_node = &inputs[0];
                 mn.in_dims = input_node.out_dims.clone();
                 mn.out_dims = input_node.out_dims.clone();
-                mn.min_cols = inputs
-                    .iter()
-                    .map(|input| input.out_dims.clone().iter().product::<usize>() as f32)
-                    .sum::<f32>() as usize;
+                mn.min_cols = 1;
 
                 inputs
                     .iter()

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -419,13 +419,13 @@ impl<T: Clone + TensorType> Tensor<T> {
     /// ```
     /// use ezkl::tensor::Tensor;
     /// let mut a = Tensor::<i32>::new(Some(&[1, 4]), &[2]).unwrap();
-    /// let mut c = a.enum_map(|i, x| i32::pow(x + i as i32, 2));
+    /// let mut c = a.enum_map(|i, x| i32::pow(x + i as i32, 2)).unwrap();
     /// assert_eq!(c, Tensor::from([1, 25].into_iter()));
     /// ```
-    pub fn enum_map<F: FnMut(usize, T) -> G, G: TensorType>(&self, mut f: F) -> Tensor<G> {
+    pub fn enum_map<F: FnMut(usize, T) -> G, G: TensorType>(&self, mut f: F) ->  Result<Tensor<G>, TensorError> {
         let mut t = Tensor::from(self.inner.iter().enumerate().map(|(i, e)| f(i, e.clone())));
         t.reshape(self.dims());
-        t
+        Ok(t)
     }
 
     /// Maps a function to tensors and enumerates using multi cartesian coordinates

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::abort;
-use log::{error, info};
+use log::error;
 /// A wrapper around a tensor where the inner type is one of Halo2's `Column<Fixed>` or `Column<Advice>`.
 /// The wrapper allows for `VarTensor`'s dimensions to differ from that of the inner (wrapped) tensor.
 /// The inner tensor might, for instance, contain 3 Advice Columns. Each of those columns in turn

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::abort;
-use log::{error};
+use log::{error, info};
 /// A wrapper around a tensor where the inner type is one of Halo2's `Column<Fixed>` or `Column<Advice>`.
 /// The wrapper allows for `VarTensor`'s dimensions to differ from that of the inner (wrapped) tensor.
 /// The inner tensor might, for instance, contain 3 Advice Columns. Each of those columns in turn
@@ -22,7 +22,6 @@ pub enum VarTensor {
 }
 
 impl VarTensor {
-   
     /// Sets the `VarTensor`'s shape.
     pub fn reshape(&mut self, new_dims: &[usize]) {
         match self {
@@ -79,18 +78,16 @@ impl VarTensor {
             }
             // when advice we have 1 col per row
             VarTensor::Advice { inner: a, dims: d } => {
-                    let mut c = Tensor::from(
-                        // this should fail if dims is empty, should be impossible
-                        (0.. d.iter().product::<usize>())
-                            .map(|i| meta.query_advice(*a, Rotation(offset as i32 + i as i32))),
-                    ); 
-                    c.reshape(d); 
-                    Ok(c)}
-        
+                let mut c = Tensor::from(
+                    // this should fail if dims is empty, should be impossible
+                    (0..d.iter().product::<usize>())
+                        .map(|i| meta.query_advice(*a, Rotation(offset as i32 + i as i32))),
+                );
+                c.reshape(d);
+                Ok(c)
+            }
         }
     }
-
-    
 
     /// Assigns specific values (`ValTensor`) to the columns of the inner tensor.
     pub fn assign<F: FieldExt + TensorType>(
@@ -110,12 +107,7 @@ impl VarTensor {
                     }
                 }
                 VarTensor::Advice { inner: a, dims: _ } => {
-                    match region.assign_advice(
-                        || "k",
-                        *a,
-                        offset + coord,
-                        || k.into(),
-                    ) {
+                    match region.assign_advice(|| "k", *a, offset + coord, || k.into()) {
                         Ok(a) => a,
                         Err(e) => {
                             abort!("failed to assign ValTensor to VarTensor {:?}", e);
@@ -123,51 +115,35 @@ impl VarTensor {
                     }
                 }
             }),
-            ValTensor::PrevAssigned { inner: v, dims: _ } => {
-                v.enum_map(|coord, x| match &self {
-                    VarTensor::Fixed { inner: _, dims: _ } => todo!(),
-                    VarTensor::Advice { inner: a, dims: _ } => {
-                        match x.copy_advice(
-                            || "k",
-                            region,
-                    *a,
-                    offset + coord,
-                        ) {
-                            Ok(a) => a,
-                            Err(e) => {
-                                abort!("failed to copy ValTensor to VarTensor {:?}", e);
-                            }
+            ValTensor::PrevAssigned { inner: v, dims: _ } => v.enum_map(|coord, x| match &self {
+                VarTensor::Fixed { inner: _, dims: _ } => todo!(),
+                VarTensor::Advice { inner: a, dims: _ } => {
+                    match x.copy_advice(|| "k", region, *a, offset + coord) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            abort!("failed to copy ValTensor to VarTensor {:?}", e);
                         }
                     }
-                })
-            }
-            ValTensor::AssignedValue { inner: v, dims: _ } => {
-                v.enum_map(|coord, k| match &self {
-                    VarTensor::Fixed { inner: f, dims: _ } => {
-                        match region.assign_fixed(|| "k", f[coord], offset, || k) {
-                            Ok(a) => a,
-                            Err(e) => {
-                                abort!("failed to assign ValTensor to VarTensor {:?}", e);
-                            }
+                }
+            }),
+            ValTensor::AssignedValue { inner: v, dims: _ } => v.enum_map(|coord, k| match &self {
+                VarTensor::Fixed { inner: f, dims: _ } => {
+                    match region.assign_fixed(|| "k", f[coord], offset, || k) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            abort!("failed to assign ValTensor to VarTensor {:?}", e);
                         }
                     }
-                    VarTensor::Advice { inner: a, dims: _ } => {
-                        match region.assign_advice(
-                            || "k",
-                            *a,
-                    offset + coord,
-                            || k,
-                        ) {
-                            Ok(a) => a,
-                            Err(e) => {
-                                abort!("failed to assign ValTensor to VarTensor {:?}", e);
-                            }
+                }
+                VarTensor::Advice { inner: a, dims: _ } => {
+                    match region.assign_advice(|| "k", *a, offset + coord, || k) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            abort!("failed to assign ValTensor to VarTensor {:?}", e);
                         }
                     }
-                })
-            }
+                }
+            }),
         }
     }
 }
-
-

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -32,9 +32,8 @@ impl VarTensor {
         dims: Vec<usize>,
         equality: bool,
     ) -> Self {
-        let base: usize = 2;
-        // TODO: figure out the actual number of rows T used for the ZK component of PLONK
-        let max_rows = base.pow((k - 2) as u32);
+        let base = 2u32;
+        let max_rows = base.pow(k as u32) as usize - cs.blinding_factors() - 1;
         let modulo = (capacity / max_rows) + 1;
         let mut advices = vec![];
         for _ in 0..modulo {
@@ -174,7 +173,7 @@ impl VarTensor {
                     match region.assign_advice(|| "k", advices[x], y, || k.into()) {
                         Ok(a) => a,
                         Err(e) => {
-                            panic!("failed to assign ValTensor to VarTensor {:?}", e);
+                            abort!("failed to assign ValTensor to VarTensor {:?}", e);
                         }
                     }
                 }


### PR DESCRIPTION
- `VarTensor` now has a Vector of columns as inner type. The number of columns in the vector is determined by `K`(logrows). 
- We can query and assign over these vectors using a 1D index. 
- Also holds information as to the dimensionality of the underlying object it represents (`dims`). 
- Note that the `capacity` attribute of  `VarTensor`  is not equal to the product of `dims`. Instead it expresses the maximum potential capacity (number of entries) that this `VarTensor`  has been programmed to hold given `K`.