### PR TITLE
fix: patch 1.71 clap qualifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
     trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
-    unused_qualifications,
     missing_debug_implementations,
     unsafe_code
 )]


### PR DESCRIPTION
As helpfully detailed in #199 nightly 1.71 release of rust/cargo treats `#[clap(flatten)]` as an unnecessary qualification  -- even though removing such a qualification means the cli doesn't compile (wonder if this is a broader bug ?). This PR relaxes some of our warning denials for `unnecessary_qualifications` to enable support for `1.71-nightly`. 

Thanks to @0xhank for catching this :) 

Resolves #199 