### PR TITLE
feat: flexible public / private variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ The `.onnx` file can be generated using pytorch or tensorflow. The data json fil
 ```javascript
 {
     "input_data": [[1.0, 22.2, 0.12 ...]], // 2D arrays of floats which represents the (private) inputs we run the proof on
-    "input_shape": [[3, 3, ...]], // 2D array of integers which represents the shapes of model inputs (excluding batch size)
-    "public_inputs": [[1.0, 5.0, 6.3 ...]], // 2D arrays of floats which represents the public inputs (model outputs for now)
+    "input_shapes": [[3, 3, ...]], // 2D array of integers which represents the shapes of model inputs (excluding batch size)
+    "output_data": [[1.0, 5.0, 6.3 ...]], // 2D arrays of floats which represents the model outputs we want to constrain against (if any)
 }
 ```
 

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -35,11 +35,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
             .map(|_| VarTensor::new_advice(cs, K, len, vec![len], true))
             .collect_vec();
 
-        let instance = {
-            let l = cs.instance_column();
-            cs.enable_equality(l);
-            l
-        };
+        let instance = VarTensor::new_instance(cs, vec![len], true);
 
         RangeCheckConfig::configure(cs, &advices[0], &advices[1], &instance, RANGE)
     }

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -19,6 +19,7 @@ const K: usize = 15; //2^k rows
 #[derive(Clone)]
 struct MyCircuit<F: FieldExt + TensorType> {
     input: ValTensor<F>,
+    output: ValTensor<F>,
 }
 
 impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
@@ -35,9 +36,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
             .map(|_| VarTensor::new_advice(cs, K, len, vec![len], true))
             .collect_vec();
 
-        let instance = ValTensor::new_instance(cs, vec![len], true);
-
-        RangeCheckConfig::configure(cs, &advices[0], &advices[1], &instance, RANGE)
+        RangeCheckConfig::configure(cs, &advices[0], &advices[1], RANGE)
     }
 
     fn synthesize(
@@ -45,7 +44,11 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.layout(layouter.namespace(|| "Assign value"), self.input.clone());
+        config.layout(
+            layouter.namespace(|| "Assign value"),
+            self.input.clone(),
+            self.output.clone(),
+        );
 
         Ok(())
     }
@@ -62,13 +65,13 @@ fn runrange(c: &mut Criterion) {
 
         let circuit = MyCircuit::<F> {
             input: ValTensor::from(input.clone()),
+            output: ValTensor::from(input.clone()),
         };
 
         group.throughput(Throughput::Elements(len as u64));
         group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, &_| {
             b.iter(|| {
-                let instances = vec![(0..len).map(|_| F::from(1)).collect_vec()];
-                let prover = MockProver::run(K as u32, &circuit, instances).unwrap();
+                let prover = MockProver::run(K as u32, &circuit, vec![]).unwrap();
                 prover.assert_satisfied();
             });
         });

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -35,7 +35,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
             .map(|_| VarTensor::new_advice(cs, K, len, vec![len], true))
             .collect_vec();
 
-        let instance = VarTensor::new_instance(cs, vec![len], true);
+        let instance = ValTensor::new_instance(cs, vec![len], true);
 
         RangeCheckConfig::configure(cs, &advices[0], &advices[1], &instance, RANGE)
     }

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -57,7 +57,7 @@ fn runrelu(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
 
-    for &len in [128].iter() {
+    for &len in [4, 8, 16, 32, 64].iter() {
         unsafe {
             LEN = len;
         };

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -73,7 +73,7 @@ impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
 
         let l2 = FusedConfig::<F>::configure(
             cs,
-            &[input.clone(), kernel.clone(), bias.clone()],
+            &[input.clone(), kernel, bias],
             &output,
             &[affine_node],
         );

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -163,6 +163,13 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                     qlookup.clone() * cs.query_fixed(fixed[x], Rotation(y as i32))
                                         + not_qlookup.clone() * default_x
                                 }
+                                VarTensor::Instance {
+                                    inner: instances, ..
+                                } => {
+                                    qlookup.clone()
+                                        * cs.query_instance(instances[x], Rotation(y as i32))
+                                        + not_qlookup.clone() * default_x
+                                }
                             },
                             table.borrow().table_input,
                         ),
