### PR TITLE
refactor: pfsys evm submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ You can easily create an `.onnx` file using `pytorch`. For samples of Onnx files
 These examples are also available as a submodule in `./examples/onnx`. To generate a proof on one of the examples, first build ezkl (`cargo build --release`) and add it to your favourite `PATH` variables.   
 
 ```bash
-ezkl --bits=16 -K=17 prove -D ./examples/onnx/examples/1l_relu/input.json -M ./examples/onnx/examples/1l_relu/network.onnx -O 1l_relu.pf --vk-path 1l_relu.vk --params-path 1l_relu.params
+ezkl --bits=16 -K=17 prove -D ./examples/onnx/examples/1l_relu/input.json -M ./examples/onnx/examples/1l_relu/network.onnx --proof-path 1l_relu.pf --vk-path 1l_relu.vk --params-path 1l_relu.params
 ``` 
 
-This command generates a proof that the model was correctly run on private inputs (this is the default setting). It then outputs the resulting proof at the path specfifed by `-O`, parameters that can be used for subsequent verification at `--params-path` and the verifier key at `ipa_1l_relu.vk`. 
+This command generates a proof that the model was correctly run on private inputs (this is the default setting). It then outputs the resulting proof at the path specfifed by `--proof-path`, parameters that can be used for subsequent verification at `--params-path` and the verifier key at `--vk-path`. 
 Luckily `ezkl` also provides command to verify the generated proofs: 
 
 ```bash 
-ezkl --bits=16 -K=17 verify -M ./examples/onnx/examples/1l_relu/network.onnx -P 1l_relu.pf --vk-path 1l_relu.vk --params-path 1l_relu.params
+ezkl --bits=16 -K=17 verify -M ./examples/onnx/examples/1l_relu/network.onnx --proof-path 1l_relu.pf --vk-path 1l_relu.vk --params-path 1l_relu.params
 ``` 
 
 The separate prove and verify steps can be combined into a single command, if you'd prefer to not write to your filesystem: 
@@ -82,6 +82,14 @@ The separate prove and verify steps can be combined into a single command, if yo
 ```bash
 ezkl --bits=16 -K=17 fullprove -D ./examples/onnx/examples/1l_relu/input.json -M ./examples/onnx/examples/1l_relu/network.onnx 
 ```
