### PR TITLE
feat: solidity verifier generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 data
+*.sol
 *.pf
 *.vk
 *.code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "ethereum-types",
  "halo2_proofs",
  "halo2curves 0.3.1",
+ "hex",
  "itertools",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-
 colog = { version = "1.1.0", optional = true }
 eq-float = "0.1.0"
 thiserror = "1.0.38"
+hex = "0.4.3"
 
 [dev-dependencies]
 criterion = {version = "0.3",  features = ["html_reports"]}

--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ Note that the above prove and verify stats can also be run with an EVM verifier.
 # gen proof
 ezkl --bits=16 -K=17 prove -D ./examples/onnx/examples/1l_relu/input.json -M ./examples/onnx/examples/1l_relu/network.onnx --proof-path 1l_relu.pf --vk-path 1l_relu.vk --params-path=kzg.params --transcript=evm
 # gen evm verifier
-target/release/ezkl -K=17 --bits=16 create-evm-verifier --pfsys=kzg --deployment-code-path 1l_relu.code --params-path=kzg.params --vk-path 1l_relu.vk
+target/release/ezkl -K=17 --bits=16 create-evm-verifier --pfsys=kzg --deployment-code-path 1l_relu.code --params-path=kzg.params --vk-path 1l_relu.vk --sol-code-path 1l_relu.sol
 # Verify (EVM) 
 target/release/ezkl -K=17 --bits=16 verify-evm --pfsys=kzg --proof-path 1l_relu.pf --deployment-code-path 1l_relu.code
 ```
+
+Note that the `.sol` file above can be deployed and composed with other Solidity contracts, via a `verify()` function. Please read [this document](https://hackmd.io/QOHOPeryRsOraO7FUnG-tg) for more information about the interface of the contract, how to obtain the data needed for its function parameters, and its limitations.
 
 The above pipeline can also be run using [proof aggregation](https://ethresear.ch/t/leveraging-snark-proof-aggregation-to-achieve-large-scale-pbft-based-consensus/11588) to reduce proof size and verifying times, so as to be more suitable for EVM deployment. A sample pipeline for doing so would be: 
 
@@ -116,7 +118,7 @@ target/release/ezkl -K=17 --bits=16 verify-evm --pfsys=kzg --proof-path aggr_1l_
  
 ```
 
-Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation. 
+Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation, and that aggregated proof verification in Solidity is not currently supported.
 
 
 ### general usage 🔧

