### PR TITLE
fix: conv benches K constant

### DIFF
--- a/benches/cnvrl.rs
+++ b/benches/cnvrl.rs
@@ -19,7 +19,7 @@ static mut IMAGE_WIDTH: usize = 2;
 static mut IN_CHANNELS: usize = 2;
 const PADDING: usize = 2;
 
-const K: usize = 8;
+const K: usize = 9;
 
 #[derive(Clone, Debug)]
 struct MyCircuit<F: FieldExt + TensorType>


### PR DESCRIPTION
The introduction of a min number of used rows mean the `K` used in `benches/cnvrl.rs` is now insufficient. The benches currently fail with `NotEnoughRowsAvailable { current_k: 8 }`. Here we increase K to 9 to accomodate the new min number of used rows. 

We should make this min number tunable as highlighted in  #78