### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,8 +105,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-    - name: IPA full-prove tests
-      run: cargo test --release --verbose tests::ipa_fullprove_ -- --test-threads 4
     - name: KZG full-prove tests
       run: cargo test --release --verbose tests::kzg_fullprove_ -- --test-threads 4
 
@@ -142,8 +140,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-    - name: IPA prove and verify tests
-      run: cargo test --release --verbose tests::ipa_prove_and_verify_ -- --test-threads 4
     - name: KZG prove and verify tests
       run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -323,6 +323,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.6",
 ]
 
@@ -343,6 +344,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -683,7 +690,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
  "thiserror",
 ]
 
@@ -1333,7 +1340,7 @@ checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 [[package]]
 name = "ecc"
 version = "0.1.0"
-source = "git+https://github.com/zkonduit/halo2wrong?branch=master#4d8016fa893f0bd5c0c86632f3081e237554b821"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "integer",
@@ -1433,7 +1440,7 @@ dependencies = [
  "rand",
  "rlp",
  "serde",
- "sha3",
+ "sha3 0.10.6",
  "zeroize",
 ]
 
@@ -1508,7 +1515,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
  "thiserror",
  "uuid",
 ]
@@ -1525,7 +1532,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.6",
  "thiserror",
  "uint",
 ]
@@ -1825,17 +1832,17 @@ dependencies = [
  "ethereum-types",
  "foundry-evm",
  "halo2_proofs",
- "halo2curves",
+ "halo2curves 0.3.1",
  "itertools",
  "lazy_static",
  "log",
  "mnist",
- "plonk_verifier",
  "plotters",
  "rand",
  "seq-macro",
  "serde",
  "serde_json",
+ "snark-verifier",
  "tabled",
  "tensorflow",
  "test-case",
@@ -2374,15 +2381,16 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2?rev=50ee8ad#50ee8ad785c53232824e60b4ff6df32b69970358"
+source = "git+https://github.com/privacy-scaling-explorations/halo2?tag=v2023_01_20#c7e42e41f8141745ba0b90213438f240d55cb347"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2curves",
+ "halo2curves 0.3.1",
  "plotters",
  "rand_core",
  "rayon",
+ "sha3 0.9.1",
  "tabbycat",
  "tracing",
 ]
@@ -2405,9 +2413,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2curves"
+version = "0.3.1"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.1#9b67e19bca30a35208b0c1b41c1723771e2c9f49"
+dependencies = [
+ "ff",
+ "group",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "pasta_curves",
+ "rand",
+ "rand_core",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "halo2wrong"
 version = "0.1.0"
-source = "git+https://github.com/zkonduit/halo2wrong?branch=master#4d8016fa893f0bd5c0c86632f3081e237554b821"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "halo2_proofs",
@@ -2720,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "integer"
 version = "0.1.0"
-source = "git+https://github.com/zkonduit/halo2wrong?branch=master#4d8016fa893f0bd5c0c86632f3081e237554b821"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "maingate",
@@ -2825,7 +2850,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
 ]
 
 [[package]]
@@ -3016,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "maingate"
 version = "0.1.0"
