### PR TITLE
refactor: switch to rawbytes serialization for vk, pk, and srs

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,13 @@ For instance:
 ezkl send-proof-evm -S ./mymnemonic.txt -U myethnode.xyz --addr 0xFFFF --proof-path my.snark
 ```
 
-#### using pre-generated SRS
 
-Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file !
+### using pre-generated SRS
+
+Note that you can use pre-generated KZG SRS. These SRS can be converted to a format that is ingestable by the `pse/halo2` prover ezkl uses by leveraging [han0110/halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs). This repo also contains pre-converted SRS from large projects such as Hermez and the [perpetual powers of tau repo](https://github.com/privacy-scaling-explorations/perpetualpowersoftau). Simply download the pre-converted file locally and point `--params-path` to the file. 
+
+> Note: Ensure you download the files in raw format. As this will be more performant and is the serialization format `ezkl` assumes.
+
 
 
 ### general usage 🔧
@@ -315,6 +319,7 @@ EZKLCONF=/path/to/fullconfig.json ezkl
 ```
 
 
+----------------------
 
 
 ## benchmarks ⏳
@@ -336,6 +341,8 @@ criterion_group! {
   targets = runrelu
 }
 ```
+----------------------
+
 
 ## onnx examples
 
@@ -348,6 +355,9 @@ If you want to add a model to `examples/onnx`, open a PR creating a new folder w
 
 
 TODO: add associated python files in the onnx model directories.
+
+----------------------
+
 
 ## library examples 🔍
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -9,10 +9,10 @@ use crate::pfsys::evm::single::gen_evm_verifier;
 use crate::pfsys::evm::{evm_verify, DeploymentCode};
 #[cfg(feature = "render")]
 use crate::pfsys::prepare_model_circuit;
-use crate::pfsys::{create_keys, load_params_kzg, load_vk, Snark};
+use crate::pfsys::{create_keys, load_params, load_vk, save_params, Snark};
 use crate::pfsys::{
-    create_proof_circuit, gen_srs, prepare_data, prepare_model_circuit_and_public_input,
-    save_params_kzg, save_vk, verify_proof_circuit,
+    create_proof_circuit, gen_srs, prepare_data, prepare_model_circuit_and_public_input, save_vk,
+    verify_proof_circuit,
 };
 use halo2_proofs::dev::VerifyFailure;
 use halo2_proofs::plonk::{Circuit, ProvingKey, VerifyingKey};
@@ -162,7 +162,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
         Commands::GenSrs { params_path } => {
             let params = gen_srs::<KZGCommitmentScheme<Bn256>>(cli.args.logrows);
-            save_params_kzg(&params_path, &params)?;
+            save_params::<KZGCommitmentScheme<Bn256>>(&params_path, &params)?;
         }
         Commands::Table { model: _ } => {
             let om = Model::from_ezkl_conf(cli)?;
@@ -236,7 +236,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
 
             let (_, public_inputs) = prepare_model_circuit_and_public_input::<Fr>(&data, &cli)?;
             let num_instance = public_inputs.iter().map(|x| x.len()).collect();
-            let mut params: ParamsKZG<Bn256> = load_params_kzg(params_path.to_path_buf())?;
+            let mut params: ParamsKZG<Bn256> =
+                load_params::<KZGCommitmentScheme<Bn256>>(params_path.to_path_buf())?;
             if cli.args.logrows < params.k() {
                 params.downsize(cli.args.logrows);
             }
@@ -263,7 +264,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             deployment_code_path,
             vk_path,
         } => {
-            let params: ParamsKZG<Bn256> = load_params_kzg(params_path)?;
+            let params: ParamsKZG<Bn256> = load_params::<KZGCommitmentScheme<Bn256>>(params_path)?;
 
             let agg_vk = load_vk::<KZGCommitmentScheme<Bn256>, Fr, AggregationCircuit>(vk_path)?;
 
@@ -287,7 +288,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             let data = prepare_data(data.to_string())?;
 
             let (circuit, public_inputs) = prepare_model_circuit_and_public_input(&data, &cli)?;
-            let mut params: ParamsKZG<Bn256> = load_params_kzg(params_path.to_path_buf())?;
+            let mut params: ParamsKZG<Bn256> =
+                load_params::<KZGCommitmentScheme<Bn256>>(params_path.to_path_buf())?;
             if cli.args.logrows < params.k() {
                 params.downsize(cli.args.logrows);
             }
@@ -339,7 +341,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             transcript,
         } => {
             // the K used for the aggregation circuit
-            let mut params: ParamsKZG<Bn256> = load_params_kzg(params_path.to_path_buf())?;
+            let mut params: ParamsKZG<Bn256> =
+                load_params::<KZGCommitmentScheme<Bn256>>(params_path.to_path_buf())?;
             if cli.args.logrows < params.k() {
                 params.downsize(cli.args.logrows);
             }
@@ -391,7 +394,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             params_path,
             transcript,
         } => {
-            let mut params: ParamsKZG<Bn256> = load_params_kzg(params_path)?;
+            let mut params: ParamsKZG<Bn256> =
+                load_params::<KZGCommitmentScheme<Bn256>>(params_path)?;
             if cli.args.logrows < params.k() {
                 params.downsize(cli.args.logrows);
             }
@@ -416,7 +420,8 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             params_path,
             transcript,
         } => {
-            let mut params: ParamsKZG<Bn256> = load_params_kzg(params_path)?;
+            let mut params: ParamsKZG<Bn256> =
+                load_params::<KZGCommitmentScheme<Bn256>>(params_path)?;
             if cli.args.logrows < params.k() {
                 params.downsize(cli.args.logrows);
             }


### PR DESCRIPTION
Recent updates made to [halo2-kzg-srs](https://github.com/han0110/halo2-kzg-srs) have made public ceremony SRS available in `RawBytes` serialization ! A current bottleneck in the proving and verification pipeline is the speed of serialization / deserialization of the SRS due to the overhead of the `Processed` serialization. 

This PR sets the serialization for vk, pk, and SRS to be of `RawBytes` form; and updates the readme instructions accordingly. 
