### PR TITLE
feat: accumulated dot product

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
         run: wasmtime run './target/wasm32-wasi/release/ezkl.wasm' -- --help
 
   benchmarks:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,15 @@ name = "affine"
 harness = false
 
 [[bench]]
+name = "dot"
+harness = false
+
+[[bench]]
+name = "accum_dot"
+harness = false
+
+
+[[bench]]
 name = "cnvrl"
 harness = false
 

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -35,9 +35,9 @@ impl Circuit<Fr> for MyCircuit {
     fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
         let len = unsafe { LEN };
 
-        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 512);
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 1024);
 
         Self::Config::configure(cs, &[a, b], &output)
     }
@@ -55,7 +55,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 8, 16, 32, 64, 128, 256].iter() {
+    for &len in [16, 256, 512].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -37,7 +37,7 @@ impl Circuit<Fr> for MyCircuit {
 
         let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
         let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let output = VarTensor::new_advice(cs, K, len, vec![1], true, 512);
+        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 512);
 
         Self::Config::configure(cs, &[a, b], &output)
     }
@@ -55,7 +55,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 8, 16, 32, 64, 128, 256, 512].iter() {
+    for &len in [4, 8, 16, 32, 64, 128, 256].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -53,9 +53,9 @@ impl Circuit<Fr> for MyCircuit {
 }
 
 fn rundot(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dot");
+    let mut group = c.benchmark_group("accum_dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [16, 256, 512].iter() {
+    for &len in [16, 512].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -1,0 +1,107 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::accumulated_dot::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = Config<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let output = VarTensor::new_advice(cs, K, len, vec![1], true, 512);
+
+        Self::Config::configure(cs, &[a, b], &output)
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.layout(&mut layouter, &self.inputs).unwrap();
+        Ok(())
+    }
+}
+
+fn rundot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dot");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [4, 8, 16, 32, 64, 128, 256, 512].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        // parameters
+        let a = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = rundot
+}
+criterion_main!(benches);

--- a/benches/dot.rs
+++ b/benches/dot.rs
@@ -37,7 +37,7 @@ impl Circuit<Fr> for MyCircuit {
 
         let a = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
         let b = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
-        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 1024);
+        let output = VarTensor::new_advice(cs, K, len, vec![1], true, 1024);
         let dot_node = Node {
             op: Op::Dot,
             input_order: vec![InputType::Input(0), InputType::Input(1)],

--- a/benches/dot.rs
+++ b/benches/dot.rs
@@ -35,9 +35,9 @@ impl Circuit<Fr> for MyCircuit {
     fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
         let len = unsafe { LEN };
 
-        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 512);
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 1024);
         let dot_node = Node {
             op: Op::Dot,
             input_order: vec![InputType::Input(0), InputType::Input(1)],
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 8, 16, 32, 64, 128, 256].iter() {
+    for &len in [16, 256, 512].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/dot.rs
+++ b/benches/dot.rs
@@ -1,0 +1,111 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::polynomial::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = Config<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let output = VarTensor::new_advice(cs, K, len, vec![1], true, 512);
+        let dot_node = Node {
+            op: Op::Dot,
+            input_order: vec![InputType::Input(0), InputType::Input(1)],
+        };
+
+        Self::Config::configure(cs, &[a, b], &output, &[dot_node])
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.layout(&mut layouter, &self.inputs).unwrap();
+        Ok(())
+    }
+}
+
+fn rundot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dot");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [4, 8, 16, 32, 64, 128, 256, 512].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        // parameters
+        let a = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = rundot
+}
+criterion_main!(benches);

