### PR TITLE
fix:  number of advices calculation

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -42,6 +42,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
             (0, 0),
             num_instances,
         );
+        info!("advice cap: {:?}", advice_cap);
         info!(
             "number of advices used: {:?}",
             vars.advices.iter().map(|a| a.num_cols()).sum::<usize>()

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -254,7 +254,8 @@ impl Model {
         let mut results = BTreeMap::new();
         let mut tables = BTreeMap::new();
 
-        for (_, bucket_nodes) in self.nodes.0.iter() {
+        for (bucket, bucket_nodes) in self.nodes.0.iter() {
+            trace!("configuring bucket: {:?}", bucket);
             let non_fused_ops: BTreeMap<&usize, &Node> = bucket_nodes
                 .iter()
                 .filter(|(_, n)| !n.opkind.is_fused())
@@ -360,7 +361,6 @@ impl Model {
                 )
             })
             .collect();
-
         // This works because retain only keeps items for which the predicate returns true, and
         // insert only returns true if the item was not previously present in the set.
         // Since the vector is traversed in order, we end up keeping just the first occurrence of each item.
@@ -383,7 +383,6 @@ impl Model {
             .collect_vec();
 
         let output_shape = self.nodes.filter(**nodes.keys().max().unwrap()).out_dims;
-
         // output node
         let output = &vars.advices[start].reshape(&output_shape);
 
@@ -413,7 +412,7 @@ impl Model {
 
         let inputs = inputs_to_layer.iter();
 
-        NodeConfigTypes::Fused(
+        let config = NodeConfigTypes::Fused(
             FusedConfig::configure(
                 meta,
                 &inputs.clone().map(|x| x.1.clone()).collect_vec(),
@@ -421,7 +420,8 @@ impl Model {
                 &fused_nodes,
             ),
             inputs.map(|x| x.0).collect_vec(),
-        )
+        );
+        config
     }
 
     /// Configures a lookup table based operation. These correspond to operations that are represented in
@@ -438,7 +438,7 @@ impl Model {
         vars: &mut ModelVars,
         tables: &mut BTreeMap<OpKind, TableTypes<F>>,
     ) -> NodeConfigTypes<F> {
-        let input_len = node.in_dims.iter().product();
+        let input_len = node.in_dims[0].iter().product();
         let input = &vars.advices[0].reshape(&[input_len]);
         let output = &vars.advices[1].reshape(&[input_len]);
         let node_inputs = node.inputs.iter().map(|e| e.node).collect();
@@ -710,7 +710,13 @@ impl Model {
             self.nodes
                 .flatten()
                 .iter()
-                .map(|e| e.in_dims.iter().product())
+                .map(|e| {
+                    e.in_dims
+                        .iter()
+                        .map(|dims| dims.iter().product::<usize>())
+                        .max()
+                        .unwrap()
+                })
                 .max()
                 .unwrap(),
             self.nodes
@@ -723,11 +729,30 @@ impl Model {
     }
 
     pub fn max_node_vars(&self) -> usize {
-        self.nodes
-            .flatten()
-            .iter()
-            .map(|e| e.num_var)
-            .max()
-            .unwrap()
+        let mut maximum_number_inputs = 0;
+        for (_, bucket_nodes) in self.nodes.0.iter() {
+            let non_fused_ops = match bucket_nodes
+                .iter()
+                .filter(|(_, n)| !n.opkind.is_fused())
+                .map(|(_, n)| n.inputs.len())
+                .max()
+            {
+                Some(m) => m,
+                None => 0,
+            };
+
+            maximum_number_inputs = max(maximum_number_inputs, non_fused_ops);
+
+            let fused_ops = bucket_nodes
+                .iter()
+                .filter(|(_, n)| n.opkind.is_fused())
+                .map(|(_, n)| n.inputs.clone())
+                .flatten()
+                .unique()
+                .collect_vec();
+
+            maximum_number_inputs = max(maximum_number_inputs, fused_ops.len());
+        }
+        maximum_number_inputs
     }
 }

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -574,7 +574,7 @@ impl Model {
                 range_check.layout(layouter.namespace(|| "range check outputs"), output)
             })
             .collect_vec();
-
+        info!("computing...");
         Ok(())
     }
 

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -220,7 +220,6 @@ fn display_tensorf32(o: &Option<Tensor<f32>>) -> String {
 pub struct Node {
     pub opkind: OpKind,
     pub output_max: f32,
-    pub num_var: usize,
     pub in_scale: i32,
     pub out_scale: i32,
     #[tabled(display_with = "display_tensor")]
@@ -232,7 +231,7 @@ pub struct Node {
     #[tabled(display_with = "display_inputs")]
     pub inputs: Vec<OutletId>,
     #[tabled(display_with = "display_vector")]
-    pub in_dims: Vec<usize>,
+    pub in_dims: Vec<Vec<usize>>,
     #[tabled(display_with = "display_vector")]
     pub out_dims: Vec<usize>,
     pub idx: usize,
@@ -272,15 +271,15 @@ impl Node {
             opkind: OpKind::new(node.op().name().as_ref()), // parses the op name
             inputs: node.inputs.clone(),
             in_scale: scale,
-            num_var: 2,
             idx,
+            in_dims: inputs.iter().map(|inp| inp.out_dims.clone()).collect(),
             ..Default::default()
         };
 
         match mn.opkind {
             OpKind::Sigmoid(_) => {
                 let input_node = &inputs[0];
-                mn.in_dims = input_node.out_dims.clone();
+                mn.in_dims = vec![input_node.out_dims.clone()];
                 mn.out_dims = input_node.out_dims.clone();
                 mn.in_scale = input_node.out_scale;
                 mn.out_scale = scale;
@@ -295,7 +294,7 @@ impl Node {
 
             OpKind::ReLU(_) => {
                 let input_node = &inputs[0];
-                mn.in_dims = input_node.out_dims.clone();
+                mn.in_dims = vec![input_node.out_dims.clone()];
                 mn.out_dims = input_node.out_dims.clone();
                 mn.output_max = input_node.output_max;
                 mn.in_scale = input_node.out_scale;
@@ -310,7 +309,7 @@ impl Node {
             }
             OpKind::Div(_) => {
                 let input_node = &inputs[0];
-                mn.in_dims = input_node.out_dims.clone();
+                mn.in_dims = vec![input_node.out_dims.clone()];
                 mn.out_dims = input_node.out_dims.clone();
 
                 // rescale the divider
@@ -335,11 +334,6 @@ impl Node {
                 }
             }
             OpKind::Fused(ref s) => {
-                let input_node = &inputs[0];
-                mn.in_dims = input_node.out_dims.clone();
-                mn.out_dims = input_node.out_dims.clone();
-                mn.num_var = 4;
-
                 inputs
                     .iter()
                     .tuple_windows()
@@ -402,10 +396,8 @@ impl Node {
                         let (padding_h, padding_w, stride_h, stride_w) =
                             (padding[0], padding[1], stride[0], stride[1]);
 
-                        mn.in_dims = input_node.out_dims.clone();
-                        trace!("{:?}", mn.in_dims);
-                        let input_height = mn.in_dims[1];
-                        let input_width = mn.in_dims[2];
+                        let input_height = input_node.out_dims[1];
+                        let input_width = input_node.out_dims[2];
 
                         let out_height =
                             (input_height + 2 * padding_h - kernel_height) / stride_h + 1;
@@ -453,11 +445,9 @@ impl Node {
                             (padding[0], padding[1], stride[0], stride[1]);
                         let (kernel_height, kernel_width) = (kernel_shape[0], kernel_shape[1]);
 
-                        mn.in_dims = input_node.out_dims.clone();
-
-                        let input_channels = mn.in_dims[0];
-                        let input_height = mn.in_dims[1];
-                        let input_width = mn.in_dims[2];
+                        let input_channels = input_node.out_dims[0];
+                        let input_height = input_node.out_dims[1];
+                        let input_width = input_node.out_dims[2];
 
                         let out_height =
                             (input_height + 2 * padding_h - kernel_height) / stride_h + 1;
@@ -477,10 +467,9 @@ impl Node {
                         let input_node = &inputs[0];
                         mn.in_scale = input_node.out_scale;
                         mn.out_scale = input_node.out_scale;
-                        mn.in_dims = input_node.out_dims.clone();
-                        let input_channels = mn.in_dims[0];
-                        let input_height = mn.in_dims[1];
-                        let input_width = mn.in_dims[2];
+                        let input_channels = input_node.out_dims[0];
+                        let input_height = input_node.out_dims[1];
+                        let input_width = input_node.out_dims[2];
 
                         let (padding_h, padding_w, stride_h, stride_w) = (0, 0, 1, 1);
                         let (kernel_height, kernel_width) = (input_height, input_width);
@@ -506,7 +495,7 @@ impl Node {
                         let a_dims = a_node.out_dims.clone();
                         let b_dims = b_node.out_dims.clone();
                         let in_dim = a_dims[1];
-                        mn.in_dims = vec![in_dim];
+                        mn.in_dims = vec![vec![in_dim]];
 
                         let mut dims = Vec::from(&a_dims[0..a_dims.len() - 2]);
                         dims.push(a_dims[a_dims.len() - 2]);
@@ -514,11 +503,11 @@ impl Node {
 
                         mn.out_dims = dims.clone();
 
-                        mn.output_max = input_node.output_max * a_node.output_max * (in_dim as f32);
+                        mn.output_max = a_node.output_max * b_node.output_max * (in_dim as f32);
 
-                        mn.in_scale = input_node.out_scale;
+                        mn.in_scale = a_node.out_scale;
 
-                        mn.out_scale = a_node.out_scale + input_node.out_scale;
+                        mn.out_scale = a_node.out_scale + b_node.out_scale;
                     }
                     FusedOp::Affine | FusedOp::ScaleAndShift => {
                         let (input_node, weight_node, bias_node) =
@@ -537,7 +526,6 @@ impl Node {
 
                         let in_dim = weight_node.out_dims.clone()[1];
                         let out_dim = weight_node.out_dims.clone()[0];
-                        mn.in_dims = vec![in_dim];
                         mn.out_dims = vec![out_dim];
 
                         mn.output_max =
@@ -581,7 +569,6 @@ impl Node {
                         // this node becomes a ScaleAndShift with former gamma and beta as params
                         mn.opkind = OpKind::Fused(FusedOp::ScaleAndShift);
 
-                        mn.in_dims = inputs[0].out_dims.clone();
                         mn.out_dims = inputs[0].out_dims.clone();
 
                         mn.output_max = //is gamma output max still accurate?
@@ -607,11 +594,13 @@ impl Node {
 
                         mn.in_scale = inputs.iter().map(|input| input.out_scale).max().unwrap();
                         mn.out_scale = mn.in_scale;
+
+                        mn.out_dims = inputs[0].out_dims.clone();
                     }
                     FusedOp::Sum => {
                         assert!(inputs.len() == 1);
                         mn.output_max = inputs[0].output_max
-                            * inputs[0].in_dims.iter().product::<usize>() as f32;
+                            * inputs[0].out_dims.iter().product::<usize>() as f32;
                         mn.in_scale = inputs.iter().map(|input| input.out_scale).max().unwrap();
                         mn.out_scale = mn.in_scale;
                         mn.out_dims = vec![1];
@@ -634,8 +623,10 @@ impl Node {
                         }
                         mn.in_scale = inputs.iter().map(|input| input.out_scale).max().unwrap();
                         mn.out_scale = mn.in_scale;
+                        mn.out_dims = inputs[0].out_dims.clone();
                     }
                     FusedOp::Mult => {
+                        let input_node = &inputs[0];
                         mn.output_max = f32::powf(
                             inputs
                                 .iter()
@@ -646,8 +637,10 @@ impl Node {
                         );
                         mn.in_scale = input_node.out_scale;
                         mn.out_scale = inputs.iter().map(|input| input.out_scale).sum::<i32>();
+                        mn.out_dims = inputs[0].out_dims.clone();
                     }
                     FusedOp::Pow(_) => {
+                        let input_node = &inputs[0];
                         let mult = scale_to_multiplier(scale);
                         mn.inputs.pop();
                         if inputs[1].out_dims != [1] {
@@ -668,17 +661,22 @@ impl Node {
                         mn.in_scale = input_node.out_scale;
                         mn.out_scale = mn.in_scale * (pow as i32);
 
+                        mn.out_dims = input_node.out_dims.clone();
+
                         mn.opkind = OpKind::Fused(FusedOp::Pow(pow as usize));
                     }
                     FusedOp::Rescaled(_, _) => {
                         error!("operations should not already be rescaled at this stage")
                     }
                     FusedOp::Identity => {
+                        let input_node = &inputs[0];
                         mn.output_max = input_node.output_max;
                         mn.in_scale = input_node.out_scale;
                         mn.out_scale = input_node.out_scale;
+                        mn.out_dims = input_node.out_dims.clone();
                     }
                     FusedOp::Reshape(_) => {
+                        let input_node = &inputs[0];
                         let shape_const_node = &inputs[1];
                         let shape_const = match shape_const_node.const_value.as_ref() {
                             Some(sc) => sc,
@@ -741,7 +739,7 @@ impl Node {
                         let raw: Tensor<f32> = Tensor::new(Some(&vec), &dims).unwrap();
                         let t = vector_to_quantized(&vec, &dims, 0f32, mn.out_scale).unwrap();
                         mn.out_dims = t.dims().to_vec();
-                        mn.in_dims = mn.out_dims.clone();
+                        mn.in_dims = vec![mn.out_dims.clone()];
                         mn.output_max = t.iter().map(|x| x.abs()).max().unwrap() as f32;
                         mn.const_value = Some(t);
                         mn.raw_const_value = Some(raw);
@@ -754,7 +752,7 @@ impl Node {
                         let cast: Vec<i32> = vec.iter().map(|x| *x as i32).collect();
                         let t = Tensor::<i32>::new(Some(&cast), &dims).unwrap();
                         mn.out_dims = t.dims().to_vec();
-                        mn.in_dims = mn.out_dims.clone();
+                        mn.in_dims = vec![mn.out_dims.clone()];
                         mn.output_max = cast.iter().map(|x| x.abs()).max().unwrap() as f32;
                         mn.const_value = Some(t);
                         mn.raw_const_value = None;
@@ -787,7 +785,7 @@ impl Node {
                 } else {
                     mn.out_dims = dims;
                 }
-                mn.in_dims = mn.out_dims.clone();
+                mn.in_dims = vec![mn.out_dims.clone()];
 
                 mn.output_max = 256.0;
                 mn.out_scale = mn.in_scale;


### PR DESCRIPTION
- fixes the systematic underestimation of the number of required advices for fused layers. 
- fixes cases where we overestimate as well, we remove intermediary calcs / nodes from the advice requirements