### PR TITLE
feat: pairwise add, sub, mul

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,10 @@ jobs:
         run: cargo bench --verbose --bench sumpool
       - name: Bench accum sumpool
         run: cargo bench --verbose --bench accum_sumpool
+      - name: Bench add
+        run: cargo bench --verbose --bench add
+      - name: Bench pairwise add
+        run: cargo bench --verbose --bench pairwise_add
 
   docs:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,14 @@ name = "accum_dot"
 harness = false
 
 [[bench]]
+name = "add"
+harness = false
+
+[[bench]]
+name = "pairwise_add"
+harness = false
+
+[[bench]]
 name = "matmul"
 harness = false
 

--- a/benches/add.rs
+++ b/benches/add.rs
@@ -1,0 +1,111 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::polynomial::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = Config<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let output = VarTensor::new_advice(cs, K, len, vec![len], true, 512);
+        let add_node = Node {
+            op: Op::Add,
+            input_order: vec![InputType::Input(0), InputType::Input(1)],
+        };
+
+        Self::Config::configure(cs, &[a, b], &output, &[add_node])
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.layout(&mut layouter, &self.inputs).unwrap();
+        Ok(())
+    }
+}
+
+fn runadd(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [16].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        // parameters
+        let a = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = runadd
+}
+criterion_main!(benches);

--- a/benches/pairwise_add.rs
+++ b/benches/pairwise_add.rs
@@ -1,0 +1,109 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl_lib::circuit::accumulated::*;
+use ezkl_lib::commands::TranscriptType;
+use ezkl_lib::execute::create_proof_circuit_kzg;
+use ezkl_lib::pfsys::{create_keys, gen_srs};
+use ezkl_lib::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    arithmetic::Field,
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use rand::rngs::OsRng;
+use std::marker::PhantomData;
+
+static mut LEN: usize = 4;
+const K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = BaseConfig<Fr>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+
+        let a = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let b = VarTensor::new_advice(cs, K, len, vec![len], true, 1024);
+        let output = VarTensor::new_advice(cs, K, len, vec![len + 1], true, 1024);
+
+        Self::Config::configure(cs, &[a, b], &output, CheckMode::SAFE)
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config
+            .layout(&mut layouter, &self.inputs, 0, Op::Add)
+            .unwrap();
+        Ok(())
+    }
+}
+
+fn runadd(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pairwise_add");
+    let params = gen_srs::<KZGCommitmentScheme<_>>(17);
+    for &len in [16, 512].iter() {
+        unsafe {
+            LEN = len;
+        };
+
+        // parameters
+        let a = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let b = Tensor::from((0..len).map(|_| Value::known(Fr::random(OsRng))));
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("pk", len), &len, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(len as u64));
+        group.bench_with_input(BenchmarkId::new("prove", len), &len, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::Blake,
+                    SingleStrategy::new(&params),
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots();
+  targets = runadd
+}
+criterion_main!(benches);


### PR DESCRIPTION
To make inroads into addressing and informing the claims of #161 this PR: 

- Introduces pairwise polynomial arguments composed of the base gates (with constraints $a_i + bi = m_i$, $a_i * bi = m_i$, $a_i -bi = m_i$
```bash
| a0  | a1  | m     | s | 
|-----|-----|-------|-------|
| a_i | b_i |m_{i}| s |

```

- Adds unit tests
- Adds benchmarks