-source = "git+https://github.com/zkonduit/halo2wrong?branch=master#4d8016fa893f0bd5c0c86632f3081e237554b821"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_01_20#aa1699b0ce988f7959d155f0db23d212cb7139ee"
 dependencies = [
  "group",
  "halo2wrong",
@@ -3708,29 +3733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
-name = "plonk_verifier"
-version = "0.1.0"
-source = "git+https://github.com/zkonduit/plonk-verifier?branch=main#4ae9470e037457e2e367de02651bb4afe7f11633"
-dependencies = [
- "bytes",
- "ecc",
- "halo2_proofs",
- "halo2curves",
- "hex",
- "itertools",
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "poseidon",
- "primitive-types",
- "rand",
- "revm",
- "rlp",
- "sha3",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,7 +3796,7 @@ version = "0.2.0"
 source = "git+https://github.com/privacy-scaling-explorations/poseidon.git?tag=v2022_10_22#5d29df01a95e3df6334080d28e983407f56b5da3"
 dependencies = [
  "group",
- "halo2curves",
+ "halo2curves 0.2.1",
  "subtle",
 ]
 
@@ -4167,7 +4169,7 @@ dependencies = [
  "revm_precompiles",
  "rlp",
  "serde",
- "sha3",
+ "sha3 0.10.6",
 ]
 
 [[package]]
@@ -4185,7 +4187,7 @@ dependencies = [
  "ripemd",
  "secp256k1",
  "sha2 0.10.6",
- "sha3",
+ "sha3 0.10.6",
  "substrate-bn",
 ]
 
@@ -4617,6 +4619,18 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
@@ -4694,6 +4708,29 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snark-verifier"
+version = "0.1.0"
+source = "git+https://github.com/zkonduit/plonk-verifier?rev=5a85fbb#5a85fbbb7336b9aaf8b843d7dfa923c68c8edb87"
+dependencies = [
+ "bytes",
+ "ecc",
+ "halo2_proofs",
+ "halo2curves 0.3.1",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "poseidon",
+ "primitive-types",
+ "rand",
+ "revm",
+ "rlp",
+ "sha3 0.10.6",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", rev = "50ee8ad"}
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.0" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_01_20"}
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.1" }
 rand = "0.8"
 itertools = "0.10.3"
 tensorflow = {version = "0.18.0", features = ["eager"], optional = true }
@@ -22,8 +22,8 @@ tabled = { version = "0.9.0", optional = true}
 # evm related deps
 ethereum_types = { package = "ethereum-types", version = "0.14.1", default-features = false, features = ["std"], optional=true}
 foundry_evm = { git = "https://github.com/foundry-rs/foundry", package = "foundry-evm", rev = "4f21719", optional=true }
-halo2_wrong_ecc = { git = "https://github.com/zkonduit/halo2wrong", package = "ecc", branch = "master", optional=true}
-plonk_verifier = { git = "https://github.com/zkonduit/plonk-verifier", branch = "main"}
+halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_01_20", optional=true}
+snark-verifier = { git = "https://github.com/zkonduit/plonk-verifier", rev = "5a85fbb"}
 colog = { version = "1.1.0", optional = true }
 eq-float = "0.1.0"
 thiserror = "1.0.38"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -116,7 +116,7 @@ pub enum Commands {
         #[arg(
             long,
             num_args = 0..=1,
-            default_value_t = ProofSystem::IPA,
+            default_value_t = ProofSystem::KZG,
 //            default_missing_value = "always",
             value_enum
         )]
@@ -150,7 +150,7 @@ pub enum Commands {
 	    short = 'B',
             require_equals = true,
             num_args = 0..=1,
-            default_value_t = ProofSystem::IPA,
+            default_value_t = ProofSystem::KZG,
             default_missing_value = "always",
             value_enum
         )]