--- a/fix_verifier_sol.py
+++ b/fix_verifier_sol.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: fix_verifier_sol.py <input>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    lines = open(input_file).readlines()
+
+    transcript_addrs = list()
+    modified_lines = list()
+
+    num_pubinputs = 0
+
+    # convert calldataload 0x0 to 0x40 to read from pubInputs, and the rest
+    # from proof
+    calldata_pattern = r"^.*(calldataload\((0x[a-f0-9]+)\)).*$"
+    mstore_pattern = r"^\s*(mstore\(0x([0-9a-fA-F]+)+),.+\)"
+    mstore8_pattern = r"^\s*(mstore8\((\d+)+),.+\)"
+    mstoren_pattern = r"^\s*(mstore\((\d+)+),.+\)"
+    mload_pattern = r"(mload\((0x[0-9a-fA-F]+))\)"
+    keccak_pattern = r"(keccak256\((0x[0-9a-fA-F]+))"
+    modexp_pattern = r"(staticcall\(gas\(\), 0x5, (0x[0-9a-fA-F]+), 0xc0, (0x[0-9a-fA-F]+), 0x20)"
+    ecmul_pattern = r"(staticcall\(gas\(\), 0x7, (0x[0-9a-fA-F]+), 0x60, (0x[0-9a-fA-F]+), 0x40)"
+    ecadd_pattern = r"(staticcall\(gas\(\), 0x6, (0x[0-9a-fA-F]+), 0x80, (0x[0-9a-fA-F]+), 0x40)"
+    ecpairing_pattern = r"(staticcall\(gas\(\), 0x8, (0x[0-9a-fA-F]+), 0x180, (0x[0-9a-fA-F]+), 0x20)"
+    bool_pattern = r":bool"
+
+    # Count the number of pub inputs
+    start = None
+    end = None
+    i = 0
+    for line in lines:
+        if line.strip().startswith("mstore(0x20"):
+            start = i
+
+        if line.strip().startswith("mstore(0x0"):
+            end = i
+            break
+        i += 1
+
+    if start is None:
+        num_pubinputs = 0
+    else:
+        num_pubinputs = end - start
+
+    max_pubinputs_addr = 0
+    if num_pubinputs > 0:
+        max_pubinputs_addr = num_pubinputs * 32 - 32
+
+    for line in lines:
+        m = re.search(bool_pattern, line)
+        if m:
+            line = line.replace(":bool", "")
+
+        m = re.search(calldata_pattern, line)
+        if m:
+            calldata_and_addr = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr, 16)
+
+            if addr_as_num <= max_pubinputs_addr:
+                proof_addr = hex(addr_as_num)
+                line = line.replace(calldata_and_addr, "mload(add(pubInputs, " + proof_addr + "))")
+            else:
+                proof_addr = hex(addr_as_num - max_pubinputs_addr)
+                line = line.replace(calldata_and_addr, "mload(add(proof, " + proof_addr + "))")
+
+        m = re.search(mstore8_pattern, line)
+        if m:
+            mstore = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr)
+            transcript_addr = hex(addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            line = line.replace(mstore, "mstore8(add(transcript, " + transcript_addr + ")")
+
+        m = re.search(mstoren_pattern, line)
+        if m:
+            mstore = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr)
+            transcript_addr = hex(addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            line = line.replace(mstore, "mstore(add(transcript, " + transcript_addr + ")")
+
+        m = re.search(modexp_pattern, line)
+        if m:
+            modexp = m.group(1)
+            start_addr = m.group(2)
+            result_addr = m.group(3)
+            start_addr_as_num = int(start_addr, 16)
+            result_addr_as_num = int(result_addr, 16)
+
+            transcript_addr = hex(start_addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            result_addr = hex(result_addr_as_num)
+            line = line.replace(modexp, "staticcall(gas(), 0x5, add(transcript, " + transcript_addr + "), 0xc0, add(transcript, " + result_addr + "), 0x20")
+
+        m = re.search(ecmul_pattern, line)
+        if m:
+            ecmul = m.group(1)
+            start_addr = m.group(2)
+            result_addr = m.group(3)
+            start_addr_as_num = int(start_addr, 16)
+            result_addr_as_num = int(result_addr, 16)
+
+            transcript_addr = hex(start_addr_as_num)
+            result_addr = hex(result_addr_as_num)
+            transcript_addrs.append(start_addr_as_num)
+            transcript_addrs.append(result_addr_as_num)
+            line = line.replace(ecmul, "staticcall(gas(), 0x7, add(transcript, " + transcript_addr + "), 0x60, add(transcript, " + result_addr + "), 0x40")
+
+        m = re.search(ecadd_pattern, line)
+        if m:
+            ecadd = m.group(1)
+            start_addr = m.group(2)
+            result_addr = m.group(3)
+            start_addr_as_num = int(start_addr, 16)
+            result_addr_as_num = int(result_addr, 16)
+
+            transcript_addr = hex(start_addr_as_num)
+            result_addr = hex(result_addr_as_num)
+            transcript_addrs.append(start_addr_as_num)
+            transcript_addrs.append(result_addr_as_num)
+            line = line.replace(ecadd, "staticcall(gas(), 0x6, add(transcript, " + transcript_addr + "), 0x80, add(transcript, " + result_addr + "), 0x40")
+
+        m = re.search(ecpairing_pattern, line)
+        if m:
+            ecpairing = m.group(1)
+            start_addr = m.group(2)
+            result_addr = m.group(3)
+            start_addr_as_num = int(start_addr, 16)
+            result_addr_as_num = int(result_addr, 16)
+
+            transcript_addr = hex(start_addr_as_num)
+            result_addr = hex(result_addr_as_num)
+            transcript_addrs.append(start_addr_as_num)
+            transcript_addrs.append(result_addr_as_num)
+            line = line.replace(ecpairing, "staticcall(gas(), 0x8, add(transcript, " + transcript_addr + "), 0x180, add(transcript, " + result_addr + "), 0x20")
+
+        m = re.search(mstore_pattern, line)
+        if m:
+            mstore = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr, 16)
+            transcript_addr = hex(addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            line = line.replace(mstore, "mstore(add(transcript, " + transcript_addr + ")")
+
+        m = re.search(keccak_pattern, line)
+        if m:
+            keccak = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr, 16)
+            transcript_addr = hex(addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            line = line.replace(keccak, "keccak256(add(transcript, " + transcript_addr + ")")
+
+        # mload can show up multiple times per line
+        while True:
+            m = re.search(mload_pattern, line)
+            if not m:
+                break
+            mload = m.group(1)
+            addr = m.group(2)
+            addr_as_num = int(addr, 16)
+            transcript_addr = hex(addr_as_num)
+            transcript_addrs.append(addr_as_num)
+            line = line.replace(mload, "mload(add(transcript, " + transcript_addr + ")")
+
+        # print(line, end="")
+        modified_lines.append(line)
+
+    # get the max transcript addr
+    max_transcript_addr = int(max(transcript_addrs) / 32)
+    print("""// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+contract Verifier {{
+    function verify(
+        uint256[{}] memory pubInputs,
+        bytes memory proof
+    ) public view returns (bool) {{
+        bool success = true;
+        bytes32[{}] memory transcript;
+        assembly {{
+    """.strip().format(num_pubinputs, max_transcript_addr))
+    for line in modified_lines[16:-7]:
+        print(line, end="")
+    print("""}
+        return success;
+    }
+}""")

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -259,12 +259,12 @@ pub enum Commands {
         /// The path to load the desired verfication key file
         #[arg(long)]
         vk_path: PathBuf,
-        /// The path to output to the desired verfication key file (optional)
+        /// The path to output to the desired EVM bytecode file (optional)
         #[arg(long, required_if_eq("transcript", "evm"))]
         deployment_code_path: Option<PathBuf>,
-        /// The path to output the Yul code (which needs further modification)
+        /// The path to output the Solidity code
         #[arg(long, required_if_eq("transcript", "evm"))]
-        yul_code_path: Option<PathBuf>,
+        sol_code_path: Option<PathBuf>,
         /// The [ProofSystem] we'll be using.
         #[arg(
             long,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -262,6 +262,9 @@ pub enum Commands {
         /// The path to output to the desired verfication key file (optional)
         #[arg(long, required_if_eq("transcript", "evm"))]
         deployment_code_path: Option<PathBuf>,
+        /// The path to output the Yul code (which needs further modification)
+        #[arg(long, required_if_eq("transcript", "evm"))]
+        yul_code_path: Option<PathBuf>,
         /// The [ProofSystem] we'll be using.
         #[arg(
             long,
@@ -373,6 +376,23 @@ pub enum Commands {
         /// The path to verifier contract's deployment code
         #[arg(long)]
         deployment_code_path: PathBuf,
+
+        #[arg(
+             long,
+             require_equals = true,
+             num_args = 0..=1,
+             default_value_t = ProofSystem::KZG,
+             value_enum
+         )]
+        pfsys: ProofSystem,
+    },
+
+    /// Print the proof in hexadecimal
+    #[command(name = "print-proof-hex", arg_required_else_help = true)]
+    PrintProofHex {
+        /// The path to the proof file
+        #[arg(long)]
+        proof_path: PathBuf,
 
         #[arg(
              long,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -30,6 +30,9 @@ use std::error::Error;
 use std::time::Instant;
 use tabled::Table;
 use thiserror::Error;
+use std::fs::File;
+use std::io::Write;
+
 /// A wrapper for tensor related errors.
 #[derive(Debug, Error)]
 pub enum ExecutionError {
@@ -164,6 +167,7 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
             ref vk_path,
             ref params_path,
             ref deployment_code_path,
+            ref yul_code_path,
             pfsys,
         } => {
             let data = prepare_data(data.to_string())?;
@@ -183,8 +187,11 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
                     )?;
                     trace!("params computed");
 
-                    let deployment_code = gen_evm_verifier(&params, &vk, num_instance)?;
+                    let (deployment_code, yul_code) = gen_evm_verifier(&params, &vk, num_instance)?;
                     deployment_code.save(&deployment_code_path.as_ref().unwrap())?;
+
+                    let mut f = File::create(yul_code_path.as_ref().unwrap()).unwrap();
+                    let _ = f.write(yul_code.as_bytes());
                 }
             }
         }
