### PR TITLE
feat: commands to interact with the EVM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,7 +143,7 @@ jobs:
         run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 4
 
   prove-and-verify-aggr-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-32-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -155,7 +155,7 @@ jobs:
         run: cargo test --release --verbose tests_aggr::kzg_aggr_prove_and_verify_
 
   prove-and-verify-aggr-evm-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-32-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,7 +143,7 @@ jobs:
         run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 4
 
   prove-and-verify-aggr-tests:
-    runs-on: ubuntu-latest-32-cores
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -155,7 +155,7 @@ jobs:
         run: cargo test --release --verbose tests_aggr::kzg_aggr_prove_and_verify_
 
   prove-and-verify-aggr-evm-tests:
-    runs-on: ubuntu-latest-32-cores
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ ezkl -K=17 --bits=16 verify-evm --proof-path aggr_1l_relu.pf --deployment-code-p
 
 Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation, and that aggregated proof verification in Solidity is not currently supported.
 
-For both pipelines the resulting verifier can be deployed to an EVM instance (mainnet or otherwise !) using the `deploy-verifier` command: 
+For both pipelines the resulting verifier can be deployed to an EVM instance (mainnet or otherwise !) using the `deploy-verifier-evm` command: 
 
 ```bash
 Deploys an EVM verifier
 
-Usage: ezkl deploy-verifier [OPTIONS] --secret <SECRET> --rpc-url <RPC_URL>
+Usage: ezkl deploy-verifier-evm [OPTIONS] --secret <SECRET> --rpc-url <RPC_URL>
 
 Options:
   -S, --secret <SECRET>
@@ -197,7 +197,29 @@ Options:
 For instance: 
 
 ```bash 
