### PR TITLE
chore: ignore readme updates when triggering actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,12 @@ name: Rust
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**/README.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**/README.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - "**/README.md"
+      - "README.md"
   pull_request:
     branches: ["main"]
     paths-ignore:
-      - "**/README.md"
+      - "README.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Also note that this may require a local [solc](https://docs.soliditylang.org/en/
 Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file !
 
 
+
 ### general usage 🔧
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ Also note that this may require a local [solc](https://docs.soliditylang.org/en/
 Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file !
 
 
-
 ### general usage 🔧
 
 ```bash


### PR DESCRIPTION
Triggering new CI pipelines solely for readme updates is overkill. 