### PR TITLE
refactor: run args as separate struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,15 @@ serde = { version = "1.0.126", features = ["derive"], optional = true  }
 serde_json = { version = "1.0.64", optional = true }
 log = { version = "0.4.17", optional = true }
 tabled = { version = "0.9.0", optional = true}
-# evm related deps
-ethereum_types = { package = "ethereum-types", version = "0.14.1", default-features = false, features = ["std"]}
-halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_02_02"}
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_02_02"}
 colog = { version = "1.1.0", optional = true }
 eq-float = "0.1.0"
 thiserror = "1.0.38"
 hex = "0.4.3"
+
+# evm related deps
+ethereum_types = { package = "ethereum-types", version = "0.14.1", default-features = false, features = ["std"]}
+halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_02_02"}
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_02_02"}
 
 [dev-dependencies]
 criterion = {version = "0.3",  features = ["html_reports"]}

--- a/examples/default_run_args.json
+++ b/examples/default_run_args.json
@@ -1,0 +1,10 @@
+{
+    "tolerance": 0,
+    "scale": 7,
+    "bits": 11,
+    "logrows": 17,
+    "public_inputs": false,
+    "public_outputs": true,
+    "public_params": false,
+    "max_rotations": 512
+}

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -5,7 +5,7 @@ use rand::seq::SliceRandom;
 use std::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    let args = Cli::create();
+    let args = Cli::create()?;
     colog::init();
     banner();
     info!("{}", &args.as_json()?);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,5 @@
 //use crate::onnx::OnnxModel;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use log::info;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -53,20 +53,9 @@ impl std::fmt::Display for StrategyType {
     }
 }
 
