### PR TITLE
feat: impl standard tensor ops

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -4,7 +4,6 @@ use crate::circuit::lookup::Op as LookupOp;
 use crate::circuit::polynomial::Config as PolyConfig;
 use crate::circuit::polynomial::Op as PolyOp;
 use crate::graph::GraphError;
-use crate::tensor::ops::{add, const_mult, div, mult};
 use crate::tensor::Tensor;
 use crate::tensor::TensorType;
 use anyhow::Result;
@@ -847,10 +846,10 @@ impl Node {
                         let sigma = inputs[4].raw_const_value.as_ref().unwrap();
                         let num_entries = gamma.len();
 
-                        let a = div(gamma.clone(), sigma.clone())?;
-                        let amu: Tensor<f32> = mult(&vec![a.clone(), mu.clone()])?;
-                        let amupb: Tensor<f32> = add(&vec![amu, beta.clone()])?;
-                        let b = const_mult(&amupb, -1f32)?;
+                        let a = (gamma.clone() / sigma.clone())?;
+                        let amu: Tensor<f32> = (a.clone() * mu.clone())?;
+                        let amupb: Tensor<f32> = (amu + beta.clone())?;
+                        let b = (amupb * Tensor::new(Some(&[-1f32]), &[1])?)?;
 
                         let in_scale = inputs[0].out_scale;
                         let out_scale = 2 * inputs[0].out_scale;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -544,6 +544,13 @@ impl<T: TensorType + Add<Output = T>> Add for Tensor<T> {
             for i in 0..output.len() {
                 output[i] = output[i].clone() + rhs[0].clone();
             }
+        }
+        // make 1D casting commutative
+        else if self.dims().len() == 1 && self.dims()[0] == 1 {
+            output = rhs.clone();
+            for i in 0..rhs.len() {
+                output[i] = output[i].clone() + self[0].clone();
+            }
         } else {
             if self.dims() != rhs.dims() {
                 return Err(TensorError::DimMismatch("add".to_string()));
@@ -567,6 +574,13 @@ impl<T: TensorType + Sub<Output = T>> Sub for Tensor<T> {
         if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
             for i in 0..output.len() {
                 output[i] = output[i].clone() - rhs[0].clone();
+            }
+        }
+        // make 1D casting commutative
+        else if self.dims().len() == 1 && self.dims()[0] == 1 {
+            output = rhs.clone();
+            for i in 0..rhs.len() {
+                output[i] = output[i].clone() - self[0].clone();
             }
         } else {
             if self.dims() != rhs.dims() {
@@ -592,6 +606,13 @@ impl<T: TensorType + Mul<Output = T>> Mul for Tensor<T> {
             for i in 0..output.len() {
                 output[i] = output[i].clone() * rhs[0].clone();
             }
+        }
+        // make 1D casting commutative
+        else if self.dims().len() == 1 && self.dims()[0] == 1 {
+            output = rhs.clone();
+            for i in 0..rhs.len() {
+                output[i] = output[i].clone() * self[0].clone();
+            }
         } else {
             if self.dims() != rhs.dims() {
                 return Err(TensorError::DimMismatch("mul".to_string()));
@@ -615,6 +636,11 @@ impl<T: TensorType + Div<Output = T>> Div for Tensor<T> {
         if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
             for i in 0..output.len() {
                 output[i] = output[i].clone() / rhs[0].clone();
+            }
+        } else if self.dims().len() == 1 && self.dims()[0] == 1 {
+            output = rhs.clone();
+            for i in 0..rhs.len() {
+                output[i] = self[0].clone() / output[i].clone();
             }
         } else {
             if self.dims() != rhs.dims() {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -17,13 +17,13 @@ use halo2_proofs::{
     poly::Rotation,
 };
 use itertools::Itertools;
-use std::cmp::max;
-use std::error::Error;
-use std::fmt::Debug;
-use std::iter::Iterator;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::ops::Range;
+use std::{cmp::max, ops::Add};
+use std::{error::Error, ops::Mul};
+use std::{fmt::Debug, ops::Sub};
+use std::{iter::Iterator, ops::Div};
 use thiserror::Error;
 /// A wrapper for tensor related errors.
 #[derive(Debug, Error)]
@@ -530,6 +530,102 @@ impl<T: Clone + TensorType> Tensor<Tensor<T>> {
             inner.extend(t.inner);
         }
         Tensor::new(Some(&inner), &[dims])
+    }
+}
+
+impl<T: TensorType + Add<Output = T>> Add for Tensor<T> {
+    type Output = Result<Tensor<T>, TensorError>;
+    fn add(self, rhs: Self) -> Self::Output {
+        // calculate value of output
+        let mut output: Tensor<T> = self.clone();
+
+        // casts a 1D addition
+        if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
+            for i in 0..output.len() {
+                output[i] = output[i].clone() + rhs[0].clone();
+            }
+        } else {
+            if self.dims() != rhs.dims() {
+                return Err(TensorError::DimMismatch("add".to_string()));
+            }
+
+            for (i, e_i) in rhs.iter().enumerate() {
+                output[i] = output[i].clone() + e_i.clone()
+            }
+        }
+        Ok(output)
+    }
+}
+
+impl<T: TensorType + Sub<Output = T>> Sub for Tensor<T> {
+    type Output = Result<Tensor<T>, TensorError>;
+    fn sub(self, rhs: Self) -> Self::Output {
+        // calculate value of output
+        let mut output: Tensor<T> = self.clone();
+
+        // casts a 1D addition
+        if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
+            for i in 0..output.len() {
+                output[i] = output[i].clone() - rhs[0].clone();
+            }
+        } else {
+            if self.dims() != rhs.dims() {
+                return Err(TensorError::DimMismatch("sub".to_string()));
+            }
+
+            for (i, e_i) in rhs.iter().enumerate() {
+                output[i] = output[i].clone() - e_i.clone()
+            }
+        }
+        Ok(output)
+    }
+}
+
+impl<T: TensorType + Mul<Output = T>> Mul for Tensor<T> {
+    type Output = Result<Tensor<T>, TensorError>;
+    fn mul(self, rhs: Self) -> Self::Output {
+        // calculate value of output
+        let mut output: Tensor<T> = self.clone();
+
+        // casts a 1D multiplication
+        if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
+            for i in 0..output.len() {
+                output[i] = output[i].clone() * rhs[0].clone();
+            }
+        } else {
+            if self.dims() != rhs.dims() {
+                return Err(TensorError::DimMismatch("mul".to_string()));
+            }
+
+            for (i, e_i) in rhs.iter().enumerate() {
+                output[i] = output[i].clone() * e_i.clone()
+            }
+        }
+        Ok(output)
+    }
+}
+
+impl<T: TensorType + Div<Output = T>> Div for Tensor<T> {
+    type Output = Result<Tensor<T>, TensorError>;
+    fn div(self, rhs: Self) -> Self::Output {
+        // calculate value of output
+        let mut output: Tensor<T> = self.clone();
+
+        // casts a 1D multiplication
+        if rhs.dims().len() == 1 && rhs.dims()[0] == 1 {
+            for i in 0..output.len() {
+                output[i] = output[i].clone() / rhs[0].clone();
+            }
+        } else {
+            if self.dims() != rhs.dims() {
+                return Err(TensorError::DimMismatch("div".to_string()));
+            }
+
+            for (i, e_i) in rhs.iter().enumerate() {
+                output[i] = output[i].clone() / e_i.clone()
+            }
+        }
+        Ok(output)
     }
 }
 

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -185,56 +185,23 @@ pub fn matmul<T: TensorType + Mul<Output = T> + Add<Output = T>>(
 /// let result = add(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[4, 4, 4, 2, 2, 2]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
-/// ```
-pub fn add<T: TensorType + Add<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor<T>, TensorError> {
-    // determines if we're multiplying by a 1D const
-    if t.len() == 2 && t[1].dims().len() == 1 && t[1].dims()[0] == 1 {
-        return const_add(&t[0], t[1][0].clone());
-    }
-    for e in t.iter() {
-        if t[0].dims() != e.dims() {
-            return Err(TensorError::DimMismatch("add".to_string()));
-        }
-    }
-    // calculate value of output
-    let mut output: Tensor<T> = t[0].clone();
-
-    for e in t[1..].iter() {
-        for (i, e_i) in e.iter().enumerate() {
-            output[i] = output[i].clone() + e_i.clone()
-        }
-    }
-
-    Ok(output)
-}
-
-/// Elementwise adds a tensor with a const element.
-/// # Arguments
 ///
-/// * `a` - Tensor
-/// * `b` - Single value
-/// # Examples
-/// ```
-/// use ezkl::tensor::Tensor;
-/// use ezkl::tensor::ops::const_add;
+/// // Now test 1D casting
 /// let x = Tensor::<i32>::new(
 ///     Some(&[2, 1, 2, 1, 1, 1]),
 ///     &[2, 3],
 /// ).unwrap();
 /// let k = 2;
-/// let result = const_add(&x, k).unwrap();
+/// let result = add(&x, k).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[4, 3, 4, 3, 3, 3]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
-pub fn const_add<T: TensorType + Add<Output = T>>(
-    a: &Tensor<T>,
-    b: T,
-) -> Result<Tensor<T>, TensorError> {
+pub fn add<T: TensorType + Add<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor<T>, TensorError> {
     // calculate value of output
-    let mut output: Tensor<T> = a.clone();
+    let mut output: Tensor<T> = t[0].clone();
 
-    for i in 0..output.len() {
-        output[i] = output[i].clone() + b.clone();
+    for e in t[1..].iter() {
+        output = (output + e.clone())?;
     }
 
     Ok(output)
@@ -260,57 +227,23 @@ pub fn const_add<T: TensorType + Add<Output = T>>(
 /// let result = sub(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[0, -2, 0, 0, 0, 0]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
-/// ```
-pub fn sub<T: TensorType + Sub<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor<T>, TensorError> {
-    // determines if we're multiplying by a 1D const
-    if t.len() == 2 && t[1].dims().len() == 1 && t[1].dims()[0] == 1 {
-        return const_sub(&t[0], t[1][0].clone());
-    }
-
-    for e in t.iter() {
-        if t[0].dims() != e.dims() {
-            return Err(TensorError::DimMismatch("sub".to_string()));
-        }
-    }
-    // calculate value of output
-    let mut output: Tensor<T> = t[0].clone();
-
-    for e in t[1..].iter() {
-        for (i, e_i) in e.iter().enumerate() {
-            output[i] = output[i].clone() - e_i.clone()
-        }
-    }
-
-    Ok(output)
-}
-
-/// Elementwise subtracts a tensor with a const element.
-/// # Arguments
 ///
-/// * `a` - Tensor
-/// * `b` - Single value
-/// # Examples
-/// ```
-/// use ezkl::tensor::Tensor;
-/// use ezkl::tensor::ops::const_sub;
+/// // Now test 1D sub
 /// let x = Tensor::<i32>::new(
 ///     Some(&[2, 1, 2, 1, 1, 1]),
 ///     &[2, 3],
 /// ).unwrap();
 /// let k = 2;
-/// let result = const_sub(&x, k).unwrap();
+/// let result = sub(&x, k).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[0, -1, 0, -1, -1, -1]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
-pub fn const_sub<T: TensorType + Sub<Output = T>>(
-    a: &Tensor<T>,
-    b: T,
-) -> Result<Tensor<T>, TensorError> {
+pub fn sub<T: TensorType + Sub<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor<T>, TensorError> {
     // calculate value of output
-    let mut output: Tensor<T> = a.clone();
+    let mut output: Tensor<T> = t[0].clone();
 
-    for i in 0..output.len() {
-        output[i] = output[i].clone() - b.clone();
+    for e in t[1..].iter() {
+        output = (output - e.clone())?;
     }
 
     Ok(output)
@@ -336,25 +269,23 @@ pub fn const_sub<T: TensorType + Sub<Output = T>>(
 /// let result = mult(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[4, 3, 4, 1, 1, 1]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
+///
+/// // Now test 1D mult
+/// let x = Tensor::<i32>::new(
+///     Some(&[2, 1, 2, 1, 1, 1]),
+///     &[2, 3],
+/// ).unwrap();
+/// let k = 2;
+/// let result = mult(&x, k).unwrap();
+/// let expected = Tensor::<i32>::new(Some(&[4, 2, 4, 2, 2, 2]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
 /// ```
 pub fn mult<T: TensorType + Mul<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor<T>, TensorError> {
-    // determines if we're multiplying by a 1D const
-    if t.len() == 2 && t[1].dims().len() == 1 && t[1].dims()[0] == 1 {
-        return const_mult(&t[0], t[1][0].clone());
-    }
-
-    for e in t.iter() {
-        if t[0].dims() != e.dims() {
-            return Err(TensorError::DimMismatch("mult".to_string()));
-        }
-    }
     // calculate value of output
     let mut output: Tensor<T> = t[0].clone();
 
     for e in t[1..].iter() {
-        for (i, e_i) in e.iter().enumerate() {
-            output[i] = output[i].clone() * e_i.clone()
-        }
+        output = (output * e.clone())?;
     }
 
     Ok(output)
@@ -385,48 +316,7 @@ pub fn div<T: TensorType + Div<Output = T>>(
     t: Tensor<T>,
     d: Tensor<T>,
 ) -> Result<Tensor<T>, TensorError> {
-    if t.dims() != d.dims() {
-        return Err(TensorError::DimMismatch("div".to_string()));
-    }
-    // calculate value of output
-    let mut output: Tensor<T> = t;
-
-    for (i, d_i) in d.iter().enumerate() {
-        output[i] = output[i].clone() / d_i.clone()
-    }
-    Ok(output)
-}
-
-/// Elementwise multiplies a tensor with a const element.
-/// # Arguments
-///
-/// * `a` - Tensor
-/// * `b` - Single value
-/// # Examples
-/// ```
-/// use ezkl::tensor::Tensor;
-/// use ezkl::tensor::ops::const_mult;
-/// let x = Tensor::<i32>::new(
-///     Some(&[2, 1, 2, 1, 1, 1]),
-///     &[2, 3],
-/// ).unwrap();
-/// let k = 2;
-/// let result = const_mult(&x, k).unwrap();
-/// let expected = Tensor::<i32>::new(Some(&[4, 2, 4, 2, 2, 2]), &[2, 3]).unwrap();
-/// assert_eq!(result, expected);
-/// ```
-pub fn const_mult<T: TensorType + Mul<Output = T>>(
-    a: &Tensor<T>,
-    b: T,
-) -> Result<Tensor<T>, TensorError> {
-    // calculate value of output
-    let mut output: Tensor<T> = a.clone();
-
-    for i in 0..output.len() {
-        output[i] = output[i].clone() * b.clone();
-    }
-
-    Ok(output)
+    t / d
 }
 
 /// Rescale a tensor with a const integer (similar to const_mult).

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -191,8 +191,10 @@ pub fn matmul<T: TensorType + Mul<Output = T> + Add<Output = T>>(
 ///     Some(&[2, 1, 2, 1, 1, 1]),
 ///     &[2, 3],
 /// ).unwrap();
-/// let k = 2;
-/// let result = add(&x, k).unwrap();
+/// let k = Tensor::<i32>::new(
+///     Some(&[2]),
+///     &[1]).unwrap();
+/// let result = add(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[4, 3, 4, 3, 3, 3]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
@@ -233,8 +235,11 @@ pub fn add<T: TensorType + Add<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor
 ///     Some(&[2, 1, 2, 1, 1, 1]),
 ///     &[2, 3],
 /// ).unwrap();
-/// let k = 2;
-/// let result = sub(&x, k).unwrap();
+/// let k = Tensor::<i32>::new(
+///     Some(&[2]),
+///     &[1],
+/// ).unwrap();
+/// let result = sub(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[0, -1, 0, -1, -1, -1]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
@@ -249,7 +254,7 @@ pub fn sub<T: TensorType + Sub<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor
     Ok(output)
 }
 
-/// Elementwise multiplies two tensors.
+/// Elementwise multiplies multiple tensors.
 /// # Arguments
 ///
 /// * `a` - Tensor
@@ -275,8 +280,10 @@ pub fn sub<T: TensorType + Sub<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tensor
 ///     Some(&[2, 1, 2, 1, 1, 1]),
 ///     &[2, 3],
 /// ).unwrap();
-/// let k = 2;
-/// let result = mult(&x, k).unwrap();
+/// let k = Tensor::<i32>::new(
+///     Some(&[2]),
+///     &[1]).unwrap();
+/// let result = mult(&vec![x, k]).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[4, 2, 4, 2, 2, 2]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
@@ -310,6 +317,19 @@ pub fn mult<T: TensorType + Mul<Output = T>>(t: &Vec<Tensor<T>>) -> Result<Tenso
 /// ).unwrap();
 /// let result = div(x, y).unwrap();
 /// let expected = Tensor::<i32>::new(Some(&[2, 1, 2, 1, 1, 4]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
+///
+/// // test 1D casting
+/// let x = Tensor::<i32>::new(
+///     Some(&[4, 1, 4, 1, 1, 4]),
+///     &[2, 3],
+/// ).unwrap();
+/// let y = Tensor::<i32>::new(
+///     Some(&[2]),
+///     &[1],
+/// ).unwrap();
+/// let result = div(x, y).unwrap();
+/// let expected = Tensor::<i32>::new(Some(&[2, 0, 2, 0, 0, 2]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```
 pub fn div<T: TensorType + Div<Output = T>>(
@@ -374,11 +394,10 @@ pub fn pow<T: TensorType + Mul<Output = T>>(
 ) -> Result<Tensor<T>, TensorError> {
     // calculate value of output
     let mut output: Tensor<T> = a.clone();
-    for (i, a_i) in a.iter().enumerate() {
-        for _ in 1..pow {
-            output[i] = output[i].clone() * a_i.clone();
-        }
+    for _ in 1..pow {
+        output = (output * a.clone())?;
     }
+
     Ok(output)
 }
 


### PR DESCRIPTION
`tensor::ops` has started to become overloaded and unintuitive. Here we implement standard ops such as `Add, Sub, Div, Mul` for `Tensor` to reduce notational burden and make usage of Tensors much simpler. 
For instance 
```rust
add(&vec![a, b])
```
Can be expressed as: 
```rust
a + b 
```


