### PR TITLE
feat: iff op

### DIFF
--- a/src/circuit/ops/mod.rs
+++ b/src/circuit/ops/mod.rs
@@ -41,8 +41,8 @@ pub trait Op<F: FieldExt + TensorType>: std::fmt::Debug + Send + Sync {
     }
 
     ///
-    fn requires_homogenous_input_scales(&self) -> bool {
-        false
+    fn requires_homogenous_input_scales(&self) -> Vec<usize> {
+        vec![]
     }
 
     ///

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -288,6 +288,7 @@ pub fn new_op_from_onnx<F: FieldExt + TensorType>(
         "Add" => Box::new(PolyOp::Add { a: None }),
         "Sub" => Box::new(PolyOp::Sub),
         "Mul" => Box::new(PolyOp::Mult { a: None }),
+        "Iff" => Box::new(PolyOp::Iff),
         "Greater" => {
             todo!()
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -40,7 +40,7 @@ fn init() {
     assert!(status.success());
 }
 
-const TESTS: [&str; 28] = [
+const TESTS: [&str; 29] = [
     "1l_mlp",
     "1l_flatten",
     "1l_average",
@@ -52,7 +52,7 @@ const TESTS: [&str; 28] = [
     "1l_sqrt",
     // "1l_instance_norm",
     "1l_batch_norm",
-    // "1l_prelu",
+    "1l_prelu",
     "1l_leakyrelu",
     "1l_gelu_noappx",
     // "1l_gelu_tanh_appx",
@@ -214,7 +214,7 @@ macro_rules! test_func {
             }
 
 
-            seq!(N in 0..=27 {
+            seq!(N in 0..=28 {
 
             #(#[test_case(TESTS[N])])*
             fn render_circuit_(test: &str) {


### PR DESCRIPTION
Creates the iff op which takes in three inputs `mask,a,b`: 
 
```rust
if mask > 0 { a } else { b }
```

It constrains mask to be boolean using the `IsBool` selector. 

As PreLu is gets decomposed into a Iff + other ops we use a prelu integration test to test the op. 