### PR TITLE
fix: logs should go to `stdout` not `stderr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,17 +677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colog"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e185a1b1027ecf407c1505a270e78652d5d066cde992ecd813d9ee686d4b5"
-dependencies = [
- "colored",
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +691,18 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "colored_json"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633215cdbb84194508d4c07c08d06e92ee9d489d54e68d17913d8d1bacfcfdeb"
+dependencies = [
+ "atty",
+ "serde",
+ "serde_json",
+ "yansi",
 ]
 
 [[package]]
@@ -1375,12 +1376,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1743,11 +1744,14 @@ name = "ezkl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap 4.1.6",
- "colog",
+ "colored",
+ "colored_json",
  "criterion",
  "ctor",
  "ecc",
+ "env_logger",
  "eq-float",
  "ethereum-types",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = { version = "1.0.126", features = ["derive"], optional = true  }
 serde_json = { version = "1.0.64", optional = true }
 log = { version = "0.4.17", optional = true }
 tabled = { version = "0.9.0", optional = true}
-colog = { version = "1.1.0", optional = true }
 eq-float = "0.1.0"
 thiserror = "1.0.38"
 hex = "0.4.3"
@@ -31,6 +30,10 @@ ethers = "1.0.2"
 ethers-solc = "1.0.2"
 tokio = { version = "1.22.0", features = ["macros"] }
 regex = "1"
+chrono = { version = "0.4.23", optional = true}
+colored = { version = "2.0.0", optional = true}
+env_logger = { version = "0.10.0", optional = true}
+colored_json =  { version = "3.0.1", optional = true}
 
 [dev-dependencies]
 criterion = {version = "0.3",  features = ["html_reports"]}
@@ -69,4 +72,4 @@ default = ["ezkl"]
 render = ["halo2_proofs/dev-graph", "plotters"]
 tensorflow = ["dep:tensorflow"]
 onnx = ["dep:tract-onnx"]
-ezkl = ["onnx", "serde", "serde_json", "log", "colog", "tabled"]
+ezkl = ["onnx", "serde", "serde_json", "log", "chrono", "colored", "env_logger", "tabled", "colored_json"]

--- a/benches/affine.rs
+++ b/benches/affine.rs
@@ -70,7 +70,6 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 }
 
 fn runaffine(c: &mut Criterion) {
-    colog::init();
     let mut group = c.benchmark_group("affine");
     for &len in [4, 8, 16, 32, 64].iter() {
         unsafe {

--- a/benches/cnvrl.rs
+++ b/benches/cnvrl.rs
@@ -105,7 +105,6 @@ where
 }
 
 fn runcnvrl(c: &mut Criterion) {
-    colog::init();
     let mut group = c.benchmark_group("cnvrl");
 
     for size in [1, 2, 4].iter() {

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -57,7 +57,6 @@ impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
 }
 
 fn runrange(c: &mut Criterion) {
-    colog::init();
     let mut group = c.benchmark_group("range");
     for &len in [4, 8, 16, 32, 64, 128].iter() {
         unsafe {

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -51,7 +51,6 @@ impl<F: FieldExt + TensorType> Circuit<F> for NLCircuit<F> {
 }
 
 fn runrelu(c: &mut Criterion) {
-    colog::init();
     let mut group = c.benchmark_group("relu");
 
     let mut rng = rand::thread_rng();

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -1,15 +1,84 @@
+use chrono::Local;
+use colored::*;
+use colored_json::prelude::*;
+use env_logger::Builder;
 use ezkl::commands::Cli;
 use ezkl::execute::run;
-use log::{error, info};
+use log::{error, info, Level, LevelFilter, Record};
 use rand::seq::SliceRandom;
+use std::env;
 use std::error::Error;
+use std::fmt::Formatter;
+use std::io::Write;
+
+#[allow(dead_code)]
+pub fn level_color(level: &log::Level, msg: &str) -> String {
+    match level {
+        Level::Error => msg.red(),
+        Level::Warn => msg.yellow(),
+        Level::Info => msg.green(),
+        Level::Debug => msg.green(),
+        Level::Trace => msg.magenta(),
+    }
+    .bold()
+    .to_string()
+}
+
+fn level_token(level: &Level) -> &str {
+    match *level {
+        Level::Error => "E",
+        Level::Warn => "W",
+        Level::Info => "*",
+        Level::Debug => "D",
+        Level::Trace => "T",
+    }
+}
+
+fn prefix_token(level: &Level) -> String {
+    format!(
+        "{}{}{}",
+        "[".blue().bold(),
+        level_color(level, level_token(level)),
+        "]".blue().bold()
+    )
+}
+
+pub fn format(buf: &mut Formatter, record: &Record<'_>) -> Result<(), std::fmt::Error> {
+    let sep = format!("\n{} ", " | ".white().bold());
+    writeln!(
+        buf,
+        "{} {}",
+        prefix_token(&record.level()),
+        format!("{}", record.args()).replace("\n", &sep),
+    )
+}
+
+pub fn init_logger() {
+    let mut builder = Builder::new();
+    builder.format(|buf, record| {
+        writeln!(
+            buf,
+            "{} [{}, {}] - {}",
+            prefix_token(&record.level()),
+            Local::now().format("%Y-%m-%dT%H:%M:%S"),
+            record.metadata().target(),
+            format!("{}", record.args()).replace("\n", &format!("\n{} ", " | ".white().bold())),
+        )
+    });
+    builder.target(env_logger::Target::Stdout);
+    builder.filter(None, LevelFilter::Info);
+    if env::var("RUST_LOG").is_ok() {
+        builder.parse_filters(&env::var("RUST_LOG").unwrap());
+    }
+    builder.init();
+}
 
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let args = Cli::create().unwrap();
-    colog::init();
+    init_logger();
     banner();
-    info!("{}", &args.as_json()?);
+    info!("command: \n {}", &args.as_json()?.to_colored_json_auto()?);
     let res = run(args).await;
     match &res {
         Ok(_) => info!("succeeded"),
@@ -32,6 +101,7 @@ fn banner() {
         "{}",
         format!(
             "
+
         ███████╗███████╗██╗  ██╗██╗
         ██╔════╝╚══███╔╝██║ ██╔╝██║
         █████╗    ███╔╝ █████╔╝ ██║
@@ -42,6 +112,7 @@ fn banner() {
         -----------------------------------------------------------
         Easy Zero Knowledge {}.
         -----------------------------------------------------------
+        
         ",
             ell.choose(&mut rand::thread_rng()).unwrap()
         )

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -141,11 +141,9 @@ fn derive_key(mnemonic: &str, path: &str, index: u32) -> Result<U256, Bytes> {
         .build()
         .map_err(|err| err.to_string().encode())?;
 
-    info!("Wallet key we use: {:#?}", wallet);
+    info!("wallet address: {:#?}", wallet.address());
 
     let private_key = U256::from_big_endian(wallet.signer().to_bytes().as_slice());
-
-    info!("Private key we use: {:#?}", private_key);
 
     Ok(private_key)
 }


### PR DESCRIPTION
`env_logger` by default targets `stderr` not `stdout` which causes annoyances like those highlighted in #148; hindering the ability for external packages / languages to leverage the cli as a subprocess. Here we remedy this issue by removing `colog`, and explicitly setting the logging target to `STDOUT`. 

Whilst we're at it this PR also introduces a number of cosmetic improvements that were desperately needed. 
- logging timestamps
- logging metadata (the submodule it was called from). 
- pretty printing of JSON of cli command.

Resolves #148 