### PR TITLE
feat: accumulated mat-vec multiplications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,14 @@ harness = false
 name = "accum_dot"
 harness = false
 
+[[bench]]
+name = "matmul"
+harness = false
+
+[[bench]]
+name = "accum_matmul"
+harness = false
+
 
 [[bench]]
 name = "cnvrl"

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use ezkl_lib::circuit::accumulated_dot::*;
+use ezkl_lib::circuit::accumulated::dot::*;
 use ezkl_lib::commands::TranscriptType;
 use ezkl_lib::execute::create_proof_circuit_kzg;
 use ezkl_lib::pfsys::{create_keys, gen_srs};

--- a/benches/accum_matmul.rs
+++ b/benches/accum_matmul.rs
@@ -58,7 +58,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("accum_matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 32].iter() {
+    for &len in [4, 30].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/accum_matmul.rs
+++ b/benches/accum_matmul.rs
@@ -1,0 +1,112 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::accumulated::matmul::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = Config<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len, len], true, 1024);
+
+        let b = VarTensor::new_advice(cs, K, len * len, vec![len, len], true, 1024);
+
+        let output =
+            VarTensor::new_advice(cs, K, (len + 1) * len, vec![len, 1, len + 1], true, 1024);
+
+        Self::Config::configure(cs, &[a, b], &output)
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.layout(&mut layouter, &self.inputs).unwrap();
+        Ok(())
+    }
+}
+
+fn rundot(c: &mut Criterion) {
+    let mut group = c.benchmark_group("accum_matmul");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [16, 512].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        let mut a = Tensor::from((0..len * len).map(|_| Value::known(Fr::random(OsRng))));
+        a.reshape(&[len, len]);
+
+        // parameters
+        let mut b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+        b.reshape(&[len, 1]);
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = rundot
+}
+criterion_main!(benches);

--- a/benches/accum_matmul.rs
+++ b/benches/accum_matmul.rs
@@ -58,7 +58,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("accum_matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [16, 512].iter() {
+    for &len in [4, 32].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/matmul.rs
+++ b/benches/matmul.rs
@@ -1,0 +1,113 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::polynomial::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = Config<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len, len], true, 1024);
+        let b = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 1024);
+        let output = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 1024);
+        let dot_node = Node {
+            op: Op::Matmul,
+            input_order: vec![InputType::Input(0), InputType::Input(1)],
+        };
+
+        Self::Config::configure(cs, &[a, b], &output, &[dot_node])
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.layout(&mut layouter, &self.inputs).unwrap();
+        Ok(())
+    }
+}
+
+fn runmatmul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("matmul");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [4, 16].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        // parameters
+        let mut a = Tensor::from((0..len * len).map(|_| Value::known(Fr::random(OsRng))));
+        a.reshape(&[len, len]);
+
+        let mut b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+        b.reshape(&[len, 1]);
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = runmatmul
+}
+criterion_main!(benches);

