### PR TITLE
refactor: reuseable tables

### DIFF
--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -135,7 +135,7 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
     }
 
     /// Configures and creates an elementwise operation within a circuit using a supplied lookup table.
-    fn configure_with_table(
+    pub fn configure_with_table(
         cs: &mut ConstraintSystem<F>,
         input: &VarTensor,
         output: &VarTensor,

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -7,13 +7,12 @@ use crate::tensor::ops::{add, const_mult, div, mult};
 use crate::tensor::Tensor;
 use crate::tensor::TensorType;
 use anyhow::Result;
-
 use halo2_proofs::arithmetic::FieldExt;
 use itertools::Itertools;
 use log::{error, info, trace, warn};
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::fmt;
-
+use std::rc::Rc;
 use tabled::Tabled;
 use tract_onnx;
 use tract_onnx::prelude::{DatumType, InferenceFact, Node as OnnxNode, OutletId};
@@ -34,7 +33,7 @@ use tract_onnx::tract_hir::{
 // Eventually, though, we probably want to keep them and treat them directly (layouting and configuring
 // at each type of node)
 /// Enum of the different kinds of operations `ezkl` can support.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd)]
 pub enum OpKind {
     ReLU(usize),
     Sigmoid(usize),
@@ -166,7 +165,7 @@ impl NodeGraph {
 /// A circuit configuration for a single self.
 #[derive(Clone, Default, Debug)]
 pub struct NodeConfig<F: FieldExt + TensorType> {
-    pub config: NodeConfigTypes<F>,
+    pub config: Rc<NodeConfigTypes<F>>,
     pub onnx_idx: Vec<usize>,
 }
 

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -7,12 +7,12 @@ use crate::tensor::ops::{add, const_mult, div, mult};
 use crate::tensor::Tensor;
 use crate::tensor::TensorType;
 use anyhow::Result;
+
 use halo2_proofs::arithmetic::FieldExt;
 use itertools::Itertools;
 use log::{error, info, trace, warn};
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::fmt;
-use std::rc::Rc;
 use tabled::Tabled;
 use tract_onnx;
 use tract_onnx::prelude::{DatumType, InferenceFact, Node as OnnxNode, OutletId};
@@ -165,7 +165,7 @@ impl NodeGraph {
 /// A circuit configuration for a single self.
 #[derive(Clone, Default, Debug)]
 pub struct NodeConfig<F: FieldExt + TensorType> {
-    pub config: Rc<NodeConfigTypes<F>>,
+    pub config: NodeConfigTypes<F>,
     pub onnx_idx: Vec<usize>,
 }
 


### PR DESCRIPTION
- During configuration we track already instantiated tables using a `BTree`. 
- Nodes that configure the same table op (eg. non-linearity with same re-scaling factor) share a reference to the same table config