### PR TITLE
chore: bump snark-verifier to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,7 +4712,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/zkonduit/plonk-verifier?rev=5a85fbb#5a85fbbb7336b9aaf8b843d7dfa923c68c8edb87"
+source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?rev=2d5ef6b#2d5ef6b4cb7e4ac9504f188167a8a2dcfcb377be"
 dependencies = [
  "bytes",
  "ecc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tabled = { version = "0.9.0", optional = true}
 ethereum_types = { package = "ethereum-types", version = "0.14.1", default-features = false, features = ["std"], optional=true}
 foundry_evm = { git = "https://github.com/foundry-rs/foundry", package = "foundry-evm", rev = "4f21719", optional=true }
 halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_01_20", optional=true}
-snark-verifier = { git = "https://github.com/zkonduit/plonk-verifier", rev = "5a85fbb"}
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", rev = "2d5ef6b"}
 colog = { version = "1.1.0", optional = true }
 eq-float = "0.1.0"
 thiserror = "1.0.38"


### PR DESCRIPTION
https://github.com/privacy-scaling-explorations/snark-verifier/pull/24 merges some of the changes we made to the snark-verifier repo. 

Can now update Cargo.toml to point to the updated upstream, rather than our fork. 