### PR TITLE
feat: vanilla model forward pass for output json generation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,19 @@ jobs:
       - name: Library tests
         run: cargo test --lib --verbose
 
+  forward-pass-tests:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Mock proving tests (public outputs)
+        run: cargo test --release --verbose tests::forward_pass_
+
   mock-proving-tests:
     runs-on: ubuntu-latest-32-cores
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data
 *~
 \#*\#
 .DS_Store
+*_forward.json

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Usage: ezkl [OPTIONS] <COMMAND>
 
 Commands:
   table                     Loads model and prints model table
+  forward                   Loads model and input and runs mock prover (for testing)
   gen-srs                   Generates a dummy SRS
   mock                      Loads model and input and runs mock prover (for testing)
   aggregate                 Aggregates proofs :)
@@ -155,6 +156,7 @@ Commands:
   verify                    Verifies a proof, returning accept or reject
   verify-aggr               Verifies an aggregate proof, returning accept or reject
   verify-evm                Verifies a proof using a local EVM executor, returning accept or reject
+  print-proof-hex           Print the proof in hexadecimal
   help                      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -166,8 +168,8 @@ Options:
       --public-outputs                 Flags whether outputs are public
       --public-params                  Flags whether params are public
   -M, --max-rotations <MAX_ROTATIONS>  Flags to set maximum rotations [default: 512]
-  -h, --help                           Print help information
-  -V, --version                        Print version information
+  -h, --help                           Print help
+  -V, --version                        Print version
 ```
 
 `bits`, `scale`, `tolerance`, and `logrows` have default values. You can use tolerance to express a tolerance to a certain amount of quantization error on the output eg. if set to 2 the circuit will verify even if the generated output deviates by an absolute value of 2 on any dimension from the expected output. `prove` and `mock`, all require `-D` and `-M` parameters, which if not provided, the cli will query the user to manually enter the path(s).

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -155,6 +155,20 @@ pub enum Commands {
         model: String,
     },
 
+    /// Loads model and input and runs mock prover (for testing)
+    #[command(arg_required_else_help = true)]
+    Forward {
+        /// The path to the .json data file
+        #[arg(short = 'D', long)]
+        data: String,
+        /// The path to the .onnx model file
+        #[arg(short = 'M', long)]
+        model: String,
+        /// Output to the new .json file
+        #[arg(short = 'O', long)]
+        output: String,
+    },
+
     /// Generates a dummy SRS
     #[command(name = "gen-srs", arg_required_else_help = true)]
     GenSrs {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -155,7 +155,7 @@ pub enum Commands {
         model: String,
     },
 
-    /// Loads model and input and runs mock prover (for testing)
+    /// Runs a vanilla forward pass, produces a quantized output, and saves it to a .json file
     #[command(arg_required_else_help = true)]
     Forward {
         /// The path to the .json data file
@@ -164,7 +164,7 @@ pub enum Commands {
         /// The path to the .onnx model file
         #[arg(short = 'M', long)]
         model: String,
-        /// Output to the new .json file
+        /// Path to the new .json file
         #[arg(short = 'O', long)]
         output: String,
     },


### PR DESCRIPTION
Determining the correct public outputs for a model is currently a bit of pain due to quantization here we introduce a new `forward` command which produces said quantized output as a `Vec<Vec<f32>>` and saves it to a new `.json` file: 

```bash 
Usage: ezkl forward --data <DATA> --model <MODEL> --output <OUTPUT>

Options:
  -D, --data <DATA>      The path to the .json data file
  -M, --model <MODEL>    The path to the .onnx model file
  -O, --output <OUTPUT>  Path to the new .json file
  -h, --help             Print help

```

- [x] introduces a vanilla forward pass command + method on `Model`
- [x] update docs
- [x] integration tests whereby we generate a new json using the forward pass then run mock tests over the generated json to assert the output is valid 

Resolves #119 