--- a/benches/dot.rs
+++ b/benches/dot.rs
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [16, 256, 512].iter() {
+    for &len in [16, 512].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/dot.rs
+++ b/benches/dot.rs
@@ -37,7 +37,7 @@ impl Circuit<Fr> for MyCircuit {
 
         let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
         let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
-        let output = VarTensor::new_advice(cs, K, len, vec![1], true, 512);
+        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 512);
         let dot_node = Node {
             op: Op::Dot,
             input_order: vec![InputType::Input(0), InputType::Input(1)],
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("dot");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 8, 16, 32, 64, 128, 256, 512].iter() {
+    for &len in [4, 8, 16, 32, 64, 128, 256].iter() {
         unsafe {
             LEN = len;
         };

--- a/src/circuit/accumulated_dot.rs
+++ b/src/circuit/accumulated_dot.rs
@@ -165,7 +165,9 @@ impl<F: FieldExt + TensorType> Config<F> {
                 }
 
                 // last element is the result
-                Ok(output.get_slice(&[output.len() - 1..output.len()]))
+                Ok(output
+                    .get_slice(&[output.len() - 1..output.len()])
+                    .expect("accum poly: failed to fetch last elem"))
             },
         ) {
             Ok(a) => a,

--- a/src/circuit/accumulated_dot.rs
+++ b/src/circuit/accumulated_dot.rs
@@ -1,0 +1,237 @@
+use super::*;
+use crate::tensor::ops::*;
+use crate::tensor::{Tensor, TensorType};
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::Layouter,
+    plonk::{ConstraintSystem, Constraints, Expression, Selector},
+};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+use std::marker::PhantomData;
+
+#[allow(missing_docs)]
+/// An enum representing the operations that can be used to expressed more complex operations via accumulation
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BaseOp {
+    Dot,
+}
+
+/// Matches a [Op] to an operation in the `tensor::ops` module.
+impl BaseOp {
+    /// forward func
+    pub fn f<T: TensorType + Add<Output = T> + Sub<Output = T> + Mul<Output = T>>(
+        &self,
+        inputs: (T, T, T),
+    ) -> T {
+        let (a, b, m) = inputs;
+        match &self {
+            BaseOp::Dot => a * b + m,
+        }
+    }
+}
+
+impl fmt::Display for BaseOp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BaseOp::Dot => write!(f, "base accum dot"),
+        }
+    }
+}
+
+#[allow(missing_docs)]
+/// An enum representing the operations that can be merged into a single circuit gate.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Op {
+    Dot,
+}
+
+impl fmt::Display for Op {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Op::Dot => write!(f, "accum dot"),
+        }
+    }
+}
+
+/// Configuration for a basic sequence of operations all fused together in a single gate.
+#[derive(Clone, Debug)]
+pub struct Config<F: FieldExt + TensorType> {
+    /// the inputs to the fused operations.
+    pub inputs: Vec<VarTensor>,
+    /// the (currently singular) output of the fused operations.
+    pub output: VarTensor,
+    /// [Selector] generated when configuring the layer.
+    pub selectors: BTreeMap<BaseOp, Selector>,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt + TensorType> Config<F> {
+    /// Configures the sequence of operations into a circuit gate, represented as an array of [Node].
+    /// # Arguments
+    /// * `inputs` - The explicit inputs to the operations. [Node]s index over these inputs using their `input_order` attribute. They can also index over the intermediate outputs of other [Node]s.
+    /// * `output` - The variable representing the (currently singular) output of the fused operations.
+    /// * `nodes` - The sequence of operations (in order of execution) that constitute the fused operation.
+    pub fn configure(
+        meta: &mut ConstraintSystem<F>,
+        inputs: &[VarTensor],
+        output: &VarTensor,
+    ) -> Self {
+        // setup a selector per base op
+        let selectors = BTreeMap::from([(BaseOp::Dot, meta.selector())]);
+        let config = Self {
+            selectors,
+            inputs: inputs.to_vec(),
+            output: output.clone(),
+            _marker: PhantomData,
+        };
+
+        for (base_op, selector) in config.selectors.iter() {
+            meta.create_gate("accum dot", |meta| {
+                let selector = meta.query_selector(*selector);
+
+                let qis = config
+                    .inputs
+                    .iter()
+                    .map(|input| {
+                        input
+                            .query_rng(meta, 0, 1)
+                            .expect("poly: input query failed")[0]
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+
+                // Get output expressions for each input channel
+                let expected_output: Tensor<Expression<F>> = config
+                    .output
+                    .query_rng(meta, 0, 2)
+                    .expect("poly: output query failed");
+
+                let res = base_op.f((qis[0].clone(), qis[1].clone(), expected_output[0].clone()));
+
+                let constraints = vec![expected_output[1].clone() - res];
+
+                Constraints::with_selector(selector, constraints)
+            });
+        }
+
+        config
+    }
+
+    /// Assigns variables to the regions created when calling `configure`.
+    /// # Arguments
+    /// * `values` - The explicit values to the operations. [Node]s index over these inputs using their `input_order` attribute. They can also index over the intermediate outputs of other [Node]s.
+    /// * `layouter` - A Halo2 Layouter.
+    pub fn layout(
+        &mut self,
+        layouter: &mut impl Layouter<F>,
+        values: &[ValTensor<F>],
+    ) -> Result<ValTensor<F>, Box<dyn Error>> {
+        if values.len() != self.inputs.len() {
+            return Err(Box::new(CircuitError::DimMismatch(
+                "accum dot layout".to_string(),
+            )));
+        }
+
+        let t = match layouter.assign_region(
+            || "assign inputs",
+            |mut region| {
+                let offset = 0;
+
+                let mut inputs = vec![];
+                for (i, input) in values.iter().enumerate() {
+                    let inp = utils::value_muxer(
+                        &self.inputs[i],
+                        &{
+                            let res = self.inputs[i].assign(&mut region, offset, input)?;
+                            res.map(|e| e.value_field().evaluate())
+                        },
+                        input,
+                    );
+                    inputs.push(inp);
+                }
+
+                // Now we can assign the dot product
+                let accumulated_dot = accumulated::dot(&inputs)
+                    .expect("accum poly: dot op failed")
+                    .into();
+                let output = self.output.assign(&mut region, offset, &accumulated_dot)?;
+
+                Ok(output)
+            },
+        ) {
+            Ok(a) => a,
+            Err(e) => {
+                return Err(Box::new(e));
+            }
+        };
+
+        Ok(ValTensor::from(t))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2_proofs::{
+        arithmetic::{Field, FieldExt},
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        dev::MockProver,
+        plonk::{Circuit, ConstraintSystem, Error},
+    };
+    use halo2curves::pasta::pallas;
+    use halo2curves::pasta::Fp as F;
+    use rand::rngs::OsRng;
+
+    const K: usize = 4;
+    const LEN: usize = 2;
+
+    #[derive(Clone)]
+    struct MyCircuit<F: FieldExt + TensorType> {
+        inputs: [ValTensor<F>; 2],
+        _marker: PhantomData<F>,
+    }
+
+    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+        type Config = Config<F>;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            self.clone()
+        }
+
+        fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
+            let a = VarTensor::new_advice(cs, K, LEN, vec![LEN], true, 512);
+            let b = VarTensor::new_advice(cs, K, LEN, vec![LEN], true, 512);
+            let output = VarTensor::new_advice(cs, K, LEN, vec![LEN], true, 512);
+
+            Self::Config::configure(cs, &[a, b], &output)
+        }
+
+        fn synthesize(
+            &self,
+            mut config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            let _ = config.layout(&mut layouter, &self.inputs.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn dotcircuit() {
+        // parameters
+        let a = Tensor::from((0..LEN).map(|_| Value::known(pallas::Base::random(OsRng))));
+
+        let b = Tensor::from((0..LEN).map(|_| Value::known(pallas::Base::random(OsRng))));
+
+        let circuit = MyCircuit::<F> {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::run(K as u32, &circuit, vec![]).unwrap();
+        prover.assert_satisfied();
+    }
+}

--- a/src/circuit/accumulated_dot.rs
+++ b/src/circuit/accumulated_dot.rs
@@ -68,7 +68,7 @@ pub struct Config<F: FieldExt + TensorType> {
 }
 
 impl<F: FieldExt + TensorType> Config<F> {
-    /// Configures the sequence of operations into a circuit gate, represented as an array of [Node].
+    /// Configures the sequence of operations into a circuit gate.
     /// # Arguments
     /// * `inputs` - The explicit inputs to the operations.
     /// * `output` - The variable representing the (currently singular) output of the operations.
@@ -120,7 +120,7 @@ impl<F: FieldExt + TensorType> Config<F> {
 
     /// Assigns variables to the regions created when calling `configure`.
     /// # Arguments
-    /// * `values` - The explicit values to the operations. [Node]s index over these inputs using their `input_order` attribute. They can also index over the intermediate outputs of other [Node]s.
+    /// * `values` - The explicit values to the operations.
     /// * `layouter` - A Halo2 Layouter.
     pub fn layout(
         &mut self,

--- a/src/circuit/accumulated_dot.rs
+++ b/src/circuit/accumulated_dot.rs
@@ -164,7 +164,8 @@ impl<F: FieldExt + TensorType> Config<F> {
                         .enable(&mut region, i)?;
                 }
 
-                Ok(output)
+                // last element is the result
+                Ok(output.get_slice(&[output.len() - 1..output.len()]))
             },
         ) {
             Ok(a) => a,

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -1,4 +1,6 @@
 use crate::tensor::*;
+/// Structs and methods for configuring and assigning "accumulated" polynomial constraints to a gate within a Halo2 circuit.
+pub mod accumulated_dot;
 /// Element-wise operations using lookup tables.
 pub mod lookup;
 /// Structs and methods for configuring and assigning polynomial constraints to a gate within a Halo2 circuit.

--- a/src/circuit/polynomial.rs
+++ b/src/circuit/polynomial.rs
@@ -122,9 +122,7 @@ impl Op {
             Op::BatchNorm => scale_and_shift(&inputs),
             Op::ScaleAndShift => scale_and_shift(&inputs),
             Op::Matmul => matmul(&inputs),
-            Op::Dot => {
-                todo!();
-            }
+            Op::Dot => dot(&inputs.iter().map(|x| x).collect()),
             Op::Conv { padding, stride } => convolution(&inputs, *padding, *stride),
             Op::SumPool {
                 padding,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -88,7 +88,7 @@ fn verify_proof_circuit_kzg<
 }
 
 /// helper function
-fn create_proof_circuit_kzg<
+pub fn create_proof_circuit_kzg<
     'params,
     C: Circuit<Fr>,
     Strategy: VerificationStrategy<'params, KZGCommitmentScheme<Bn256>, VerifierGWC<'params, Bn256>>,


### PR DESCRIPTION
A foundational component of many the operations constrained using polynomial args is the _dot product_. To make inroads into addressing and informing the claims of #161 this PR: 

- Introduces an accumulated polynomial argument composed of the base gate (with constraints $a_i*bi + m{i-1} = m_i$
```bash
| a0  | a1  | m     | s_dot | 
|-----|-----|-------|-------|
| a_i | b_i |m_{i-1}| s_dot |
|     |     |m_i    |       |

```
- Introduces an accumulated dot product operations, which returns the "transcript" (i.e intermediate ops) of the dot product: 

```rust
use ezkl_lib::tensor::Tensor;
use ezkl_lib::tensor::ops::accumulated::dot;
    
let x = Tensor::<i128>::new(
         Some(&[5, 2]),
         &[2],
     ).unwrap();
let y = Tensor::<i128>::new(
         Some(&[5, 5]),
         &[2],
     ).unwrap();
let expected = Tensor::<i128>::new(
         Some(&[0, 25, 35]),
        &[3],
).unwrap();
assert_eq!(dot(&vec![x, y]).unwrap(), expected);

```

- Introduces full proving generation benchmarks for our current dot product argument and the new accumulated dot product: 

```bash
# current
cargo bench --bench dot
# accumulated
cargo bench --bench accum_dot
```

- Due to the benchmarks in the CI pipeline are now run on the larger `self-hosted` runner. 
