### PR TITLE
feat: serialization compatibility for pre-generated SRS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -15,180 +15,169 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
-          components: rustfmt, clippy    
-    - name: Build
-      run: cargo build --verbose
-  
-  benchmarks: 
+          components: rustfmt, clippy
+      - name: Build
+        run: cargo build --verbose
 
+  benchmarks:
     runs-on: ubuntu-latest-16-cores
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
-          components: rustfmt, clippy    
-    - name: Bench
-      run: cargo bench --verbose
+          components: rustfmt, clippy
+      - name: Bench
+        run: cargo bench --verbose
 
   docs:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
-          components: rustfmt, clippy    
-    - name: Docs
-      run: cargo doc --verbose
+          components: rustfmt, clippy
+      - name: Docs
+        run: cargo doc --verbose
 
   library-tests:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
-          components: rustfmt, clippy 
-    - name: Doc tests
-      run: cargo test --doc --verbose
-    - name: Library tests
-      run: cargo test --lib --verbose
-  
+          components: rustfmt, clippy
+      - name: Doc tests
+        run: cargo test --doc --verbose
+      - name: Library tests
+        run: cargo test --lib --verbose
+
   mock-proving-tests:
-
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
           submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy 
-
-    - name: Mock proving tests (public outputs)
-      run: cargo test --release --verbose tests::mock_public_outputs_ -- --test-threads 16
-    - name: Mock proving tests (public inputs)
-      run: cargo test --release --verbose tests::mock_public_inputs_ -- --test-threads 16
-    - name: Mock proving tests (public params)
-      run: cargo test --release --verbose tests::mock_public_params_ -- --test-threads 16
-  
-  prove-and-verify-evm-tests:
-
-    runs-on: ubuntu-latest-16-cores
-    steps:
-    - uses: actions/checkout@v3
-      with:
-          submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
 
-    - name: Install solc
-      run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
-    - name: Install Anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --profile local --locked foundry-cli anvil
-    - name: KZG prove and verify tests (EVM)
-      run: cargo test --release --verbose tests_evm -- --test-threads 4
+      - name: Mock proving tests (public outputs)
+        run: cargo test --release --verbose tests::mock_public_outputs_ -- --test-threads 16
+      - name: Mock proving tests (public inputs)
+        run: cargo test --release --verbose tests::mock_public_inputs_ -- --test-threads 16
+      - name: Mock proving tests (public params)
+        run: cargo test --release --verbose tests::mock_public_params_ -- --test-threads 16
+
+  prove-and-verify-evm-tests:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Install solc
+        run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
+      - name: Install Anvil
+        run: cargo install --git https://github.com/foundry-rs/foundry --profile local --locked foundry-cli anvil
+      - name: KZG prove and verify tests (EVM)
+        run: cargo test --release --verbose tests_evm -- --test-threads 4
 
   prove-and-verify-tests:
-
     runs-on: ubuntu-latest-16-cores
     steps:
-    - uses: actions/checkout@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
           submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
 
-    - name: KZG prove and verify tests
-      run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 4
+      - name: KZG prove and verify tests
+        run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 4
 
   prove-and-verify-aggr-tests:
-
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
           submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
 
-    - name: KZG prove and verify aggr tests
-      run: cargo test --release --verbose tests_aggr::kzg_aggr_prove_and_verify_ -- --test-threads 2
+      - name: KZG prove and verify aggr tests
+        run: cargo test --release --verbose tests_aggr::kzg_aggr_prove_and_verify_ -- --test-threads 4
 
   prove-and-verify-evm-aggr-tests:
-
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
           submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
-    - name: Install solc
-      run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
-    - name: KZG prove and verify aggr tests
-      run: cargo test --release --verbose tests_evm::kzg_evm_aggr_prove_and_verify_ -- --test-threads 2 --include-ignored
+      - name: Install solc
+        run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
+      - name: KZG prove and verify aggr tests
+        run: cargo test --release --verbose tests_evm::kzg_evm_aggr_prove_and_verify_ -- --test-threads 4 --include-ignored
 
   examples:
-
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
 
-    - name: Download MNIST
-      run: sh data.sh
-    - name: Examples
-      run: cargo test --release tests_examples  
+      - name: Download MNIST
+        run: sh data.sh
+      - name: Examples
+        run: cargo test --release tests_examples
 
   neg-tests:
-
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
+      - uses: actions/checkout@v3
+        with:
           submodules: recursive
-    - uses: actions-rs/toolchain@v1
-      with:
+      - uses: actions-rs/toolchain@v1
+        with:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
 
-    - name: Mock proving tests (should fail)
-      run: cargo test neg_tests::neg_examples_      
+      - name: Mock proving tests (should fail)
+        run: cargo test neg_tests::neg_examples_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,11 +1761,13 @@ dependencies = [
  "mnist",
  "plotters",
  "rand",
+ "reqwest",
  "seq-macro",
  "serde",
  "serde_json",
  "snark-verifier",
  "tabled",
+ "tempfile",
  "tensorflow",
  "test-case",
  "thiserror",
@@ -2358,6 +2360,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2905,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3110,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
 dependencies = [
  "bytes",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -3774,10 +3833,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3787,6 +3848,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -4084,6 +4146,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4779,6 +4864,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { version = "1.22.0", features = ["macros"] }
 
 [dev-dependencies]
 criterion = {version = "0.3",  features = ["html_reports"]}
+tempfile = "3.3.0"
+reqwest = "0.11.14"
 lazy_static = "1.4.0"
 mnist = "0.5"
 seq-macro = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ target/release/ezkl -K=17 --bits=16 verify-evm --pfsys=kzg --proof-path aggr_1l_
 
 Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation, and that aggregated proof verification in Solidity is not currently supported.
 
+#### using pre-generated SRS 
+
+Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file ! 
+
 
 ### general usage 🔧
 


### PR DESCRIPTION
Our current serialization and deserialization pipeline for KZGParams (SRS) assumes a raw bytes serialization. Whereas the pre-converted SRS strings [here](https://github.com/han0110/halo2-kzg-srs), assume a `SerdeFormat::Processed` serialization. Here we: 

- [x] load and save ParamsKZG using `SerdeFormat::Processed` serialization format. 
- [x] add unit tests to test compatibility
- [x] update the readme to include instructions on how to use pre-generated SRS  

Resolves #116 