@@ -175,6 +182,12 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                 VarTensor::Fixed { inner: fixed, .. } => {
                                     qlookup * cs.query_fixed(fixed[x], Rotation(y as i32))
                                         + not_qlookup * default_y
+                                }
+                                VarTensor::Instance {
+                                    inner: instances, ..
+                                } => {
+                                    qlookup * cs.query_instance(instances[x], Rotation(y as i32))
+                                        + not_qlookup.clone() * default_y
                                 }
                             },
                             table.borrow().table_output,

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -163,13 +163,6 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                     qlookup.clone() * cs.query_fixed(fixed[x], Rotation(y as i32))
                                         + not_qlookup.clone() * default_x
                                 }
-                                VarTensor::Instance {
-                                    inner: instance, ..
-                                } => {
-                                    qlookup.clone()
-                                        * cs.query_instance(*instance, Rotation(i as i32))
-                                        + not_qlookup.clone() * default_x
-                                }
                             },
                             table.borrow().table_input,
                         ),
@@ -182,12 +175,6 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                 VarTensor::Fixed { inner: fixed, .. } => {
                                     qlookup * cs.query_fixed(fixed[x], Rotation(y as i32))
                                         + not_qlookup * default_y
-                                }
-                                VarTensor::Instance {
-                                    inner: instance, ..
-                                } => {
-                                    qlookup * cs.query_instance(*instance, Rotation(i as i32))
-                                        + not_qlookup.clone() * default_y
                                 }
                             },
                             table.borrow().table_output,

--- a/src/circuit/eltwise.rs
+++ b/src/circuit/eltwise.rs
@@ -164,10 +164,10 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                         + not_qlookup.clone() * default_x
                                 }
                                 VarTensor::Instance {
-                                    inner: instances, ..
+                                    inner: instance, ..
                                 } => {
                                     qlookup.clone()
-                                        * cs.query_instance(instances[x], Rotation(y as i32))
+                                        * cs.query_instance(*instance, Rotation(i as i32))
                                         + not_qlookup.clone() * default_x
                                 }
                             },
@@ -184,9 +184,9 @@ impl<F: FieldExt + TensorType, NL: 'static + Nonlinearity<F>> EltwiseConfig<F, N
                                         + not_qlookup * default_y
                                 }
                                 VarTensor::Instance {
-                                    inner: instances, ..
+                                    inner: instance, ..
                                 } => {
-                                    qlookup * cs.query_instance(instances[x], Rotation(y as i32))
+                                    qlookup * cs.query_instance(*instance, Rotation(i as i32))
                                         + not_qlookup.clone() * default_y
                                 }
                             },