@@ -404,6 +411,21 @@ pub fn run(args: Cli) -> Result<(), Box<dyn Error>> {
                 let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path, None, None)?;
                 let code = DeploymentCode::load(&deployment_code_path)?;
                 evm_verify(code, proof)?;
+            }
+        },
+        Commands::PrintProofHex {
+            proof_path,
+            pfsys,
+        } => match pfsys {
+            ProofSystem::IPA => {
+                unimplemented!()
+            }
+            ProofSystem::KZG => {
+                let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path, None, None)?;
+                for instance in proof.instances {
+                    println!("{:?}", instance);
+                }
+                println!("{}", hex::encode(proof.proof))
             }
         },
     }

--- a/src/pfsys/evm/single.rs
+++ b/src/pfsys/evm/single.rs
@@ -29,7 +29,7 @@ pub fn gen_evm_verifier(
     params: &ParamsKZG<Bn256>,
     vk: &VerifyingKey<G1Affine>,
     num_instance: Vec<usize>,
-) -> Result<DeploymentCode, SimpleError> {
+) -> Result<(DeploymentCode, String), SimpleError> {
     let protocol = compile(
         params,
         vk,
@@ -47,7 +47,9 @@ pub fn gen_evm_verifier(
     PlonkVerifier::verify(&vk, &protocol, &instances, &proof)
         .map_err(|_| SimpleError::ProofVerify)?;
 
-    Ok(DeploymentCode {
-        code: evm::compile_yul(&loader.yul_code()),
-    })
+    let yul_code = &loader.yul_code();
+
+    Ok((DeploymentCode {
+        code: evm::compile_yul(yul_code),
+    }, yul_code.clone()))
 }

--- a/src/pfsys/mod.rs
+++ b/src/pfsys/mod.rs
@@ -59,7 +59,8 @@ pub struct Snark<F: FieldExt + SerdeObject, C: CurveAffine> {
     protocol: Option<PlonkProtocol<C>>,
     /// public instances of the snark
     pub instances: Vec<Vec<F>>,
-    proof: Vec<u8>,
+    /// the proof
+    pub proof: Vec<u8>,
 }
 
 impl<F: FieldExt + SerdeObject, C: CurveAffine> Snark<F, C> {


### PR DESCRIPTION
This PR adds the ability to generate a Solidity verifier.

Here is a document that describes the steps that a user can take to generate such a verifier. It can serve as a quick start guide. https://hackmd.io/QOHOPeryRsOraO7FUnG-tg

## Context

Teams who want to build on ezkl and want to verify their proofs on-chain can now do so easily. This functionality is intended to be short-lived and only meant to make it easier teams at ETHDenver to use ezkl.

## Overview of approach

I have added a `--sol-code-path` parameter to the `create-evm-verifier` subcommand. This subcommand will write the Yul code generated to snark-verifier to this file, then run `fix_verifier_sol.py` on it, and save the output to the same file.

### What `fix_verifier_sol.py` does

1. It rewrites the Yul code to be a Solidity contract with a `verify()` function that accepts a `uint256` array of pubinputs and a bytes array for the proof.
2. It rewrites the `mload`, `mstore`, `mload8`, `keccak`, and `staticcall` memory locations in the Yul code to use the transcript and elements from the function arguments as needed.

## Limitations

The largest number of public inputs/outputs which has been confirmed to work is 6. This is due to the contract size limit and the way that snark-verifier constructs the verifier code - as straight-line implementation in Yul, without loops of any kind, which means that the contract size increases with the number of public inputs/outputs.

It is also infeasible to have different models which have the same number of outputs share the same verifier contract code, because snark-verifier generates very different Yul code even for these models even though their number of outputs is the same. Hence it is better for now to generate each verifier contract as needed, rather than have a universal one per `n` outputs.

## Future work

Let's consider writing a Solidity/Yul verifier by hand, so that it can be more flexible and debuggable.