-// pub enum VerifierEnv {
-//     Native,
-//     KZG,
-// }
-
-const EZKLCONF: &str = "EZKLCONF";
-
-#[allow(missing_docs)]
-#[derive(Parser, Debug, Clone, Deserialize, Serialize)]
-#[command(author, version, about, long_about = None)]
-pub struct Cli {
-    #[command(subcommand)]
-    #[allow(missing_docs)]
-    pub command: Commands,
+/// Parameters specific to a proving run
+#[derive(Debug, Args, Deserialize, Serialize, Clone)]
+pub struct RunArgs {
     /// The tolerance for error on model outputs
     #[arg(short = 'T', long, default_value = "0")]
     pub tolerance: usize,
@@ -91,6 +80,20 @@ pub struct Cli {
     /// Flags to set maximum rotations
     #[arg(short = 'M', long, default_value = "512")]
     pub max_rotations: usize,
+}
+
+const EZKLCONF: &str = "EZKLCONF";
+
+#[allow(missing_docs)]
+#[derive(Parser, Debug, Clone, Deserialize, Serialize)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    #[allow(missing_docs)]
+    pub command: Commands,
+    /// The tolerance for error on model outputs
+    #[clap(flatten)]
+    pub args: RunArgs,
 }
 
 impl Cli {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,10 +1,11 @@
 //use crate::onnx::OnnxModel;
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use log::info;
+use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::error::Error;
-use std::io::{stdin, stdout, Write};
+use std::fs::File;
+use std::io::{stdin, stdout, Read, Write};
 use std::path::PathBuf;
 
 #[allow(missing_docs)]
@@ -83,6 +84,7 @@ pub struct RunArgs {
 }
 
 const EZKLCONF: &str = "EZKLCONF";
+const RUNARGS: &str = "RUNARGS";
 
 #[allow(missing_docs)]
 #[derive(Parser, Debug, Clone, Deserialize, Serialize)]
@@ -112,10 +114,32 @@ impl Cli {
         serde_json::from_str(arg_json)
     }
     /// Create an ezkl configuration: if there is an EZKLCONF env variable, parse its value, else read it from the command line.
-    pub fn create() -> Self {
+    pub fn create() -> Result<Self, Box<dyn Error>> {
         match env::var(EZKLCONF) {
-            Ok(val) => Self::from_json(&val).unwrap(),
-            Err(_e) => Cli::parse(),
+            Ok(path) => {
+                debug!("loading ezkl conf from {}", path);
+                let mut file = File::open(path).map_err(Box::<dyn Error>::from)?;
+                let mut data = String::new();
+                file.read_to_string(&mut data)
+                    .map_err(Box::<dyn Error>::from)?;
+                Self::from_json(&data).map_err(Box::<dyn Error>::from)
+            }
+            Err(_e) => match env::var(RUNARGS) {
+                Ok(path) => {
+                    debug!("loading run args from {}", path);
+                    let mut file = File::open(path).map_err(Box::<dyn Error>::from)?;
+                    let mut data = String::new();
+                    file.read_to_string(&mut data)
+                        .map_err(Box::<dyn Error>::from)?;
+                    let args: RunArgs =
+                        serde_json::from_str(&data).map_err(Box::<dyn Error>::from)?;
+                    Ok(Cli {
+                        command: Cli::parse().command,
+                        args,
+                    })
+                }
+                Err(_e) => Ok(Cli::parse()),
+            },
         }
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -94,8 +94,8 @@ impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
 
         let mut vars = ModelVars::new(
             cs,
-            model.logrows as usize,
-            model.max_rotations,
+            model.run_args.logrows as usize,
+            model.run_args.max_rotations,
             (num_advice, row_cap),
             (num_fixed, row_cap),
             (num_instances, instance_shapes),

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -69,7 +69,7 @@ pub struct Model {
     pub model: Graph<InferenceFact, Box<dyn InferenceOp>>,
     /// Graph of nodes we are loading from Onnx.
     pub nodes: NodeGraph, // Wrapped nodes with additional methods and data (e.g. inferred shape, quantization)
-    /// bits used in lookup tables
+    /// The [RunArgs] being used
     pub run_args: RunArgs,
     /// The [Mode] we're using the model in.
     pub mode: Mode,
@@ -138,7 +138,7 @@ impl Model {
 
     /// Creates a `Model` based on CLI arguments
     pub fn from_arg() -> Result<Self, Box<dyn Error>> {
-        let args = Cli::create();
+        let args = Cli::create()?;
         Self::from_ezkl_conf(args)
     }
 

--- a/src/graph/vars.rs
+++ b/src/graph/vars.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use crate::commands::Cli;
+use crate::commands::RunArgs;
 use crate::tensor::TensorType;
 use crate::tensor::{ValTensor, VarTensor};
 use halo2_proofs::{arithmetic::FieldExt, plonk::ConstraintSystem};
@@ -55,7 +55,7 @@ impl std::fmt::Display for VarVisibility {
 impl VarVisibility {
     /// Read from cli args whether the model input, model parameters, and model output are Public or Private to the prover.
     /// Place in [VarVisibility] struct.
-    pub fn from_args(args: Cli) -> Result<Self, Box<dyn Error>> {
+    pub fn from_args(args: RunArgs) -> Result<Self, Box<dyn Error>> {
         let input_vis = if args.public_inputs {
             Visibility::Public
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,23 +15,15 @@
     unused_parens,
     while_true,
     missing_docs,
-    missing_debug_implementations,
-    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
     missing_debug_implementations,
-    missing_docs,
-    unsafe_code,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unused_import_braces,
-    unused_qualifications
+    unsafe_code
 )]
-#![feature(slice_flatten)]
+
 //! A library for turning computational graphs, such as neural networks, into ZK-circuits.
 //!
 

--- a/src/pfsys/evm/aggregation.rs
+++ b/src/pfsys/evm/aggregation.rs
@@ -186,14 +186,14 @@ impl AggregationCircuit {
             let mut transcript = PoseidonTranscript::<NativeLoader, _>::new(snark.proof.as_slice());
             let proof = PlonkSuccinctVerifier::read_proof(
                 &svk,
-                &snark.protocol.as_ref().unwrap(),
+                snark.protocol.as_ref().unwrap(),
                 &snark.instances,
                 &mut transcript,
             )
             .map_err(|_| AggregationError::ProofRead)?;
             let mut accum = PlonkSuccinctVerifier::verify(
                 &svk,
-                &snark.protocol.as_ref().unwrap(),
+                snark.protocol.as_ref().unwrap(),
                 &snark.instances,
                 &proof,
             )

--- a/src/pfsys/evm/mod.rs
+++ b/src/pfsys/evm/mod.rs
@@ -38,9 +38,14 @@ pub struct DeploymentCode {
     code: Vec<u8>,
 }
 impl DeploymentCode {
-    /// Return (inner) byte code
+    /// Return len byte code
     pub fn len(&self) -> usize {
         self.code.len()
+    }
+
+    /// If no byte code
+    pub fn is_empty(&self) -> bool {
+        self.code.len() == 0
     }
     /// Return (inner) byte code
     pub fn code(&self) -> &Vec<u8> {


### PR DESCRIPTION
To start creating easy to re-use config files across all run, we're moving the main run args (like the scale used, which variables are instances etc...) into a separate serializable struct -- which would make saving and loading said parameters much easier. 

We want this because these parameters (rather than the path parameters of each of the subcommands) are most critical for reproducibility. 

- [x] move run args into separate struct
- [x] easy interface for loading these args from a file

