### PR TITLE
add: build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# EZKL 
+# EZKL
 
 [![Test](https://github.com/zkonduit/ezkl/workflows/Rust/badge.svg)](https://github.com/zkonduit/ezkl/actions?query=workflow%3ARust)
 
 `ezkl` is a library and command-line tool for doing inference for deep learning models and other computational graphs in a zk-snark. It enables the following workflow:
 
-1. Define a computational graph, for instance a neural network (but really any arbitrary set of operations), as you would normally in pytorch or tensorflow. 
+1. Define a computational graph, for instance a neural network (but really any arbitrary set of operations), as you would normally in pytorch or tensorflow.
 2. Export the final graph of operations as an [.onnx](https://onnx.ai/) file and some sample inputs to a `.json` file.
-3. Point `ezkl` to the `.onnx` and `.json` files to generate a ZK-SNARK circuit with which you can prove statements such as: 
+3. Point `ezkl` to the `.onnx` and `.json` files to generate a ZK-SNARK circuit with which you can prove statements such as:
 > "I ran this publicly available neural network on some private data and it produced this output"
 
 > "I ran my private neural network on some public data and it produced this output"
@@ -15,36 +15,63 @@
 
 The rust API is also sufficiently flexible to enable you to code up a computational graph and resulting circuit from scratch. For examples on how to do so see the **library examples** section below.
 
-In the backend we use [Halo2](https://github.com/privacy-scaling-explorations/halo2) as a proof system.  
+In the backend we use [Halo2](https://github.com/privacy-scaling-explorations/halo2) as a proof system.
 
-For more details on how to use `ezkl`, see below ! 
+For more details on how to use `ezkl`, see below !
 
 ----------------------
 
 ## Contributing 🌎
 
-If you're interested in contributing and are unsure where to start, reach out to one of the maintainers:  
+If you're interested in contributing and are unsure where to start, reach out to one of the maintainers:
 
 * dante (alexander-camuto)
 * jason ( jasonmorton)
 
-More broadly: 
+More broadly:
 
-- Feel free to open up a discussion topic to ask questions. 
+- Feel free to open up a discussion topic to ask questions.
 
-- See currently open issues for ideas on how to contribute. 
+- See currently open issues for ideas on how to contribute.
 
-- For PRs we use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) naming convention. 
+- For PRs we use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) naming convention.
 
 ----------------------
 
 ## Getting Started ⚙️
 
+### building the project 🔨
 Note that the library requires a nightly version of the rust toolchain. You can change the default toolchain by running:
 
 ```bash
-rustup override set nightly         
+rustup override set nightly
 ```
+
+After which you may build the library
+
+```bash
+cargo build --release
+```
+
+A folder `./target/release` will be generated. Add this folder the your PATH environment variable to call `ezkl` from CLI.
+
+```bash
+# For UNIX like systems
+# in .bashrc, .bash_profile, or some other path file
+export PATH="<replace with where you cloned the repo>/ezkl/target/release:$PATH"
+```
+
+Restart your shell or reload your shell settings
+
+```bash
+# example, replace .bash_profile with the file you use to configure your shell
+source ~/.bash_profile
+```
+
+You will need a functioning installation of `solc` in order to run `ezkl` properly.
+[solc-select](https://github.com/crytic/solc-select) is recommended.
+Follow the instructions on [solc-select](https://github.com/crytic/solc-select) to activate `solc` in your environment.
+
 
 ### docs 📖
 
@@ -60,23 +87,23 @@ The `ezkl` cli provides a simple interface to load `.onnx` files, which represen
 
 ### python and cli tutorial 🐍
 
-You can easily create an `.onnx` file using `pytorch`. For samples of Onnx files see [here](https://github.com/zkonduit/onnx-examples). For a tutorial on how to quickly generate Onnx files using python, check out [pyezkl](https://github.com/zkonduit/pyezkl). 
+You can easily create an `.onnx` file using `pytorch`. For samples of Onnx files see [here](https://github.com/zkonduit/onnx-examples). For a tutorial on how to quickly generate Onnx files using python, check out [pyezkl](https://github.com/zkonduit/pyezkl).
 
-Sample onnx files are also available in `./examples/onnx`. To generate a proof on one of the examples, first build ezkl (`cargo build --release`) and add it to your favourite `PATH` variables, then generate a structured reference string (SRS): 
+Sample onnx files are also available in `./examples/onnx`. To generate a proof on one of the examples, first build ezkl (`cargo build --release`) and add it to your favourite `PATH` variables, then generate a structured reference string (SRS):
 ```bash
 ezkl -K=17 gen-srs --pfsys=kzg --params-path=kzg.params
-``` 
+```
 
 ```bash
 ezkl --bits=16 -K=17 prove -D ./examples/onnx/1l_relu/input.json -M ./examples/onnx/1l_relu/network.onnx --proof-path 1l_relu.pf --vk-path 1l_relu.vk --params-path=kzg.params
-``` 
+```
 
-This command generates a proof that the model was correctly run on private inputs (this is the default setting). It then outputs the resulting proof at the path specfifed by `--proof-path`, parameters that can be used for subsequent verification at `--params-path` and the verifier key at `--vk-path`. 
-Luckily `ezkl` also provides command to verify the generated proofs: 
+This command generates a proof that the model was correctly run on private inputs (this is the default setting). It then outputs the resulting proof at the path specfifed by `--proof-path`, parameters that can be used for subsequent verification at `--params-path` and the verifier key at `--vk-path`.
+Luckily `ezkl` also provides command to verify the generated proofs:
 
-```bash 
+```bash
 ezkl --bits=16 -K=17 verify -M ./examples/onnx/1l_relu/network.onnx --proof-path 1l_relu.pf --vk-path 1l_relu.vk --params-path=kzg.params
-``` 
+```
 
 To display a table of the loaded onnx nodes, their associated parameters, set `RUST_LOG=DEBUG` or run:
 
@@ -87,7 +114,7 @@ cargo run --release --bin ezkl -- table -M ./examples/onnx/1l_relu/network.onnx
 
 #### verifying with the EVM ◊
 
-Note that the above prove and verify stats can also be run with an EVM verifier. This can be done by generating a verifier smart contract after generating the proof 
+Note that the above prove and verify stats can also be run with an EVM verifier. This can be done by generating a verifier smart contract after generating the proof
 
 ```bash
 # gen proof
@@ -98,20 +125,20 @@ ezkl --bits=16 -K=17 prove -D ./examples/onnx/1l_relu/input.json -M ./examples/o
 ezkl -K=17 --bits=16 create-evm-verifier -D ./examples/onnx/1l_relu/input.json -M ./examples/onnx/1l_relu/network.onnx --pfsys=kzg --deployment-code-path 1l_relu.code --params-path=kzg.params --vk-path 1l_relu.vk --sol-code-path 1l_relu.sol
 ```
 ```bash
-# Verify (EVM) 
+# Verify (EVM)
 ezkl -K=17 --bits=16 verify-evm --pfsys=kzg --proof-path 1l_relu.pf --deployment-code-path 1l_relu.code
 ```
 
 Note that the `.sol` file above can be deployed and composed with other Solidity contracts, via a `verify()` function. Please read [this document](https://hackmd.io/QOHOPeryRsOraO7FUnG-tg) for more information about the interface of the contract, how to obtain the data needed for its function parameters, and its limitations.
 
-The above pipeline can also be run using [proof aggregation](https://ethresear.ch/t/leveraging-snark-proof-aggregation-to-achieve-large-scale-pbft-based-consensus/11588) to reduce proof size and verifying times, so as to be more suitable for EVM deployment. A sample pipeline for doing so would be: 
+The above pipeline can also be run using [proof aggregation](https://ethresear.ch/t/leveraging-snark-proof-aggregation-to-achieve-large-scale-pbft-based-consensus/11588) to reduce proof size and verifying times, so as to be more suitable for EVM deployment. A sample pipeline for doing so would be:
 
 ```bash
 # Generate a new 2^20 SRS
 ezkl -K=20 gen-srs --pfsys=kzg --params-path=kzg.params
 ```
 
-```bash 
+```bash
 # Single proof -> single proof we are going to feed into aggregation circuit. (Mock)-verifies + verifies natively as sanity check
 ezkl -K=17 --bits=16 prove --pfsys=kzg --transcript=poseidon --strategy=accum -D ./examples/onnx/1l_relu/input.json -M ./examples/onnx/1l_relu/network.onnx --proof-path 1l_relu.pf --params-path=kzg.params  --vk-path=1l_relu.vk
 ```
@@ -119,24 +146,24 @@ ezkl -K=17 --bits=16 prove --pfsys=kzg --transcript=poseidon --strategy=accum -D
 ```bash
 # Aggregate -> generates aggregate proof and also (mock)-verifies + verifies natively as sanity check
 ezkl -K=17 --bits=16 aggregate --transcript=evm -M ./examples/onnx/1l_relu/network.onnx --pfsys=kzg --aggregation-snarks=1l_relu.pf --aggregation-vk-paths 1l_relu.vk --vk-path aggr_1l_relu.vk --proof-path aggr_1l_relu.pf --params-path=kzg.params
-``` 
+```
 
 ```bash
-# Generate verifier code -> create the EVM verifier code 
+# Generate verifier code -> create the EVM verifier code
 ezkl -K=17 --bits=16 aggregate create-evm-verifier-aggr --pfsys=kzg --deployment-code-path aggr_1l_relu.code --params-path=kzg.params --vk-path aggr_1l_relu.vk
 ```
 
 ```bash
-# Verify (EVM) -> 
+# Verify (EVM) ->
 ezkl -K=17 --bits=16 verify-evm --pfsys=kzg --proof-path aggr_1l_relu.pf --deployment-code-path aggr_1l_relu.code
- 
+
 ```
 
 Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation, and that aggregated proof verification in Solidity is not currently supported.
 
-#### using pre-generated SRS 
+#### using pre-generated SRS
 
-Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file ! 
+Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file !
 
 
 ### general usage 🔧
@@ -219,21 +246,21 @@ criterion_group! {
 }
 ```
 
-## onnx examples 
+## onnx examples
 
 This repository includes onnx example files as a submodule for testing out the cli.
 
-If you want to add a model to `examples/onnx`, open a PR creating a new folder within `examples/onnx` with a descriptive model name. This folder should contain: 
-- an `input.json` input file, with the fields expected by the  [ezkl](https://github.com/zkonduit/ezkl) cli. 
-- a `network.onnx` file representing the trained model 
+If you want to add a model to `examples/onnx`, open a PR creating a new folder within `examples/onnx` with a descriptive model name. This folder should contain:
+- an `input.json` input file, with the fields expected by the  [ezkl](https://github.com/zkonduit/ezkl) cli.
+- a `network.onnx` file representing the trained model
 - a `gen.py` file for generating the `.json` and `.onnx` files following the general structure of `examples/tutorial/tutorial.py`.
 
 
-TODO: add associated python files in the onnx model directories. 
+TODO: add associated python files in the onnx model directories.
 
 ## library examples 🔍
 
-Beyond the `.onnx` examples detailed above, we also include examples which directly use some of our rust API; allowing users to code up computational graphs and circuits from scratch in rust without having to go via python. 
+Beyond the `.onnx` examples detailed above, we also include examples which directly use some of our rust API; allowing users to code up computational graphs and circuits from scratch in rust without having to go via python.
 
 The MNIST inference example using ezkl as a library is contained in `examples/conv2d_mnist`. To run it:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After which you may build the library
 cargo build --release
 ```
 
-A folder `./target/release` will be generated. Add this folder the your PATH environment variable to call `ezkl` from CLI.
+A folder `./target/release` will be generated. Add this folder to your PATH environment variable to call `ezkl` from the CLI.
 
 ```bash
 # For UNIX like systems


### PR DESCRIPTION
Previous instructions with regards to building `ezkl` had been unclear leading to bugs. 
This PR adds more details required to run `ezkl` properly by making the installation of `solc` more explicit.