### PR TITLE
feat: accumulated mat-mat mul

### DIFF
--- a/benches/accum_matmul.rs
+++ b/benches/accum_matmul.rs
@@ -35,12 +35,12 @@ impl Circuit<Fr> for MyCircuit {
     fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
         let len = unsafe { LEN };
 
-        let a = VarTensor::new_advice(cs, K, len, vec![len, len], true, 1024);
+        let a = VarTensor::new_advice(cs, K, len * len, vec![len, len], true, 100000);
 
-        let b = VarTensor::new_advice(cs, K, len * len, vec![len, len], true, 1024);
+        let b = VarTensor::new_advice(cs, K, len * len, vec![len, len], true, 100000);
 
         let output =
-            VarTensor::new_advice(cs, K, (len + 1) * len, vec![len, 1, len + 1], true, 1024);
+            VarTensor::new_advice(cs, K, (len + 1) * len, vec![len, 1, len + 1], true, 100000);
 
         Self::Config::configure(cs, &[a, b], &output)
     }
@@ -58,7 +58,7 @@ impl Circuit<Fr> for MyCircuit {
 fn rundot(c: &mut Criterion) {
     let mut group = c.benchmark_group("accum_matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 30].iter() {
+    for &len in [32].iter() {
         unsafe {
             LEN = len;
         };
@@ -67,8 +67,8 @@ fn rundot(c: &mut Criterion) {
         a.reshape(&[len, len]);
 
         // parameters
-        let mut b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
-        b.reshape(&[len, 1]);
+        let mut b = Tensor::from((0..len * len).map(|_| Value::known(Fr::random(OsRng))));
+        b.reshape(&[len, len]);
 
         let circuit = MyCircuit {
             inputs: [ValTensor::from(a), ValTensor::from(b)],

--- a/benches/matmul.rs
+++ b/benches/matmul.rs
@@ -35,9 +35,9 @@ impl Circuit<Fr> for MyCircuit {
     fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
         let len = unsafe { LEN };
 
-        let a = VarTensor::new_advice(cs, K, len, vec![len, len], true, 1024);
-        let b = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 1024);
-        let output = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 1024);
+        let a = VarTensor::new_advice(cs, K, len * len, vec![len, len], true, 100000);
+        let b = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 100000);
+        let output = VarTensor::new_advice(cs, K, len, vec![len, 1], true, 100000);
         let dot_node = Node {
             op: Op::Matmul,
             input_order: vec![InputType::Input(0), InputType::Input(1)],
@@ -59,7 +59,7 @@ impl Circuit<Fr> for MyCircuit {
 fn runmatmul(c: &mut Criterion) {
     let mut group = c.benchmark_group("matmul");
     let params = gen_srs::<KZGCommitmentScheme<_>>(17);
-    for &len in [4, 30].iter() {
+    for &len in [4, 32].iter() {
         unsafe {
             LEN = len;
         };
@@ -68,8 +68,8 @@ fn runmatmul(c: &mut Criterion) {
         let mut a = Tensor::from((0..len * len).map(|_| Value::known(Fr::random(OsRng))));
         a.reshape(&[len, len]);
 
-        let mut b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
-        b.reshape(&[len, 1]);
+        let mut b = Tensor::from((0..len * len).map(|_| Value::known(Fr::random(OsRng))));
+        b.reshape(&[len, len]);
 
         let circuit = MyCircuit {
             inputs: [ValTensor::from(a), ValTensor::from(b)],

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -512,9 +512,7 @@ pub fn fix_verifier_sol(input_file: PathBuf) -> Result<String, Box<dyn Error>> {
         let m = mstore_pattern.captures(&line);
         if m.is_some() {
             let mstore = m.as_ref().unwrap().get(1).unwrap().as_str();
-            println!("{:?}", m);
             let addr = m.as_ref().unwrap().get(2).unwrap().as_str();
-            println!("{}", addr);
             let addr_as_num = u32::from_str_radix(addr, 16)?;
             let transcript_addr = format!("{:#x}", addr_as_num);
             transcript_addrs.push(addr_as_num);
@@ -546,7 +544,6 @@ pub fn fix_verifier_sol(input_file: PathBuf) -> Result<String, Box<dyn Error>> {
             let mload = m.as_ref().unwrap().get(1).unwrap().as_str();
             let addr = m.as_ref().unwrap().get(2).unwrap().as_str();
 
-            println!("{}", addr);
             let addr_as_num = u32::from_str_radix(addr.strip_prefix("0x").unwrap(), 16)?;
             let transcript_addr = format!("{:#x}", addr_as_num);
             transcript_addrs.push(addr_as_num);

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -228,6 +228,50 @@ impl<F: FieldExt + TensorType> ValTensor<F> {
         Ok(())
     }
 
+    /// Calls `repeat_rows` on the inner [Tensor].
+    pub fn repeat_rows(&mut self, n: usize) -> Result<(), TensorError> {
+        match self {
+            ValTensor::Value { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::AssignedValue { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::PrevAssigned { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::Instance { .. } => {
+                return Err(TensorError::WrongMethod);
+            }
+        }
+        Ok(())
+    }
+
+    /// Calls `repeat_rows` on the inner [Tensor].
+    pub fn every_n_rows(&mut self, n: usize) -> Result<(), TensorError> {
+        match self {
+            ValTensor::Value { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::AssignedValue { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::PrevAssigned { inner: v, dims: d } => {
+                *v = v.repeat_rows(n)?;
+                *d = v.dims().to_vec();
+            }
+            ValTensor::Instance { .. } => {
+                return Err(TensorError::WrongMethod);
+            }
+        }
+        Ok(())
+    }
+
     /// Calls `tile` on the inner [Tensor].
     pub fn concat(&self, other: Self) -> Result<Self, TensorError> {
         let res = match (self, other) {


### PR DESCRIPTION
#165 previously introduced accumulated mat-vec multiplication; but remaining shape issues prevented full mat-mat multiplication. 

Here we resolve those issues by: 

1. Matrix `a` (m x n) has its rows repeated k times, 
2. Matrix `b` (n x k)  has its columns repeated m times. 
3. We assigned the repeated matrices side by side. 