+
+To display a table of the loaded onnx nodes, their associated parameters, set `RUST_LOG=DEBUG` or run:
+
+```bash
+cargo run --release --bin ezkl -- table -M ./examples/onnx/examples/1l_relu/network.onnx
+
+```
+
 #### verifying with the EVM ◊
 
 Note that `fullprove` can also be run with an EVM verifier.  We need to pass the `evm` feature flag to conditionally compile the requisite [foundry_evm](https://github.com/foundry-rs/foundry) dependencies. Using `foundry_evm` we spin up a local EVM executor and verify the generated proof. In future releases we'll create a simple pipeline for deploying to EVM based networks. Also note that this requires a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation. 
@@ -94,7 +102,7 @@ cargo run  --release --features evm --bin ezkl fullprove -D ./examples/onnx/exam
 ```
 
 
-### usage 🔧
+### general usage 🔧
 
 ```bash
 Usage: ezkl [OPTIONS] <COMMAND>
@@ -108,15 +116,16 @@ Commands:
   help       Print this message or the help of the given subcommand(s)
 
 Options:
-  -T, --tolerance <TOLERANCE>  The tolerance for error on model outputs [default: 0]
-  -S, --scale <SCALE>          The denominator in the fixed point representation used when quantizing [default: 7]
-  -B, --bits <BITS>            The number of bits used in lookup tables [default: 16]
-  -K, --logrows <LOGROWS>      The log_2 number of rows [default: 17]
-      --public-inputs          Flags whether inputs are public
-      --public-outputs         Flags whether outputs are public
-      --public-params          Flags whether params are public
-  -h, --help                   Print help information
-  -V, --version                Print version information
+  -T, --tolerance <TOLERANCE>          The tolerance for error on model outputs [default: 0]
+  -S, --scale <SCALE>                  The denominator in the fixed point representation used when quantizing [default: 7]
+  -B, --bits <BITS>                    The number of bits used in lookup tables [default: 16]
+  -K, --logrows <LOGROWS>              The log_2 number of rows [default: 17]
+      --public-inputs                  Flags whether inputs are public
+      --public-outputs                 Flags whether outputs are public
+      --public-params                  Flags whether params are public
+  -M, --max-rotations <MAX_ROTATIONS>  Flags to set maximum rotations [default: 512]
+  -h, --help                           Print help information
+  -V, --version                        Print version information
 ```
 
 `bits`, `scale`, `tolerance`, and `logrows` have default values. You can use tolerance to express a tolerance to a certain amount of quantization error on the output eg. if set to 2 the circuit will verify even if the generated output deviates by an absolute value of 2 on any dimension from the expected output. `prove`, `mock`, `fullprove` all require `-D` and `-M` parameters, which if not provided, the cli will query the user to manually enter the path(s).
@@ -143,18 +152,8 @@ The `.onnx` file can be generated using pytorch or tensorflow. The data json fil
 
 For examples of such files see `examples/onnx_models`.
 
-To run a simple example using the cli:
+To run a simple example using the cli see **python and cli tutorial** above.
 
-```bash
-cargo run --release --bin ezkl -- mock -D ./examples/onnx/examples/1l_relu/input.json -M ./examples/onnx/examples/1l_relu/network.onnx
-```
-
-To display a table of loaded Onnx nodes, and their associated parameters, set `RUST_LOG=DEBUG` or run:
-
-```bash
-cargo run --release --bin ezkl -- table -M ./examples/onnx/examples/1l_relu/network.onnx
-
-```
 
 ## benchmarks ⏳
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -88,7 +88,7 @@ pub enum Commands {
     #[command(arg_required_else_help = true)]
     Table {
         /// The path to the .onnx model file
-        #[arg(short = 'M', long, default_value = "")]
+        #[arg(short = 'M', long)]
         model: String,
     },
 
@@ -96,10 +96,10 @@ pub enum Commands {
     #[command(arg_required_else_help = true)]
     Mock {
         /// The path to the .json data file
-        #[arg(short = 'D', long, default_value = "")]
+        #[arg(short = 'D', long)]
         data: String,
         /// The path to the .onnx model file
-        #[arg(short = 'M', long, default_value = "")]
+        #[arg(short = 'M', long)]
         model: String,
     },
 
@@ -107,83 +107,74 @@ pub enum Commands {
     #[command(arg_required_else_help = true)]
     Fullprove {
         /// The path to the .json data file
-        #[arg(short = 'D', long, default_value = "")]
+        #[arg(short = 'D', long)]
         data: String,
         /// The path to the .onnx model file
-        #[arg(short = 'M', long, default_value = "")]
+        #[arg(short = 'M', long)]
         model: String,
         //todo: optional Params
         #[arg(
             long,
             num_args = 0..=1,
             default_value_t = ProofSystem::KZG,
-//            default_missing_value = "always",
             value_enum
         )]
         pfsys: ProofSystem,
     },
 
-    /// Loads model and data, prepares vk and pk, and creates proof, saving proof in --output
+    /// Loads model and data, prepares vk and pk, and creates proof, saving proof in --proof-path
+    #[command(arg_required_else_help = true)]
     Prove {
         /// The path to the .json data file, which should include both the network input (possibly private) and the network output (public input to the proof)
-        #[arg(short = 'D', long, default_value = "")]
+        #[arg(short = 'D', long)]
         data: String,
-
         /// The path to the .onnx model file
-        #[arg(short = 'M', long, default_value = "")]
+        #[arg(short = 'M', long)]
         model: PathBuf,
         /// The path to the desired output file
-        #[arg(short = 'O', long, default_value = "")]
+        #[arg(long)]
         proof_path: PathBuf,
         /// The path to output to the desired verfication key file (optional)
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         vk_path: PathBuf,
         /// The path to output to the desired verfication key file (optional)
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         params_path: PathBuf,
-
-        // /// The path to the Params for the proof system
-        // #[arg(short = 'P', long, default_value = "")]
-        // params: PathBuf,
+        /// The [ProofSystem] we'll be using.
         #[arg(
             long,
 	    short = 'B',
             require_equals = true,
             num_args = 0..=1,
             default_value_t = ProofSystem::KZG,
-            default_missing_value = "always",
             value_enum
         )]
-        /// The [ProofSystem] we'll be using.
         pfsys: ProofSystem,
         // todo, optionally allow supplying proving key
     },
     /// Verifies a proof, returning accept or reject
+    #[command(arg_required_else_help = true)]
     Verify {
         /// The path to the .onnx model file
-        #[arg(short = 'M', long, default_value = "")]
+        #[arg(short = 'M', long)]
         model: PathBuf,
 
         /// The path to the proof file
-        #[arg(short = 'P', long, default_value = "")]
+        #[arg(long)]
         proof_path: PathBuf,
         /// The path to output to the desired verfication key file (optional)
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         vk_path: PathBuf,
         /// The path to output to the desired verfication key file (optional)
-        #[arg(long, default_value = "")]
+        #[arg(long)]
         params_path: PathBuf,
 
-        // /// The path to the Params for the proof system
-        // #[arg(short = 'P', long, default_value = "")]
-        // params: PathBuf,
         #[arg(
             long,
 	    short = 'B',
             require_equals = true,
             num_args = 0..=1,
             default_value_t = ProofSystem::KZG,
-            default_missing_value = "always",
             value_enum
         )]
         pfsys: ProofSystem,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -2,7 +2,7 @@ use crate::commands::{Cli, Commands, ProofSystem};
 use crate::fieldutils::i32_to_felt;
 use crate::graph::Model;
 #[cfg(feature = "evm")]
-use crate::pfsys::aggregation::{
+use crate::pfsys::evm::aggregation::{
     evm_verify, gen_aggregation_evm_verifier, gen_application_snark, gen_kzg_proof, gen_pk,
     gen_srs, AggregationCircuit,
 };

--- a/src/pfsys/evm/aggregation.rs
+++ b/src/pfsys/evm/aggregation.rs
@@ -1,7 +1,7 @@
-use super::prepare_circuit_and_public_input;
-use super::ModelInput;
 use crate::commands::Cli;
 use crate::fieldutils::i32_to_felt;
+use crate::pfsys::prepare_circuit_and_public_input;
+use crate::pfsys::ModelInput;
 use ethereum_types::Address;
 use foundry_evm::executor::{fork::MultiFork, Backend, ExecutorBuilder};
 use halo2_proofs::plonk::VerifyingKey;

--- a/src/pfsys/evm/mod.rs
+++ b/src/pfsys/evm/mod.rs
@@ -1,0 +1,2 @@
+/// Aggregate proof generation for EVM
+pub mod aggregation;

--- a/src/pfsys/mod.rs
+++ b/src/pfsys/mod.rs
@@ -1,6 +1,6 @@
 /// Aggregation circuit
 #[cfg(feature = "evm")]
-pub mod aggregation;
+pub mod evm;
 
 use crate::commands::{data_path, Cli};
 use crate::fieldutils::i32_to_felt;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -249,65 +249,6 @@ fn mock_public_params(example_name: String) {
     assert!(status.success());
 }
 
-// full prove (slower, covers more, but still reuses the pk)
-// fn ipa_fullprove(example_name: String) {
-//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-//         .args([
-//             "--bits=16",
-//             "-K=17",
-//             "fullprove",
-//             "-D",
-//             format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
-//             "-M",
-//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-//             // "-K",
-//             // "2",  //causes failure
-//         ])
-//         .status()
-//         .expect("failed to execute process");
-//     assert!(status.success());
-// }
-
-// prove-serialize-verify, the usual full path
-// fn ipa_prove_and_verify(example_name: String) {
-//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-//         .args([
-//             "--bits=16",
-//             "-K=17",
-//             "prove",
-//             "-D",
-//             format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
-//             "-M",
-//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-//             "-O",
-//             format!("ipa_{}.pf", example_name).as_str(),
-//             "--vk-path",
-//             format!("ipa_{}.vk", example_name).as_str(),
-//             "--params-path",
-//             format!("ipa_{}.params", example_name).as_str(),
-//         ])
-//         .status()
-//         .expect("failed to execute process");
-//     assert!(status.success());
-//     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-//         .args([
-//             "--bits=16",
-//             "-K=17",
-//             "verify",
-//             "-M",
-//             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-//             "-P",
-//             format!("ipa_{}.pf", example_name).as_str(),
-//             "--vk-path",
-//             format!("ipa_{}.vk", example_name).as_str(),
-//             "--params-path",
-//             format!("ipa_{}.params", example_name).as_str(),
-//         ])
-//         .status()
-//         .expect("failed to execute process");
-//     assert!(status.success());
-// }
-
 // prove-serialize-verify, the usual full path
 fn kzg_prove_and_verify(example_name: String) {
     let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
@@ -320,7 +261,7 @@ fn kzg_prove_and_verify(example_name: String) {
             format!("./examples/onnx/examples/{}/input.json", example_name).as_str(),
             "-M",
             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-            "-O",
+            "--proof-path",
             format!("kzg_{}.pf", example_name).as_str(),
             "--vk-path",
             format!("kzg_{}.vk", example_name).as_str(),
@@ -338,7 +279,7 @@ fn kzg_prove_and_verify(example_name: String) {
             "--pfsys=kzg",
             "-M",
             format!("./examples/onnx/examples/{}/network.onnx", example_name).as_str(),
-            "-P",
+            "--proof-path",
             format!("kzg_{}.pf", example_name).as_str(),
             "--vk-path",
             format!("kzg_{}.vk", example_name).as_str(),


### PR DESCRIPTION
In anticipation of #105 and #104, `pfsys` has a new EVM submodule which holds the methods for aggregate proof generation. 

- Introduces `./src/pfysys/evm` as a submodule
- Cleans up some of the cli command code