--- a/benches/matmul.rs
+++ b/benches/matmul.rs
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn runmatmul(c: &mut Criterion) {
     let mut group = c.benchmark_group("matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 32].iter() {
+    for &len in [4, 30].iter() {
         unsafe {
             LEN = len;
         };

--- a/benches/matmul.rs
+++ b/benches/matmul.rs
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn runmatmul(c: &mut Criterion) {
     let mut group = c.benchmark_group("matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 16].iter() {
+    for &len in [4, 32].iter() {
         unsafe {
             LEN = len;
         };

--- a/src/circuit/accumulated/matmul.rs
+++ b/src/circuit/accumulated/matmul.rs
@@ -1,0 +1,255 @@
+use super::*;
+use crate::circuit::{utils, CircuitError};
+use crate::tensor::{ops::*, ValTensor, VarTensor};
+use crate::tensor::{Tensor, TensorType};
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::Layouter,
+    plonk::{ConstraintSystem, Constraints, Expression, Selector},
+};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::marker::PhantomData;
+
+/// Configuration for an accumulated arg.
+#[derive(Clone, Debug)]
+pub struct Config<F: FieldExt + TensorType> {
+    /// the inputs to the operations.
+    pub inputs: Vec<VarTensor>,
+    /// the (currently singular) output of the operations.
+    pub output: VarTensor,
+    /// [Selectors] generated when configuring the layer. We use a BTreeMap as we expect to configure many base gates.
+    pub selectors: BTreeMap<(BaseOp, usize), Selector>,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt + TensorType> Config<F> {
+    /// Configures the sequence of operations into a circuit gate.
+    /// # Arguments
+    /// * `inputs` - The explicit inputs to the operations.
+    /// * `output` - The variable representing the (currently singular) output of the operations.
+    /// * `op` - The operation being represented
+    pub fn configure(
+        meta: &mut ConstraintSystem<F>,
+        inputs: &[VarTensor],
+        output: &VarTensor,
+    ) -> Self {
+        // setup a selector per base op AND across columns
+        // TODO: make this more robust as we expand the module
+        let mut selectors = BTreeMap::new();
+        for i in 0..inputs[0].num_cols() {
+            selectors.insert((BaseOp::Dot, i), meta.selector());
+            selectors.insert((BaseOp::InitDot, i), meta.selector());
+        }
+
+        let config = Self {
+            selectors,
+            inputs: inputs.to_vec(),
+            output: output.clone(),
+            _marker: PhantomData,
+        };
+
+        for ((base_op, i), selector) in config.selectors.iter() {
+            meta.create_gate(base_op.as_str(), |meta| {
+                let selector = meta.query_selector(*selector);
+
+                let qis = config
+                    .inputs
+                    .iter()
+                    .map(|input| {
+                        input
+                            .query_rng(meta, i * input.col_size(), 1)
+                            .expect("accum: input query failed")[0]
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+
+                // Get output expressions for each input channel
+                let expected_output: Tensor<Expression<F>> = config
+                    .output
+                    .query_rng(meta, i * config.output.col_size(), 2)
+                    .expect("accum: output query failed");
+
+                let res = base_op.f((qis[0].clone(), qis[1].clone(), expected_output[0].clone()));
+
+                let constraints = vec![expected_output[1].clone() - res];
+
+                Constraints::with_selector(selector, constraints)
+            });
+        }
+
+        config
+    }
+
+    /// Assigns variables to the regions created when calling `configure`.
+    /// # Arguments
+    /// * `values` - The explicit values to the operations.
+    /// * `layouter` - A Halo2 Layouter.
+    pub fn layout(
+        &mut self,
+        layouter: &mut impl Layouter<F>,
+        values: &[ValTensor<F>],
+    ) -> Result<ValTensor<F>, Box<dyn Error>> {
+        if values.len() != 2 {
+            return Err(Box::new(CircuitError::DimMismatch(
+                "accum matmul layout".to_string(),
+            )));
+        };
+
+        let mut a = values[0].clone();
+        let mut b = values[1].clone();
+        // b.transpose_2d()?;
+
+        a.tile(b.dims()[1])?;
+        b.tile(a.dims()[1])?;
+
+        let t = match layouter.assign_region(
+            || "assign inputs",
+            |mut region| {
+                let offset = 0;
+
+                let mut inputs = vec![];
+
+                for (i, elem) in vec![a.clone(), b.clone()].iter().enumerate() {
+                    let inp = utils::value_muxer(
+                        &self.inputs[i],
+                        &{
+                            let res = self.inputs[i].assign(&mut region, offset, elem)?;
+                            res.map(|e| e.value_field().evaluate())
+                        },
+                        elem,
+                    );
+                    inputs.push(inp);
+                }
+
+                inputs[0] = inputs[0].get_slice(&[0..1]).unwrap();
+                inputs[0].reshape(values[0].dims());
+                inputs[1] = inputs[1].get_slice(&[0..1]).unwrap();
+                inputs[1].reshape(values[1].dims());
+
+                let accumulated_matmul =
+                    accumulated::matmul(&vec![inputs[0].clone(), inputs[1].clone()])
+                        .expect("accum poly: matmul op failed");
+
+                // remove 0 elements bar the first
+                let cleaned_matmul: Tensor<_> = accumulated_matmul
+                    .iter()
+                    .enumerate()
+                    .filter(|&(i, _)| {
+                        ((i % accumulated_matmul.dims().last().unwrap()) > 0) || i == 0
+                    })
+                    .map(|(_, v)| *v)
+                    .into();
+
+                let output = self
+                    .output
+                    .assign(&mut region, offset, &cleaned_matmul.into())?;
+
+                // these selectors map from
+                for i in 0..a.dims().iter().product::<usize>() {
+                    let (x, y) = self.inputs[0].cartesian_coord(i);
+                    if (i) % b.dims()[1] > 0 || i == 0 {
+                        self.selectors
+                            .get(&(BaseOp::Dot, x))
+                            .unwrap()
+                            .enable(&mut region, y)?;
+                    } else {
+                        self.selectors
+                            .get(&(BaseOp::InitDot, x))
+                            .unwrap()
+                            .enable(&mut region, y)?;
+                    }
+                }
+
+                let dims = output.dims();
+                let mut last_dims = vec![];
+
+                for d in &dims[0..dims.len() - 1] {
+                    last_dims.push(0..*d);
+                }
+                let script_len = dims.last().unwrap();
+                last_dims.push(script_len - 1..*script_len);
+                // Now we can assign the matmul op
+                Ok({
+                    output
+                        .get_slice(&last_dims)
+                        .expect("accum poly: failed to fetch last elem")
+                })
+            },
+        ) {
+            Ok(a) => a,
+            Err(e) => {
+                return Err(Box::new(e));
+            }
+        };
+
+        Ok(ValTensor::from(t))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use halo2_proofs::{
+        arithmetic::{Field, FieldExt},
+        circuit::{Layouter, SimpleFloorPlanner, Value},
+        dev::MockProver,
+        plonk::{Circuit, ConstraintSystem, Error},
+    };
+    use halo2curves::pasta::pallas;
+    use halo2curves::pasta::Fp as F;
+    use rand::rngs::OsRng;
+
+    const K: usize = 5;
+    const LEN: usize = 8;
+
+    #[derive(Clone)]
+    struct AffineCircuit<F: FieldExt + TensorType> {
+        inputs: [ValTensor<F>; 2],
+        _marker: PhantomData<F>,
+    }
+
+    impl<F: FieldExt + TensorType> Circuit<F> for AffineCircuit<F> {
+        type Config = Config<F>;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            self.clone()
+        }
+
+        fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
+            let a = VarTensor::new_advice(cs, K, LEN * LEN, vec![LEN, LEN], true, 512);
+            let b = VarTensor::new_advice(cs, K, LEN * LEN, vec![LEN, LEN], true, 512);
+            let output =
+                VarTensor::new_advice(cs, K, (LEN + 1) * LEN, vec![LEN + 1, 1, LEN], true, 512);
+            Self::Config::configure(cs, &[a, b], &output)
+        }
+
+        fn synthesize(
+            &self,
+            mut config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            let _ = config.layout(&mut layouter, &self.inputs.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn matmulcircuit() {
+        // parameters
+        let mut a = Tensor::from((0..LEN * LEN).map(|_| Value::known(pallas::Base::random(OsRng))));
+        a.reshape(&[LEN, LEN]);
+
+        let mut w = Tensor::from((0..LEN).map(|_| Value::known(pallas::Base::random(OsRng))));
+        w.reshape(&[LEN, 1]);
+
+        let circuit = AffineCircuit::<F> {
+            inputs: [ValTensor::from(a), ValTensor::from(w)],
+            _marker: PhantomData,
+        };
+
+        let prover = MockProver::run(K as u32, &circuit, vec![]).unwrap();
+        prover.assert_satisfied();
+    }
+}

--- a/src/circuit/accumulated/mod.rs
+++ b/src/circuit/accumulated/mod.rs
@@ -1,0 +1,53 @@
+use crate::tensor::TensorType;
+use std::{
+    fmt,
+    ops::{Add, Mul, Sub},
+};
+
+#[allow(missing_docs)]
+/// An enum representing the operations that can be used to express more complex operations via accumulation
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BaseOp {
+    Dot,
+    InitDot,
+    Add,
+}
+
+/// Matches a [Op] to an operation in the `tensor::ops` module.
+impl BaseOp {
+    /// forward func
+    pub fn f<T: TensorType + Add<Output = T> + Sub<Output = T> + Mul<Output = T>>(
+        &self,
+        inputs: (T, T, T),
+    ) -> T {
+        let (a, b, m) = inputs;
+        match &self {
+            BaseOp::InitDot => a * b,
+            BaseOp::Dot => a * b + m,
+            BaseOp::Add => b + m,
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            BaseOp::InitDot => "INITDOT",
+            BaseOp::Dot => "DOT",
+            BaseOp::Add => "ADD",
+        }
+    }
+}
+
+impl fmt::Display for BaseOp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BaseOp::InitDot => write!(f, "base accum init dot"),
+            BaseOp::Dot => write!(f, "base accum dot"),
+            BaseOp::Add => write!(f, "base accum add"),
+        }
+    }
+}
+
+/// Accumulated dot product
+pub mod dot;
+/// Accumulated matmul op
+pub mod matmul;

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -1,6 +1,6 @@
 use crate::tensor::*;
 /// Structs and methods for configuring and assigning "accumulated" polynomial constraints to a gate within a Halo2 circuit.
-pub mod accumulated_dot;
+pub mod accumulated;
 /// Element-wise operations using lookup tables.
 pub mod lookup;
 /// Structs and methods for configuring and assigning polynomial constraints to a gate within a Halo2 circuit.

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -455,12 +455,12 @@ impl<T: Clone + TensorType> Tensor<T> {
             let index = self.get_index(&e);
             res.push(self[index].clone())
         }
-        let mut dims: Vec<usize> = full_indices.iter().map(|e| e.end - e.start).collect();
-        for i in (0..indices.len()).rev() {
-            if (dims[i] == 1) && (dims.len() > 1) {
-                dims.remove(i);
-            }
-        }
+        let dims: Vec<usize> = full_indices.iter().map(|e| e.end - e.start).collect();
+        // for i in (0..indices.len()).rev() {
+        //     if (dims[i] == 1) && (dims.len() > 1) {
+        //         dims.remove(i);
+        //     }
+        // }
 
         Tensor::new(Some(&res), &dims)
     }

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -121,6 +121,13 @@ impl VarTensor {
         }
     }
 
+    /// Gets the size of each column
+    pub fn col_size(&self) -> usize {
+        match self {
+            VarTensor::Advice { col_size, .. } | VarTensor::Fixed { col_size, .. } => *col_size,
+        }
+    }
+
     /// Gets the dims of the object the VarTensor represents
     pub fn dims(&self) -> Vec<usize> {
         match self {
@@ -280,6 +287,7 @@ impl VarTensor {
             ValTensor::Value { inner: v, .. } => v.enum_map(|coord, k| match &self {
                 VarTensor::Fixed { inner: fixed, .. } => {
                     let (x, y) = self.cartesian_coord(offset + coord);
+
                     region.assign_fixed(|| "k", fixed[x], y, || k)
                 }
                 VarTensor::Advice { inner: advices, .. } => {


### PR DESCRIPTION
A foundational component of many the operations constrained using polynomial args is the _matrix to vector multiplication_. To make inroads into addressing and informing the claims of #161 this PR build on the accumulated dot product introduced in #162 . 

- Introduces an "init" polynomial argument composed of the base gate (with constraints $a_i*bi = m_i$
```bash
| a0  | a1  | m     | s_dot | 
|-----|-----|-------|-------|
| a_i | b_i | _     | s_dot |
|     |     | m_i   |       |

```

- This gate is used whenever the column enters a "new" matrix row to vector column dot product within an advice column. 
- Introduces an accumulated matrix multiplication, which returns the "transcript" (i.e intermediate ops) of the matmul: 

```rust
use ezkl_lib::tensor::Tensor;
use ezkl_lib::tensor::ops::accumulated::matmul;

let x = Tensor::<i128>::new(
         Some(&[5, 2, 3]),
         &[3, 1],
     ).unwrap();
let k = Tensor::<i128>::new(
         Some(&[2, 1, 2, 1, 1, 1]),
         &[2, 3],
     ).unwrap();
let result = matmul(&vec![k, x]).unwrap();
let expected = Tensor::<i128>::new(Some(&[0, 10, 12, 18, 0, 5, 7, 10]), &[2, 1, 4]).unwrap();
assert_eq!(result, expected);

```

- Introduces full proving generation benchmarks for our current dot product argument and the new accumulated mat-vec product: 

```bash
# current
cargo bench --bench matmul
# accumulated
cargo bench --bench accum_matmul
```

- Overview of process for laying out the accumulated mat-vec multiplication:

1. The input vector `b` is tiled N times such that b is of the same dimensionality as `a` the multiplying matrix.  
2. We assign the the tiled `b` and tiled `a` to the advices. 
3. We calculate the accumulated matrix multiplication between `a` and `b`. By design this returns a transcript of each row-col dot product; which are prepended with 0s. We remove the intermediate 0s from the transcripts; at each position where a 0 appeared we apply the new  "init" dot gate. Otherwise we apply the accumulated dot product gate detailed in #162 .

> Note: More general matrix multiplication currently breaks and requires some more thoughts as to how `a` is repeated / tiled as a function of the dimensionality of `b`. 