--- a/src/circuit/range.rs
+++ b/src/circuit/range.rs
@@ -160,7 +160,7 @@ mod tests {
                 .collect_vec();
             let input = &advices[0];
             let expected = &advices[1];
-            RangeCheckConfig::configure(cs, &input, &expected, RANGE)
+            RangeCheckConfig::configure(cs, input, expected, RANGE)
         }
 
         fn synthesize(

--- a/src/circuit/utils.rs
+++ b/src/circuit/utils.rs
@@ -10,6 +10,7 @@ pub fn value_muxer<F: FieldExt + TensorType>(
     input: &ValTensor<F>,
 ) -> Tensor<Value<F>> {
     match variable {
+        VarTensor::Instance { .. } => assigned.clone(),
         VarTensor::Advice { .. } => assigned.clone(),
         VarTensor::Fixed { .. } => match input {
             ValTensor::Value {

--- a/src/circuit/utils.rs
+++ b/src/circuit/utils.rs
@@ -10,7 +10,6 @@ pub fn value_muxer<F: FieldExt + TensorType>(
     input: &ValTensor<F>,
 ) -> Tensor<Value<F>> {
     match variable {
-        VarTensor::Instance { .. } => assigned.clone(),
         VarTensor::Advice { .. } => assigned.clone(),
         VarTensor::Fixed { .. } => match input {
             ValTensor::Value {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,13 +22,13 @@ pub struct Cli {
     #[arg(short = 'K', long, default_value = "17")]
     pub logrows: u32,
     /// Flags whether inputs are public
-    #[arg(short = 'I', long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     pub public_inputs: bool,
     /// Flags whether inputs are public
-    #[arg(short = 'O', long, default_value = "true")]
+    #[arg(long, default_value = "true")]
     pub public_outputs: bool,
     /// Flags whether inputs are public
-    #[arg(short = 'P', long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     pub public_params: bool,
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -21,6 +21,15 @@ pub struct Cli {
     /// The log_2 number of rows
     #[arg(short = 'K', long, default_value = "17")]
     pub logrows: u32,
+    /// Flags whether inputs are public
+    #[arg(short = 'I', long, default_value = "false")]
+    pub public_inputs: bool,
+    /// Flags whether inputs are public
+    #[arg(short = 'O', long, default_value = "true")]
+    pub public_outputs: bool,
+    /// Flags whether inputs are public
+    #[arg(short = 'P', long, default_value = "false")]
+    pub public_params: bool,
 }
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -33,6 +33,12 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
         let model = Model::from_arg();
         let num_advice = model.max_node_vars();
         let row_cap = model.max_node_size();
+        // TODO: extract max number of params in a given fused layer
+        let num_fixed = if model.visibility.params.is_public() {
+            num_advice
+        } else {
+            0
+        };
         // for now the number of instances corresponds to the number of graph / model outputs
         let mut num_instances = 0;
         if model.visibility.input.is_public() {
@@ -45,7 +51,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
             cs,
             model.logrows as usize,
             (num_advice, row_cap),
-            (num_advice, row_cap),
+            (num_fixed, row_cap),
             (num_instances, usize::MAX),
         );
         info!("row cap: {:?}", row_cap);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -40,7 +40,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
             model.logrows as usize,
             (num_advice, advice_cap),
             (0, 0),
-            num_instances,
+            (num_instances, usize::MAX),
         );
         info!("advice cap: {:?}", advice_cap);
         info!(

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -34,7 +34,13 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
         let num_advice = model.max_node_vars();
         let row_cap = model.max_node_size();
         // for now the number of instances corresponds to the number of graph / model outputs
-        let num_instances: usize = model.num_outputs();
+        let mut num_instances = 0;
+        if model.visibility.input.is_public() {
+            num_instances += model.num_inputs();
+        }
+        if model.visibility.output.is_public() {
+            num_instances += model.num_outputs();
+        }
         let mut vars = ModelVars::new(
             cs,
             model.logrows as usize,
@@ -47,6 +53,11 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
             "number of advices used: {:?}",
             vars.advices.iter().map(|a| a.num_cols()).sum::<usize>()
         );
+        info!(
+            "number of fixed used: {:?}",
+            vars.fixed.iter().map(|a| a.num_cols()).sum::<usize>()
+        );
+        info!("number of instances used: {:?}", num_instances);
         model.configure(cs, &mut vars).unwrap()
     }
 
@@ -64,7 +75,7 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
         trace!("Setting output in synthesize");
         config
             .model
-            .layout(config.clone(), &mut layouter, &inputs)
+            .layout(config.clone(), &mut layouter, &inputs, &config.vars)
             .unwrap();
 
         Ok(())

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -32,17 +32,17 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let model = Model::from_arg();
         let num_advice = model.max_node_vars();
-        let advice_cap = model.max_node_size();
+        let row_cap = model.max_node_size();
         // for now the number of instances corresponds to the number of graph / model outputs
         let num_instances: usize = model.num_outputs();
         let mut vars = ModelVars::new(
             cs,
             model.logrows as usize,
-            (num_advice, advice_cap),
-            (0, 0),
+            (num_advice, row_cap),
+            (num_advice, row_cap),
             (num_instances, usize::MAX),
         );
-        info!("advice cap: {:?}", advice_cap);
+        info!("row cap: {:?}", row_cap);
         info!(
             "number of advices used: {:?}",
             vars.advices.iter().map(|a| a.num_cols()).sum::<usize>()

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -11,9 +11,12 @@ pub mod utilities;
 pub use utilities::*;
 pub mod model;
 pub mod node;
+pub mod vars;
 use log::{info, trace};
 pub use model::*;
 pub use node::*;
+use std::cmp::max;
+pub use vars::*;
 
 #[derive(Clone, Debug)]
 pub struct ModelCircuit<F: FieldExt> {
@@ -31,28 +34,40 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
 
     fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
         let model = Model::from_arg();
-        let num_advice = model.max_node_vars();
+        let num_advice: usize;
+        let mut num_fixed = 0;
         let row_cap = model.max_node_size();
+
         // TODO: extract max number of params in a given fused layer
-        let num_fixed = if model.visibility.params.is_public() {
-            num_advice
+        if model.visibility.params.is_public() {
+            num_fixed += model.max_node_params();
+            // this is the maximum of variables in non-fused layer, and the maximum of variables (non-params) in fused layers
+            num_advice = max(model.max_node_vars_non_fused(), model.max_node_vars_fused());
         } else {
-            0
-        };
+            // this is the maximum of variables in non-fused layer, and the maximum of variables (non-params) in fused layers
+            //  + the max number of params in a fused layer
+            num_advice = max(
+                model.max_node_vars_non_fused(),
+                model.max_node_params() + model.max_node_vars_fused(),
+            );
+        }
         // for now the number of instances corresponds to the number of graph / model outputs
         let mut num_instances = 0;
+        let mut instance_shapes = vec![];
         if model.visibility.input.is_public() {
             num_instances += model.num_inputs();
+            instance_shapes.extend(model.input_shapes());
         }
         if model.visibility.output.is_public() {
             num_instances += model.num_outputs();
+            instance_shapes.extend(model.output_shapes());
         }
         let mut vars = ModelVars::new(
             cs,
             model.logrows as usize,
             (num_advice, row_cap),
             (num_fixed, row_cap),
-            (num_instances, usize::MAX),
+            (num_instances, instance_shapes),
         );
         info!("row cap: {:?}", row_cap);
         info!(

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::{Layouter, Value},
-    plonk::{Column, ConstraintSystem, Instance},
+    plonk::ConstraintSystem,
 };
 use itertools::Itertools;
 use log::{debug, error, info, trace};
@@ -71,7 +71,7 @@ pub struct ModelVars {
     pub advices: Vec<VarTensor>,
     pub fixed: Vec<VarTensor>,
     // TODO: create a new VarTensor for Instance Columns
-    pub instances: Vec<Column<Instance>>,
+    pub instances: Vec<VarTensor>,
 }
 /// A wrapper for holding all columns that will be assigned to by a model.
 impl ModelVars {
@@ -80,7 +80,7 @@ impl ModelVars {
         logrows: usize,
         advice_dims: (usize, usize),
         fixed_dims: (usize, usize),
-        num_instances: usize,
+        instance_dims: (usize, usize),
     ) -> Self {
         let advices = (0..advice_dims.0)
             .map(|_| {
@@ -99,12 +99,9 @@ impl ModelVars {
                 VarTensor::new_fixed(cs, logrows as usize, fixed_dims.1, vec![fixed_dims.1], true)
             })
             .collect_vec();
-        let instances = (0..num_instances)
-            .map(|_| {
-                let l = cs.instance_column();
-                cs.enable_equality(l);
-                l
-            })
+        // todo init fixed
+        let instances = (0..instance_dims.0)
+            .map(|_| VarTensor::new_instance(cs, vec![instance_dims.1], true))
             .collect_vec();
         ModelVars {
             advices,

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -72,6 +72,9 @@ impl ModelVisibility {
         } else {
             Visibility::Private
         };
+        if !output_vis.is_public() & !params_vis.is_public() & !input_vis.is_public() {
+            abort!("at least one set of variables should be public");
+        }
         Self {
             input: input_vis,
             params: params_vis,

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -67,15 +67,15 @@ impl<F: FieldExt + TensorType> TableTypes<F> {
     }
 }
 
-pub struct ModelVars {
+pub struct ModelVars<F: FieldExt + TensorType> {
     pub advices: Vec<VarTensor>,
     pub fixed: Vec<VarTensor>,
     // TODO: create a new VarTensor for Instance Columns
-    pub instances: Vec<VarTensor>,
+    pub instances: Vec<ValTensor<F>>,
 }
 /// A wrapper for holding all columns that will be assigned to by a model.
-impl ModelVars {
-    pub fn new<F: FieldExt>(
+impl<F: FieldExt + TensorType> ModelVars<F> {
+    pub fn new(
         cs: &mut ConstraintSystem<F>,
         logrows: usize,
         advice_dims: (usize, usize),
@@ -101,7 +101,7 @@ impl ModelVars {
             .collect_vec();
         // todo init fixed
         let instances = (0..instance_dims.0)
-            .map(|_| VarTensor::new_instance(cs, vec![instance_dims.1], true))
+            .map(|_| ValTensor::new_instance(cs, vec![instance_dims.1], true))
             .collect_vec();
         ModelVars {
             advices,
@@ -245,7 +245,7 @@ impl Model {
     pub fn configure<F: FieldExt + TensorType>(
         &self,
         meta: &mut ConstraintSystem<F>,
-        vars: &mut ModelVars,
+        vars: &mut ModelVars<F>,
     ) -> Result<ModelConfig<F>> {
         info!("configuring model");
         let mut results = BTreeMap::new();
@@ -299,7 +299,7 @@ impl Model {
     fn range_check_outputs<F: FieldExt + TensorType>(
         &self,
         meta: &mut ConstraintSystem<F>,
-        vars: &mut ModelVars,
+        vars: &mut ModelVars<F>,
     ) -> Vec<RangeCheckConfig<F>> {
         let mut configs = vec![];
         let output_nodes = self.model.outputs.clone();
@@ -338,7 +338,7 @@ impl Model {
         &self,
         nodes: &BTreeMap<&usize, &Node>,
         meta: &mut ConstraintSystem<F>,
-        vars: &mut ModelVars,
+        vars: &mut ModelVars<F>,
     ) -> NodeConfigTypes<F> {
         let input_nodes: BTreeMap<(&usize, &FusedOp), Vec<Node>> = nodes
             .iter()
@@ -432,7 +432,7 @@ impl Model {
         &self,
         node: &Node,
         meta: &mut ConstraintSystem<F>,
-        vars: &mut ModelVars,
+        vars: &mut ModelVars<F>,
         tables: &mut BTreeMap<OpKind, TableTypes<F>>,
     ) -> NodeConfigTypes<F> {
         let input_len = node.in_dims[0].iter().product();

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -342,10 +342,15 @@ impl Model {
             }
         }
 
+        let mut public_outputs = vec![];
+        if !self.visibility.output.is_public() {
+            public_outputs = self.range_check_outputs(meta, vars)
+        };
+
         Ok(ModelConfig {
             configs: results,
             model: self.clone(),
-            public_outputs: self.range_check_outputs(meta, vars),
+            public_outputs,
         })
     }
 

--- a/src/graph/vars.rs
+++ b/src/graph/vars.rs
@@ -1,0 +1,150 @@
+use crate::abort;
+use crate::circuit::eltwise::{DivideBy, EltwiseTable, ReLu, Sigmoid};
+use crate::commands::Cli;
+use crate::tensor::TensorType;
+use crate::tensor::{ValTensor, VarTensor};
+use clap::Parser;
+use halo2_proofs::{arithmetic::FieldExt, plonk::ConstraintSystem};
+use itertools::Itertools;
+use log::error;
+use serde::Deserialize;
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(Clone, Debug, Deserialize)]
+pub enum Visibility {
+    Private,
+    Public,
+}
+impl Visibility {
+    pub fn is_public(&self) -> bool {
+        matches!(&self, Visibility::Public)
+    }
+}
+impl std::fmt::Display for Visibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Visibility::Private => write!(f, "private"),
+            Visibility::Public => write!(f, "public"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct VarVisibility {
+    pub input: Visibility,
+    pub params: Visibility,
+    pub output: Visibility,
+}
+impl std::fmt::Display for VarVisibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "(inputs: {}, params: {}, outputs: {})",
+            self.input, self.params, self.output
+        )
+    }
+}
+
+impl VarVisibility {
+    pub fn from_args() -> Self {
+        let args = Cli::parse();
+
+        let input_vis = if args.public_inputs {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        };
+        let params_vis = if args.public_params {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        };
+        let output_vis = if args.public_outputs {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        };
+        if !output_vis.is_public() & !params_vis.is_public() & !input_vis.is_public() {
+            abort!("at least one set of variables should be public");
+        }
+        Self {
+            input: input_vis,
+            params: params_vis,
+            output: output_vis,
+        }
+    }
+}
+
+pub enum TableTypes<F: FieldExt + TensorType> {
+    ReLu(Rc<RefCell<EltwiseTable<F, ReLu<F>>>>),
+    DivideBy(Rc<RefCell<EltwiseTable<F, DivideBy<F>>>>),
+    Sigmoid(Rc<RefCell<EltwiseTable<F, Sigmoid<F>>>>),
+}
+impl<F: FieldExt + TensorType> TableTypes<F> {
+    pub fn get_relu(&self) -> Rc<RefCell<EltwiseTable<F, ReLu<F>>>> {
+        match self {
+            TableTypes::ReLu(inner) => inner.clone(),
+            _ => {
+                abort!("fetching wrong table type");
+            }
+        }
+    }
+    pub fn get_div(&self) -> Rc<RefCell<EltwiseTable<F, DivideBy<F>>>> {
+        match self {
+            TableTypes::DivideBy(inner) => inner.clone(),
+            _ => {
+                abort!("fetching wrong table type");
+            }
+        }
+    }
+    pub fn get_sig(&self) -> Rc<RefCell<EltwiseTable<F, Sigmoid<F>>>> {
+        match self {
+            TableTypes::Sigmoid(inner) => inner.clone(),
+            _ => {
+                abort!("fetching wrong table type");
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ModelVars<F: FieldExt + TensorType> {
+    pub advices: Vec<VarTensor>,
+    pub fixed: Vec<VarTensor>,
+    pub instances: Vec<ValTensor<F>>,
+}
+/// A wrapper for holding all columns that will be assigned to by a model.
+impl<F: FieldExt + TensorType> ModelVars<F> {
+    pub fn new(
+        cs: &mut ConstraintSystem<F>,
+        logrows: usize,
+        advice_dims: (usize, usize),
+        fixed_dims: (usize, usize),
+        instance_dims: (usize, Vec<Vec<usize>>),
+    ) -> Self {
+        let advices = (0..advice_dims.0)
+            .map(|_| {
+                VarTensor::new_advice(
+                    cs,
+                    logrows as usize,
+                    advice_dims.1,
+                    vec![advice_dims.1],
+                    true,
+                )
+            })
+            .collect_vec();
+        let fixed = (0..fixed_dims.0)
+            .map(|_| {
+                VarTensor::new_fixed(cs, logrows as usize, fixed_dims.1, vec![fixed_dims.1], true)
+            })
+            .collect_vec();
+        let instances = (0..instance_dims.0)
+            .map(|i| ValTensor::new_instance(cs, instance_dims.1[i].clone(), true))
+            .collect_vec();
+        ModelVars {
+            advices,
+            fixed,
+            instances,
+        }
+    }
+}

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -91,26 +91,14 @@ impl<F: FieldExt + TensorType> ValTensor<F> {
     pub fn reshape(&mut self, new_dims: &[usize]) {
         match self {
             ValTensor::Value { inner: v, dims: d } => {
-                assert_eq!(
-                    d.iter().product::<usize>(),
-                    new_dims.iter().product::<usize>()
-                );
                 v.reshape(new_dims);
                 *d = v.dims().to_vec();
             }
             ValTensor::AssignedValue { inner: v, dims: d } => {
-                assert_eq!(
-                    d.iter().product::<usize>(),
-                    new_dims.iter().product::<usize>()
-                );
                 v.reshape(new_dims);
                 *d = v.dims().to_vec();
             }
             ValTensor::PrevAssigned { inner: v, dims: d } => {
-                assert_eq!(
-                    d.iter().product::<usize>(),
-                    new_dims.iter().product::<usize>()
-                );
                 v.reshape(new_dims);
                 *d = v.dims().to_vec();
             }

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -221,7 +221,7 @@ impl VarTensor {
             ValTensor::Value { inner: v, dims: _ } => v.enum_map(|coord, k| match &self {
                 VarTensor::Fixed { inner: fixed, .. } => {
                     let (x, y) = self.cartesian_coord(offset + coord);
-                    match region.assign_fixed(|| "k", fixed[x], y, || k.into()) {
+                    match region.assign_fixed(|| "k", fixed[x], y, || k) {
                         Ok(a) => a,
                         Err(e) => {
                             abort!("failed to assign ValTensor to VarTensor {:?}", e);
@@ -230,7 +230,7 @@ impl VarTensor {
                 }
                 VarTensor::Advice { inner: advices, .. } => {
                     let (x, y) = self.cartesian_coord(offset + coord);
-                    match region.assign_advice(|| "k", advices[x], y, || k.into()) {
+                    match region.assign_advice(|| "k", advices[x], y, || k) {
                         Ok(a) => a,
                         Err(e) => {
                             abort!("failed to assign ValTensor to VarTensor {:?}", e);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -62,6 +62,132 @@ fn test_reshape_mock() {
     test_onnx_mock("1l_reshape".to_string());
 }
 
+// Mock prove (fast, but does not cover some potential issues)
+fn test_onnx_mock_public_inputs(example_name: String) {
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--release",
+            "--bin",
+            "ezkl",
+            "--",
+            "--public-inputs",
+            "--bits",
+            "16",
+            "-K",
+            "17",
+            "mock",
+            "-D",
+            format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
+            "-M",
+            format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
+            // "-K",
+            // "2",  //causes failure
+        ])
+        .status()
+        .expect("failed to execute process");
+    assert!(status.success());
+}
+
+#[test]
+fn test_ff_mock_public_inputs() {
+    test_onnx_mock_public_inputs("1l_mlp".to_string());
+}
+
+#[test]
+fn test_flatten_mock_public_inputs() {
+    test_onnx_mock_public_inputs("1l_flatten".to_string());
+}
+
+#[test]
+fn test_avg_mock_public_inputs() {
+    test_onnx_mock_public_inputs("1l_average".to_string());
+}
+
+#[test]
+fn test_relusig_mock_public_inputs() {
+    test_onnx_mock_public_inputs("2l_relu_sigmoid".to_string());
+}
+
+#[test]
+#[ignore]
+fn test_1lcnvrl_mock_public_inputs() {
+    test_onnx_mock_public_inputs("1l_conv".to_string());
+}
+
+#[test]
+fn test_2lcnvrl_mock_public_inputs() {
+    test_onnx_mock_public_inputs("2l_relu_sigmoid_conv".to_string());
+}
+
+#[test]
+fn test_reshape_mock_public_inputs() {
+    test_onnx_mock_public_inputs("1l_reshape".to_string());
+}
+
+// Mock prove (fast, but does not cover some potential issues)
+fn test_onnx_mock_public_params(example_name: String) {
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--release",
+            "--bin",
+            "ezkl",
+            "--",
+            "--public-params",
+            "--bits",
+            "16",
+            "-K",
+            "17",
+            "mock",
+            "-D",
+            format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
+            "-M",
+            format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
+            // "-K",
+            // "2",  //causes failure
+        ])
+        .status()
+        .expect("failed to execute process");
+    assert!(status.success());
+}
+
+#[test]
+fn test_ff_mock_public_params() {
+    test_onnx_mock_public_params("1l_mlp".to_string());
+}
+
+#[test]
+fn test_flatten_mock_public_params() {
+    test_onnx_mock_public_params("1l_flatten".to_string());
+}
+
+#[test]
+fn test_avg_mock_public_params() {
+    test_onnx_mock_public_params("1l_average".to_string());
+}
+
+#[test]
+fn test_relusig_mock_public_params() {
+    test_onnx_mock_public_params("2l_relu_sigmoid".to_string());
+}
+
+#[test]
+#[ignore]
+fn test_1lcnvrl_mock_public_params() {
+    test_onnx_mock_public_params("1l_conv".to_string());
+}
+
+#[test]
+fn test_2lcnvrl_mock_public_params() {
+    test_onnx_mock_public_params("2l_relu_sigmoid_conv".to_string());
+}
+
+#[test]
+fn test_reshape_mock_public_params() {
+    test_onnx_mock_public_params("1l_reshape".to_string());
+}
+
 // full prove (slower, covers more, but still reuses the pk)
 fn test_onnx_fullprove(example_name: String) {
     let status = Command::new("cargo")


### PR DESCRIPTION
resolves #46 

TODO: 

- [x] complete `VarTensor::Fixed` patterns
- [x] add `Column<Instance>` as a `ValTensor` type
- [x] ~~create InputType enum, which represents inputs to a layer (`Input` or `Params`)~~
- [x] create `Visibility` enum which qualifies the visibility of inputs, outputs, params. 
- [x] in the `input.json` or cli arguments specify the VarTensor type for inputs, parameters, and ouputs as a flag (eg. model_params: private / public, input: private / public)
- [x] public/private params 
- [x] public/private inputs
- [x] public/private outputs 