-ezkl deploy-verifier -S ./mymnemonic.txt -U myethnode.xyz --deployment-code-path aggr_1l_relu.code
+ezkl deploy-verifier-evm -S ./mymnemonic.txt -U myethnode.xyz --deployment-code-path aggr_1l_relu.code
+```
+
+You can also send proofs to be verified on deployed contracts using `send-proof`: 
+
+```bash
+Send a proof to be verified to an already deployed verifier
+
+Usage: ezkl send-proof-evm --secret <SECRET> --rpc-url <RPC_URL> --addr <ADDR> --proof-path <PROOF_PATH>
+
+Options:
+  -S, --secret <SECRET>          The path to the wallet mnemonic
+  -U, --rpc-url <RPC_URL>        RPC Url
+      --addr <ADDR>              The deployed verifier address
+      --proof-path <PROOF_PATH>  The path to the proof
+  -h, --help                     Print help
+
+```
+
+For instance: 
+
+```bash 
+ezkl send-proof-evm -S ./mymnemonic.txt -U myethnode.xyz --addr 0xFFFF --proof-path my.snark
 ```
 
 #### using pre-generated SRS

--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ ezkl -K=17 --bits=16 verify-evm --proof-path aggr_1l_relu.pf --deployment-code-p
 
 Also note that this may require a local [solc](https://docs.soliditylang.org/en/v0.8.17/installing-solidity.html) installation, and that aggregated proof verification in Solidity is not currently supported.
 
+For both pipelines the resulting verifier can be deployed to an EVM instance (mainnet or otherwise !) using the `deploy-verifier` command: 
+
+```bash
+Deploys an EVM verifier
+
+Usage: ezkl deploy-verifier [OPTIONS] --secret <SECRET> --rpc-url <RPC_URL>
+
+Options:
+  -S, --secret <SECRET>
+          The path to the wallet mnemonic
+  -U, --rpc-url <RPC_URL>
+          RPC Url
+      --deployment-code-path <DEPLOYMENT_CODE_PATH>
+          The path to the desired EVM bytecode file (optional), either set this or sol_code_path
+      --sol-code-path <SOL_CODE_PATH>
+          The path to output the Solidity code (optional) supercedes deployment_code_path in priority
+  -h, --help
+          Print help
+
+```
+
+For instance: 
+
+```bash 
+ezkl deploy-verifier -S ./mymnemonic.txt -U myethnode.xyz --deployment-code-path aggr_1l_relu.code
+```
+
 #### using pre-generated SRS
 
 Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file !
@@ -193,6 +220,7 @@ Commands:
   prove                     Loads model and data, prepares vk and pk, and creates proof
   create-evm-verifier       Creates an EVM verifier for a single proof
   create-evm-verifier-aggr  Creates an EVM verifier for an aggregate proof
+  deploy-verifier           Deploys an EVM verifier
   verify                    Verifies a proof, returning accept or reject
   verify-aggr               Verifies an aggregate proof, returning accept or reject
   verify-evm                Verifies a proof using a local EVM executor, returning accept or reject

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -208,7 +208,7 @@ pub enum Commands {
         /// The path to the desired output file
         #[arg(long)]
         proof_path: PathBuf,
-        /// The path to load the desired params file
+        /// The transcript type
         #[arg(long)]
         params_path: PathBuf,
         #[arg(
@@ -237,7 +237,7 @@ pub enum Commands {
         /// The path to the desired output file
         #[arg(long)]
         proof_path: PathBuf,
-        /// The path to load the desired params file
+        /// The transcript type
         #[arg(long)]
         params_path: PathBuf,
         #[arg(
@@ -248,6 +248,7 @@ pub enum Commands {
             value_enum
         )]
         transcript: TranscriptType,
+        /// The proving strategy  
         #[arg(
             long,
             require_equals = true,
@@ -298,6 +299,24 @@ pub enum Commands {
         // todo, optionally allow supplying proving key
     },
 
+    /// Deploys an EVM verifier
+    #[command(name = "deploy-verifier", arg_required_else_help = true)]
+    DeployVerifier {
+        /// The path to the wallet mnemonic
+        #[arg(short = 'S', long)]
+        secret: PathBuf,
+        /// RPC Url
+        #[arg(short = 'U', long)]
+        rpc_url: String,
+        /// The path to the desired EVM bytecode file (optional), either set this or sol_code_path
+        #[arg(long)]
+        deployment_code_path: Option<PathBuf>,
+        /// The path to output the Solidity code (optional) supercedes deployment_code_path in priority
+        #[arg(long)]
+        sol_code_path: Option<PathBuf>,
+        // todo, optionally allow supplying proving key
+    },
+
     /// Verifies a proof, returning accept or reject
     #[command(arg_required_else_help = true)]
     Verify {
@@ -310,7 +329,7 @@ pub enum Commands {
         /// The path to output the desired verfication key file (optional)
         #[arg(long)]
         vk_path: PathBuf,
-        /// The path to load the desired verfication key file (optional)
+        /// The transcript type
         #[arg(long)]
         params_path: PathBuf,
         #[arg(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,6 @@
 //use crate::onnx::OnnxModel;
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use ethereum_types::Address;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -300,8 +301,8 @@ pub enum Commands {
     },
 
     /// Deploys an EVM verifier
-    #[command(name = "deploy-verifier", arg_required_else_help = true)]
-    DeployVerifier {
+    #[command(name = "deploy-verifier-evm", arg_required_else_help = true)]
+    DeployVerifierEVM {
         /// The path to the wallet mnemonic
         #[arg(short = 'S', long)]
         secret: PathBuf,
@@ -315,6 +316,23 @@ pub enum Commands {
         #[arg(long)]
         sol_code_path: Option<PathBuf>,
         // todo, optionally allow supplying proving key
+    },
+
+    /// Send a proof to be verified to an already deployed verifier
+    #[command(name = "send-proof-evm", arg_required_else_help = true)]
+    SendProofEVM {
+        /// The path to the wallet mnemonic
+        #[arg(short = 'S', long)]
+        secret: PathBuf,
+        /// RPC Url
+        #[arg(short = 'U', long)]
+        rpc_url: String,
+        /// The deployed verifier address
+        #[arg(long)]
+        addr: Address,
+        /// The path to the proof
+        #[arg(long)]
+        proof_path: PathBuf,
     },
 
     /// Verifies a proof, returning accept or reject

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -1,10 +1,17 @@
+use crate::pfsys::evm::DeploymentCode;
 use crate::pfsys::evm::EvmVerificationError;
 use crate::pfsys::Snark;
+use ethers::abi::ethabi::Bytes;
+use ethers::abi::Abi;
+use ethers::abi::AbiEncode;
 use ethers::contract::abigen;
 use ethers::contract::ContractFactory;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::middleware::SignerMiddleware;
+use ethers::providers::Middleware;
 use ethers::providers::{Http, Provider};
+use ethers::signers::coins_bip39::English;
+use ethers::signers::MnemonicBuilder;
 use ethers::signers::Signer;
 use ethers::types::U256;
 use ethers::utils::AnvilInstance;
@@ -15,7 +22,13 @@ use ethers::{
 use ethers_solc::Solc;
 use halo2curves::bn256::{Fr, G1Affine};
 use halo2curves::group::ff::PrimeField;
+use log::{debug, info};
+use std::error::Error;
+use std::fs::read_to_string;
+use std::path::PathBuf;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
+
+const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
 /// A local ethers-rs based client
 pub type EthersClient = Arc<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>;
@@ -45,7 +58,7 @@ pub async fn setup_eth_backend() -> (AnvilInstance, EthersClient) {
 /// Verify a proof using a Solidity verifier contract
 pub async fn verify_proof_via_solidity(
     proof: Snark<Fr, G1Affine>,
-    sol_code_path: std::path::PathBuf,
+    sol_code_path: PathBuf,
 ) -> Result<bool, Box<EvmVerificationError>> {
     let (anvil, client) = setup_eth_backend().await;
 
@@ -86,4 +99,128 @@ pub async fn verify_proof_via_solidity(
 
     drop(anvil);
     Ok(result)
+}
+
+/// Parses a private key into a [SigningKey]  
+fn parse_private_key(private_key: U256) -> Result<SigningKey, Bytes> {
+    if private_key.is_zero() {
+        return Err("Private key cannot be 0.".to_string().encode());
+    }
+    let mut bytes: [u8; 32] = [0; 32];
+    private_key.to_big_endian(&mut bytes);
+    SigningKey::from_bytes(&bytes).map_err(|err| err.to_string().encode())
+}
+
+/// Parses a private key into a [Wallet]  
+fn get_signing_wallet(private_key: U256, chain_id: u64) -> Wallet<SigningKey> {
+    let private_key = parse_private_key(private_key).unwrap();
+    let wallet: Wallet<SigningKey> = private_key.into();
+
+    wallet.with_chain_id(chain_id)
+}
+
+/// Derives a key from a mnemonic phrase
+fn derive_key(mnemonic: &str, path: &str, index: u32) -> Result<U256, Bytes> {
+    let derivation_path = if path.ends_with('/') {
+        format!("{path}{index}")
+    } else {
+        format!("{path}/{index}")
+    };
+
+    let wallet = MnemonicBuilder::<English>::default()
+        .phrase(mnemonic)
+        .derivation_path(&derivation_path)
+        .map_err(|err| err.to_string().encode())?
+        .build()
+        .map_err(|err| err.to_string().encode())?;
+
+    info!("Wallet key we use: {:#?}", wallet);
+
+    let private_key = U256::from_big_endian(wallet.signer().to_bytes().as_slice());
+
+    info!("Private key we use: {:#?}", private_key);
+
+    Ok(private_key)
+}
+
+/// From a mnemonic and an rpc url returns a provider that can sign transaction via HTTP
+pub async fn get_signing_provider(
+    mnemonic: &str,
+    rpc_url: &str,
+) -> SignerMiddleware<Arc<Provider<Http>>, Wallet<SigningKey>> {
+    let provider =
+        Provider::<Http>::try_from(rpc_url).expect("could not instantiate HTTP Provider");
+    debug!("{:#?}", provider);
+    // provider.for_chain(Chain::try_from(3141));
+    let chain_id = provider.get_chainid().await.unwrap();
+    let private_key = derive_key(mnemonic, DEFAULT_DERIVATION_PATH_PREFIX, 0).unwrap();
+    let signing_wallet = get_signing_wallet(private_key, chain_id.as_u64());
+
+    let provider = Arc::new(provider);
+
+    SignerMiddleware::new(provider, signing_wallet)
+}
+
+/// Deploys a verifier contract  
+pub async fn deploy_verifier(
+    secret: PathBuf,
+    rpc_url: String,
+    deployment_code_path: Option<PathBuf>,
+    sol_code_path: Option<PathBuf>,
+) -> Result<(), Box<dyn Error>> {
+    // comment the following two lines if want to deploy to anvil
+    let mnemonic = read_to_string(secret)?;
+    let client = Arc::new(get_signing_provider(&mnemonic, &rpc_url).await);
+    // uncomment if want to test on local anvil
+    // let (anvil, client) = setup_eth_backend().await;
+
+    let gas = client.provider().get_gas_price().await?;
+    info!("gas price: {:#?}", gas);
+
+    // sol code supercedes deployment code
+    let factory = match sol_code_path {
+        Some(path) => {
+            let compiled = Solc::default().compile_source(path).unwrap();
+            let (abi, bytecode, _runtime_bytecode) = compiled
+                .find("Verifier")
+                .expect("could not find contract")
+                .into_parts_or_default();
+            ContractFactory::new(abi, bytecode, client.clone())
+        }
+        None => match deployment_code_path {
+            Some(path) => {
+                let bytecode = DeploymentCode::load(&path)?;
+                ContractFactory::new(
+                    // our constructor is empty and ContractFactory only uses the abi constructor -- so this should be safe
+                    Abi::default(),
+                    (bytecode.code().clone()).into(),
+                    client.clone(),
+                )
+            }
+            None => {
+                panic!("at least one path should be set");
+            }
+        },
+    };
+
+    let deployer = factory.deploy(())?;
+
+    let tx = &deployer.tx;
+
+    debug!("transaction {:#?}", tx);
+    info!(
+        "estimated deployment gas cost: {:#?}",
+        client.estimate_gas(tx, None).await?
+    );
+    let deploy_transaction = deployer.send().await?;
+    debug!("deploy receipt: {:#?}", deploy_transaction);
+
+    let addr = deploy_transaction.address();
+
+    info!("contract address: {}", addr);
+
+    // uncomment if want to test on local anvil
+    // drop(anvil);
+
+    Ok(())
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,6 +1,6 @@
 use super::eth::verify_proof_via_solidity;
 use crate::commands::{Cli, Commands, StrategyType, TranscriptType};
-use crate::eth::deploy_verifier;
+use crate::eth::{deploy_verifier, send_proof};
 use crate::graph::{vector_to_quantized, Model, ModelCircuit};
 use crate::pfsys::evm::aggregation::{
     gen_aggregation_evm_verifier, AggregationCircuit, PoseidonTranscript,
@@ -143,7 +143,16 @@ fn create_proof_circuit_kzg<
 /// Run an ezkl command with given args
 pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
-        Commands::DeployVerifier {
+        Commands::SendProofEVM {
+            secret,
+            rpc_url,
+            addr,
+            proof_path,
+        } => {
+            let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path, None, None)?;
+            send_proof(secret, rpc_url, addr, proof).await?;
+        }
+        Commands::DeployVerifierEVM {
             secret,
             rpc_url,
             deployment_code_path,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1,5 +1,6 @@
 use super::eth::verify_proof_via_solidity;
 use crate::commands::{Cli, Commands, StrategyType, TranscriptType};
+use crate::eth::deploy_verifier;
 use crate::graph::{vector_to_quantized, Model, ModelCircuit};
 use crate::pfsys::evm::aggregation::{
     gen_aggregation_evm_verifier, AggregationCircuit, PoseidonTranscript,
@@ -142,6 +143,14 @@ fn create_proof_circuit_kzg<
 /// Run an ezkl command with given args
 pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
+        Commands::DeployVerifier {
+            secret,
+            rpc_url,
+            deployment_code_path,
+            sol_code_path,
+        } => {
+            deploy_verifier(secret, rpc_url, deployment_code_path, sol_code_path).await?;
+        }
         Commands::GenSrs { params_path } => {
             let params = gen_srs::<KZGCommitmentScheme<Bn256>>(cli.args.logrows);
             save_params_kzg(&params_path, &params)?;

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -768,20 +768,17 @@ impl Model {
 
             // handle output variables
             let max_id = poly_ops.keys().max();
-            match max_id {
-                Some(m) => {
-                    let output_size = self.nodes.filter(**m).out_dims.iter().product();
-                    if inputs.len() == maximum_sizes.len() {
-                        maximum_sizes.push(output_size)
-                    } else {
-                        let output_idx = inputs.len();
-                        // set last entry to be the output column
-                        maximum_sizes[output_idx] = max(maximum_sizes[output_idx], output_size);
-                    }
+            // is None if the bucket is empty
+            if let Some(m) = max_id {
+                let output_size = self.nodes.filter(**m).out_dims.iter().product();
+                if inputs.len() == maximum_sizes.len() {
+                    maximum_sizes.push(output_size)
+                } else {
+                    let output_idx = inputs.len();
+                    // set last entry to be the output column
+                    maximum_sizes[output_idx] = max(maximum_sizes[output_idx], output_size);
                 }
-                // None if the bucket is empty
-                None => {}
-            }
+            };
         }
         // add 1 for layer output
         maximum_sizes
@@ -818,21 +815,19 @@ impl Model {
 
             // handle output variables
             let max_id = fused_ops.keys().max();
-            match max_id {
-                Some(m) => {
-                    let output_size = self.nodes.filter(**m).out_dims.iter().product();
-                    if inputs.len() == maximum_sizes.len() {
-                        maximum_sizes.push(output_size)
-                    } else {
-                        let output_idx = inputs.len();
-                        // set last entry to be the output column
-                        maximum_sizes[output_idx] = max(maximum_sizes[output_idx], output_size);
-                    }
+            // None if the bucket is empty
+            if let Some(m) = max_id {
+                let output_size = self.nodes.filter(**m).out_dims.iter().product();
+                if inputs.len() == maximum_sizes.len() {
+                    maximum_sizes.push(output_size)
+                } else {
+                    let output_idx = inputs.len();
+                    // set last entry to be the output column
+                    maximum_sizes[output_idx] = max(maximum_sizes[output_idx], output_size);
                 }
-                // None if the bucket is empty
-                None => {}
-            }
+            };
         }
+
         // add 1 for layer output
         maximum_sizes
     }


### PR DESCRIPTION
Deploying contracts is tough ! let us help you. 

```rust
/// Deploys an EVM verifier
    #[command(name = "deploy-verifier-evm", arg_required_else_help = true)]
    DeployVerifierEVM {
        /// The path to the wallet mnemonic
        #[arg(short = 'S', long)]
        secret: PathBuf,
        /// RPC Url
        #[arg(short = 'U', long)]
        rpc_url: String,
        /// The path to the desired EVM bytecode file (optional), either set this or sol_code_path
        #[arg(long)]
        deployment_code_path: Option<PathBuf>,
        /// The path to output the Solidity code (optional) supercedes deployment_code_path in priority
        #[arg(long)]
        sol_code_path: Option<PathBuf>,
        // todo, optionally allow supplying proving key
    },

```

Sending proofs to already deployed contracts is also tough ! Let us help with dat too: 

```rust
/// Send a proof to be verified to an already deployed verifier
    #[command(name = "send-proof-evm", arg_required_else_help = true)]
    SendProofEVM {
        /// The path to the wallet mnemonic
        #[arg(short = 'S', long)]
        secret: PathBuf,
        /// RPC Url
        #[arg(short = 'U', long)]
        rpc_url: String,
        /// The deployed verifier address
        #[arg(long)]
        addr: Address,
        /// The path to the proof
        #[arg(long)]
        proof_path: PathBuf,
    },


```

- [x] `deploy-verifier-evm` command
- [x] `send-proof-evm` command
- [x] tested locally w/ Anvil  