@@ -182,7 +182,7 @@ pub enum Commands {
 	    short = 'B',
             require_equals = true,
             num_args = 0..=1,
-            default_value_t = ProofSystem::IPA,
+            default_value_t = ProofSystem::KZG,
             default_missing_value = "always",
             value_enum
         )]

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -14,29 +14,16 @@ use crate::pfsys::{
 use halo2_proofs::dev::VerifyFailure;
 #[cfg(feature = "evm")]
 use halo2_proofs::poly::commitment::Params;
-use halo2_proofs::poly::ipa::commitment::IPACommitmentScheme;
-use halo2_proofs::poly::ipa::multiopen::ProverIPA;
 use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
 use halo2_proofs::poly::kzg::multiopen::ProverGWC;
 use halo2_proofs::poly::kzg::{
     commitment::ParamsKZG, multiopen::VerifierGWC, strategy::SingleStrategy as KZGSingleStrategy,
 };
-use halo2_proofs::{
-    dev::MockProver,
-    poly::{
-        commitment::ParamsProver,
-        ipa::{commitment::ParamsIPA, strategy::SingleStrategy as IPASingleStrategy},
-        VerificationStrategy,
-    },
-};
-#[cfg(feature = "evm")]
-use halo2curves::bn256::G1Affine;
+use halo2_proofs::{dev::MockProver, poly::commitment::ParamsProver};
 use halo2curves::bn256::{Bn256, Fr};
-use halo2curves::pasta::vesta;
-use halo2curves::pasta::Fp;
 use log::{info, trace};
 #[cfg(feature = "evm")]
-use plonk_verifier::system::halo2::transcript::evm::EvmTranscript;
+use snark_verifier::system::halo2::transcript::evm::EvmTranscript;
 use std::error::Error;
 #[cfg(feature = "evm")]
 use std::time::Instant;
@@ -61,9 +48,9 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
             let data = prepare_data(data.to_string())?;
             let (circuit, public_inputs) = prepare_circuit_and_public_input(&data, &args)?;
             info!("Mock proof");
-            let pi: Vec<Vec<Fp>> = public_inputs
+            let pi: Vec<Vec<Fr>> = public_inputs
                 .into_iter()
-                .map(|i| i.into_iter().map(i32_to_felt::<Fp>).collect())
+                .map(|i| i.into_iter().map(i32_to_felt::<Fr>).collect())
                 .collect();
 
             let prover =
@@ -84,26 +71,7 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
 
             match pfsys {
                 ProofSystem::IPA => {
-                    let (circuit, public_inputs) =
-                        prepare_circuit_and_public_input::<Fp>(&data, &args)?;
-                    info!("full proof with {}", pfsys);
-
-                    let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
-                    let pk = create_keys::<IPACommitmentScheme<_>, Fp>(&circuit, &params)
-                        .map_err(Box::<dyn Error>::from)?;
-                    let strategy = IPASingleStrategy::new(&params);
-                    trace!("params computed");
-
-                    let (proof, _dims) = create_proof_model::<
-                        IPACommitmentScheme<_>,
-                        Fp,
-                        ProverIPA<_>,
-                    >(
-                        &circuit, &public_inputs, &params, &pk
-                    )
-                    .map_err(Box::<dyn Error>::from)?;
-
-                    verify_proof_model(proof, &params, pk.get_vk(), strategy)?;
+                    unimplemented!()
                 }
                 #[cfg(not(feature = "evm"))]
                 ProofSystem::KZG => {
@@ -183,26 +151,7 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
 
             match pfsys {
                 ProofSystem::IPA => {
-                    info!("proof with {}", pfsys);
-                    let (circuit, public_inputs) =
-                        prepare_circuit_and_public_input::<Fp>(&data, &args)?;
-                    let params: ParamsIPA<vesta::Affine> = ParamsIPA::new(args.logrows);
-                    let pk = create_keys::<IPACommitmentScheme<_>, Fp>(&circuit, &params)
-                        .map_err(Box::<dyn Error>::from)?;
-                    trace!("params computed");
-
-                    let (proof, _) =
-                        create_proof_model::<IPACommitmentScheme<_>, Fp, ProverIPA<_>>(
-                            &circuit,
-                            &public_inputs,
-                            &params,
-                            &pk,
-                        )
-                        .map_err(Box::<dyn Error>::from)?;
-
-                    proof.save(proof_path)?;
-                    save_params::<IPACommitmentScheme<_>>(params_path, &params)?;
-                    save_vk::<IPACommitmentScheme<_>>(vk_path, pk.get_vk())?;
+                    unimplemented!()
                 }
                 ProofSystem::KZG => {
                     info!("proof with {}", pfsys);
@@ -237,19 +186,13 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
             let proof = Proof::load(&proof_path)?;
             match pfsys {
                 ProofSystem::IPA => {
-                    let params: ParamsIPA<vesta::Affine> =
-                        load_params::<IPACommitmentScheme<_>>(params_path)?;
-                    let strategy = IPASingleStrategy::new(&params);
-                    let vk = load_vk::<IPACommitmentScheme<_>, Fp>(vk_path, &params)?;
-                    let result = verify_proof_model(proof, &params, &vk, strategy).is_ok();
-                    info!("verified: {}", result);
-                    assert!(result);
+                    unimplemented!()
                 }
                 ProofSystem::KZG => {
                     let params: ParamsKZG<Bn256> =
                         load_params::<KZGCommitmentScheme<Bn256>>(params_path)?;
                     let strategy = KZGSingleStrategy::new(&params);
-                    let vk = load_vk::<KZGCommitmentScheme<Bn256>, Fr>(vk_path, &params)?;
+                    let vk = load_vk::<KZGCommitmentScheme<Bn256>, Fr>(vk_path)?;
                     let result = verify_proof_model::<_, VerifierGWC<'_, Bn256>, _, _>(
                         proof, &params, &vk, strategy,
                     )

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -20,6 +20,8 @@ use halo2_proofs::poly::kzg::{
     commitment::ParamsKZG, multiopen::VerifierGWC, strategy::SingleStrategy as KZGSingleStrategy,
 };
 use halo2_proofs::{dev::MockProver, poly::commitment::ParamsProver};
+#[cfg(feature = "evm")]
+use halo2curves::bn256::G1Affine;
 use halo2curves::bn256::{Bn256, Fr};
 use log::{info, trace};
 #[cfg(feature = "evm")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -58,8 +58,8 @@ macro_rules! test_func {
             use crate::mock;
             use crate::mock_public_inputs;
             use crate::mock_public_params;
-            use crate::ipa_fullprove;
-            use crate::ipa_prove_and_verify;
+            // use crate::ipa_fullprove;
+            // use crate::ipa_prove_and_verify;
             use crate::kzg_fullprove;
             use crate::kzg_prove_and_verify;
             seq!(N in 0..=11 {
@@ -78,15 +78,15 @@ macro_rules! test_func {
                 mock_public_params(test.to_string());
             }
 
-            #(#[test_case(TESTS[N])])*
-            fn ipa_fullprove_(test: &str) {
-                ipa_fullprove(test.to_string());
-            }
+            // #(#[test_case(TESTS[N])])*
+            // fn ipa_fullprove_(test: &str) {
+            //     ipa_fullprove(test.to_string());
+            // }
 
-            #(#[test_case(TESTS[N])])*
-            fn ipa_prove_and_verify_(test: &str) {
-                ipa_prove_and_verify(test.to_string());
-            }
+            // #(#[test_case(TESTS[N])])*
+            // fn ipa_prove_and_verify_(test: &str) {
+            //     ipa_prove_and_verify(test.to_string());
+            // }
 
             #(#[test_case(TESTS[N])])*
             fn kzg_fullprove_(test: &str) {
@@ -250,63 +250,63 @@ fn mock_public_params(example_name: String) {
 }
 
 // full prove (slower, covers more, but still reuses the pk)
-fn ipa_fullprove(example_name: String) {
-    let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-        .args([
-            "--bits=16",
-            "-K=17",
-            "fullprove",
-            "-D",
-            format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
-            "-M",
-            format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-            // "-K",
-            // "2",  //causes failure
-        ])
-        .status()
-        .expect("failed to execute process");
-    assert!(status.success());
-}
+// fn ipa_fullprove(example_name: String) {
+//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+//         .args([
+//             "--bits=16",
+//             "-K=17",
+//             "fullprove",
+//             "-D",
+//             format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
+//             "-M",
+//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
+//             // "-K",
+//             // "2",  //causes failure
+//         ])
+//         .status()
+//         .expect("failed to execute process");
+//     assert!(status.success());
+// }
 
 // prove-serialize-verify, the usual full path
-fn ipa_prove_and_verify(example_name: String) {
-    let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-        .args([
-            "--bits=16",
-            "-K=17",
-            "prove",
-            "-D",
-            format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
-            "-M",
-            format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-            "-O",
-            format!("ipa_{}.pf", example_name).as_str(),
-            "--vk-path",
-            format!("ipa_{}.vk", example_name).as_str(),
-            "--params-path",
-            format!("ipa_{}.params", example_name).as_str(),
-        ])
-        .status()
-        .expect("failed to execute process");
-    assert!(status.success());
-    let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-        .args([
-            "--bits=16",
-            "-K=17",
-            "verify",
-            "-M",
-            format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-            "-P",
-            format!("ipa_{}.pf", example_name).as_str(),
-            "--vk-path",
-            format!("ipa_{}.vk", example_name).as_str(),
-            "--params-path",
-            format!("ipa_{}.params", example_name).as_str(),
-        ])
-        .status()
-        .expect("failed to execute process");
-    assert!(status.success());
-}
+// fn ipa_prove_and_verify(example_name: String) {
+//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+//         .args([
+//             "--bits=16",
+//             "-K=17",
+//             "prove",
+//             "-D",
+//             format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
+//             "-M",
+//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
+//             "-O",
+//             format!("ipa_{}.pf", example_name).as_str(),
+//             "--vk-path",
+//             format!("ipa_{}.vk", example_name).as_str(),
+//             "--params-path",
+//             format!("ipa_{}.params", example_name).as_str(),
+//         ])
+//         .status()
+//         .expect("failed to execute process");
+//     assert!(status.success());
+//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+//         .args([
+//             "--bits=16",
+//             "-K=17",
+//             "verify",
+//             "-M",
+//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
+//             "-P",
+//             format!("ipa_{}.pf", example_name).as_str(),
+//             "--vk-path",
+//             format!("ipa_{}.vk", example_name).as_str(),
+//             "--params-path",
+//             format!("ipa_{}.params", example_name).as_str(),
+//         ])
+//         .status()
+//         .expect("failed to execute process");
+//     assert!(status.success());
+// }
 
 // prove-serialize-verify, the usual full path
 fn kzg_prove_and_verify(example_name: String) {


### PR DESCRIPTION
Updates dependencies: 

```bash
plonk-verifier -> snark-verifier
halo2_wrong_ecc -> v2023_01_20
halo2_proofs -> v2023_01_20
halo2curves -> 0.3.1
```

Some of the updates made break the usage of pasta curves (see https://github.com/privacy-scaling-explorations/halo2curves/issues/23) and IPA commitments, which we remove the implementation for for now. 

**Note:** the plonk-verifier updates required a fork + a few fixes and updates that can be tracked [here](https://github.com/zkonduit/plonk-verifier). Will be hoping to merge them into the main PSE repo ASAP so we don't need to maintain a fork.  