### PR TITLE
chore: upgrade  `halo2curves`, `halo2proofs`, `halo2wrong` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,9 +1255,8 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecc"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
 dependencies = [
- "group 0.12.1",
  "integer",
  "num-bigint",
  "num-integer",
@@ -1305,9 +1304,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.6",
- "ff 0.13.0",
+ "ff",
  "generic-array 0.14.6",
- "group 0.13.0",
+ "group",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1769,7 +1768,7 @@ dependencies = [
  "ethers-solc",
  "getrandom",
  "halo2_proofs",
- "halo2curves 0.3.1",
+ "halo2curves",
  "hex",
  "itertools",
  "lazy_static",
@@ -1809,21 +1808,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec 1.0.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec 1.0.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2162,22 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2220,13 +2198,14 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2?tag=v2023_02_02#0a8646b78286a13d320759b1c585262d6536dce4"
+source = "git+https://github.com/privacy-scaling-explorations/halo2?tag=v2023_04_20#0d56c57a074915e2b6092fb9a0f3792fd71d8df8"
 dependencies = [
  "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "halo2curves 0.3.1",
+ "ff",
+ "group",
+ "halo2curves",
  "plotters",
+ "rand_chacha",
  "rand_core 0.6.4",
  "rayon",
  "sha3 0.9.1",
@@ -2236,32 +2215,16 @@ dependencies = [
 
 [[package]]
 name = "halo2curves"
-version = "0.2.1"
-source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.0#83c72d49762343ffc9576ca11a2aa615efe1029b"
+version = "0.3.2"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.2#9f5c50810bbefe779ee5cf1d852b2fe85dc35d5e"
 dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
+ "ff",
+ "group",
  "lazy_static",
  "num-bigint",
  "num-traits",
  "pasta_curves",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "halo2curves"
-version = "0.3.1"
-source = "git+https://github.com/privacy-scaling-explorations/halo2curves?tag=0.3.1#9b67e19bca30a35208b0c1b41c1723771e2c9f49"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "num-bigint",
- "num-traits",
- "pasta_curves",
+ "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "static_assertions",
@@ -2271,9 +2234,8 @@ dependencies = [
 [[package]]
 name = "halo2wrong"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
 dependencies = [
- "group 0.12.1",
  "halo2_proofs",
  "num-bigint",
  "num-integer",
@@ -2629,9 +2591,8 @@ dependencies = [
 [[package]]
 name = "integer"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
 dependencies = [
- "group 0.12.1",
  "maingate",
  "num-bigint",
  "num-integer",
@@ -2931,9 +2892,8 @@ dependencies = [
 [[package]]
 name = "maingate"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_02_02#5905a20b62fcd9f6c269416a39c80de7ced8fb02"
+source = "git+https://github.com/privacy-scaling-explorations/halo2wrong?tag=v2023_04_20#f72db265aa3cebe297c9b9816e940d0e1d400886"
 dependencies = [
- "group 0.12.1",
  "halo2wrong",
  "num-bigint",
  "num-integer",
@@ -3434,13 +3394,13 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
+ "ff",
+ "group",
  "lazy_static",
  "rand 0.8.5",
  "static_assertions",
@@ -3736,10 +3696,9 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.2.0"
-source = "git+https://github.com/privacy-scaling-explorations/poseidon.git?tag=v2022_10_22#5d29df01a95e3df6334080d28e983407f56b5da3"
+source = "git+https://github.com/privacy-scaling-explorations/poseidon.git?tag=v2023_04_20#807f8f555313f726ca03bdf941f798098f488ba4"
 dependencies = [
- "group 0.12.1",
- "halo2curves 0.2.1",
+ "halo2curves",
  "subtle",
 ]
 
@@ -4749,12 +4708,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2023_02_02#df03d898b841f71cbc36c2fb9fa07b8196f9623e"
+source = "git+https://github.com/privacy-scaling-explorations/snark-verifier?tag=v2023_04_20#e5d5e4a6ccff2bba71baf77ab7a12b124d6364a1"
 dependencies = [
  "bytes",
  "ecc",
  "halo2_proofs",
- "halo2curves 0.3.1",
+ "halo2curves",
  "hex",
  "itertools",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_02_02"}
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.1" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_04_20"}
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.2" }
 rand = "0.8"
 itertools = "0.10.3"
 tensorflow = {version = "0.18.0", features = ["eager"], optional = true }
@@ -29,8 +29,8 @@ tabled = { version = "0.9.0", optional = true}
 thiserror = "1.0.38"
 hex = "0.4.3"
 ethereum_types = { package = "ethereum-types", version = "0.14.1", default-features = false, features = ["std"]}
-halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_02_02"}
-snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_02_02"}
+halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", package = "ecc", tag = "v2023_04_20"}
+snark-verifier = { git = "https://github.com/privacy-scaling-explorations/snark-verifier", tag = "v2023_04_20"}
 regex = "1"
 colored = { version = "2.0.0", optional = true}
 env_logger = { version = "0.10.0", optional = true}

--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -6,7 +6,6 @@ use ezkl_lib::fieldutils::i32_to_felt;
 use ezkl_lib::tensor::*;
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{
         create_proof, keygen_pk, keygen_vk, verify_proof, Circuit, Column, ConstraintSystem, Error,
@@ -25,6 +24,7 @@ use halo2_proofs::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
     },
 };
+use halo2curves::ff::PrimeField;
 use halo2curves::pasta::vesta;
 use halo2curves::pasta::Fp as F;
 use mnist::*;
@@ -37,7 +37,7 @@ const K: usize = 20;
 
 #[derive(Clone)]
 struct Config<
-    F: FieldExt + TensorType,
+    F: PrimeField + TensorType + PartialOrd,
     const LEN: usize, //LEN = CHOUT x OH x OW flattened //not supported yet in rust stable
     const CLASSES: usize,
     const BITS: usize,
@@ -61,7 +61,7 @@ struct Config<
 
 #[derive(Clone)]
 struct MyCircuit<
-    F: FieldExt + TensorType,
+    F: PrimeField + TensorType + PartialOrd,
     const LEN: usize, //LEN = CHOUT x OH x OW flattened
     const CLASSES: usize,
     const BITS: usize,
@@ -85,7 +85,7 @@ struct MyCircuit<
 }
 
 impl<
-        F: FieldExt + TensorType,
+        F: PrimeField + TensorType + PartialOrd,
         const LEN: usize,
         const CLASSES: usize,
         const BITS: usize,

--- a/examples/mlp_4d.rs
+++ b/examples/mlp_4d.rs
@@ -5,24 +5,24 @@ use ezkl_lib::fieldutils::i32_to_felt;
 use ezkl_lib::tensor::*;
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Circuit, Column, ConstraintSystem, Error, Instance},
 };
+use halo2curves::ff::PrimeField;
 use halo2curves::pasta::Fp as F;
 use std::marker::PhantomData;
 
 const K: usize = 15;
 // A columnar ReLu MLP
 #[derive(Clone)]
-struct MyConfig<F: FieldExt + TensorType> {
+struct MyConfig<F: PrimeField + TensorType + PartialOrd> {
     layer_config: PolyConfig<F>,
     public_output: Column<Instance>,
 }
 
 #[derive(Clone)]
 struct MyCircuit<
-    F: FieldExt + TensorType,
+    F: PrimeField + TensorType + PartialOrd,
     const LEN: usize, //LEN = CHOUT x OH x OW flattened
     const BITS: usize,
 > {
@@ -34,7 +34,7 @@ struct MyCircuit<
     _marker: PhantomData<F>,
 }
 
-impl<F: FieldExt + TensorType, const LEN: usize, const BITS: usize> Circuit<F>
+impl<F: PrimeField + TensorType + PartialOrd, const LEN: usize, const BITS: usize> Circuit<F>
     for MyCircuit<F, LEN, BITS>
 {
     type Config = MyConfig<F>;

--- a/src/circuit/ops/hybrid.rs
+++ b/src/circuit/ops/hybrid.rs
@@ -1,5 +1,4 @@
 use halo2_proofs::circuit::Region;
-use halo2curves::FieldExt;
 
 use crate::{
     circuit::layouts,
@@ -7,6 +6,7 @@ use crate::{
 };
 
 use super::{lookup::LookupOp, Op};
+use halo2curves::ff::PrimeField;
 
 #[allow(missing_docs)]
 /// An enum representing the operations that can be used to express more complex operations via accumulation
@@ -25,7 +25,7 @@ pub enum HybridOp {
     },
 }
 
-impl<F: FieldExt + TensorType> Op<F> for HybridOp {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
     /// Matches a [Op] to an operation in the `tensor::ops` module.
     fn f(&self, inputs: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError> {
         match &self {

--- a/src/circuit/ops/layouts.rs
+++ b/src/circuit/ops/layouts.rs
@@ -2,6 +2,7 @@ use core::panic;
 use std::error::Error;
 
 use halo2_proofs::circuit::{Region, Value};
+use halo2curves::ff::PrimeField;
 use itertools::Itertools;
 use log::error;
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -23,7 +24,7 @@ use crate::{
 use super::*;
 use crate::circuit::ops::lookup::LookupOp;
 
-fn allocate_multi_dot<F: FieldExt + TensorType>(
+fn allocate_multi_dot<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     a: &mut [ValTensor<F>],
@@ -107,7 +108,7 @@ fn allocate_multi_dot<F: FieldExt + TensorType>(
 }
 
 /// Dot product accumulated layout
-pub fn dot<F: FieldExt + TensorType>(
+pub fn dot<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 2],
@@ -189,7 +190,7 @@ pub fn dot<F: FieldExt + TensorType>(
 }
 
 /// Sum accumulated layout
-pub fn sum<F: FieldExt + TensorType>(
+pub fn sum<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -264,7 +265,7 @@ pub fn sum<F: FieldExt + TensorType>(
 }
 
 /// Sum accumulated layout
-pub fn sum_axes<F: FieldExt + TensorType>(
+pub fn sum_axes<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -316,7 +317,7 @@ pub fn sum_axes<F: FieldExt + TensorType>(
 }
 
 /// Max accumulated layout
-pub fn max_axes<F: FieldExt + TensorType>(
+pub fn max_axes<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -368,7 +369,7 @@ pub fn max_axes<F: FieldExt + TensorType>(
 }
 
 /// Min accumulated layout
-pub fn min_axes<F: FieldExt + TensorType>(
+pub fn min_axes<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -420,7 +421,7 @@ pub fn min_axes<F: FieldExt + TensorType>(
 }
 
 /// Pairwise (elementwise) op layout
-pub fn pairwise<F: FieldExt + TensorType>(
+pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 2],
@@ -521,7 +522,7 @@ pub fn pairwise<F: FieldExt + TensorType>(
 }
 
 /// Matrix multiplication accumulated layout
-pub fn matmul<F: FieldExt + TensorType>(
+pub fn matmul<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 2],
@@ -621,7 +622,7 @@ pub fn matmul<F: FieldExt + TensorType>(
 }
 
 /// Iff
-pub fn iff<F: FieldExt + TensorType>(
+pub fn iff<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 3],
@@ -692,7 +693,7 @@ pub fn iff<F: FieldExt + TensorType>(
 }
 
 /// Negation operation accumulated layout
-pub fn neg<F: FieldExt + TensorType>(
+pub fn neg<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -724,7 +725,7 @@ pub fn neg<F: FieldExt + TensorType>(
 }
 
 /// Sumpool accumulated layout
-pub fn sumpool<F: FieldExt + TensorType>(
+pub fn sumpool<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>],
@@ -791,7 +792,7 @@ pub fn sumpool<F: FieldExt + TensorType>(
 }
 
 /// Convolution accumulated layout
-pub fn max_pool2d<F: FieldExt + TensorType>(
+pub fn max_pool2d<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -859,7 +860,7 @@ pub fn max_pool2d<F: FieldExt + TensorType>(
 }
 
 /// Convolution accumulated layout
-pub fn conv<F: FieldExt + TensorType + std::marker::Send + std::marker::Sync>(
+pub fn conv<F: PrimeField + TensorType + PartialOrd + std::marker::Send + std::marker::Sync>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>],
@@ -1023,7 +1024,7 @@ pub fn conv<F: FieldExt + TensorType + std::marker::Send + std::marker::Sync>(
 }
 
 /// Power accumulated layout
-pub fn pow<F: FieldExt + TensorType>(
+pub fn pow<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1065,7 +1066,7 @@ pub fn pow<F: FieldExt + TensorType>(
 }
 
 /// Rescaled op accumulated layout
-pub fn rescale<F: FieldExt + TensorType>(
+pub fn rescale<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>],
@@ -1110,7 +1111,7 @@ pub fn rescale<F: FieldExt + TensorType>(
 }
 
 /// Pack accumulated layout
-pub fn pack<F: FieldExt + TensorType>(
+pub fn pack<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1168,7 +1169,7 @@ pub fn pack<F: FieldExt + TensorType>(
 }
 
 /// Dummy (no contraints) reshape layout
-pub fn reshape<F: FieldExt + TensorType>(
+pub fn reshape<F: PrimeField + TensorType + PartialOrd>(
     values: &[ValTensor<F>; 1],
     new_dims: &[usize],
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
@@ -1178,7 +1179,7 @@ pub fn reshape<F: FieldExt + TensorType>(
 }
 
 /// Identity constraint. Usually used to constrain an instance column to an advice so the returned cells / values can be operated upon.
-pub fn identity<F: FieldExt + TensorType>(
+pub fn identity<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1192,7 +1193,7 @@ pub fn identity<F: FieldExt + TensorType>(
 }
 
 /// Layout for range check.
-pub fn range_check<F: FieldExt + TensorType>(
+pub fn range_check<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 2],
@@ -1221,7 +1222,7 @@ pub fn range_check<F: FieldExt + TensorType>(
 }
 
 /// Layout for range check.
-pub fn nonlinearity<F: FieldExt + TensorType>(
+pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1276,7 +1277,7 @@ pub fn nonlinearity<F: FieldExt + TensorType>(
 }
 
 /// mean function layout
-pub fn mean<F: FieldExt + TensorType>(
+pub fn mean<F: PrimeField + TensorType + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1293,7 +1294,7 @@ pub fn mean<F: FieldExt + TensorType>(
 }
 
 /// max layout
-pub fn max<F: FieldExt + TensorType>(
+pub fn max<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],
@@ -1407,7 +1408,7 @@ pub fn max<F: FieldExt + TensorType>(
 }
 
 /// min layout
-pub fn min<F: FieldExt + TensorType>(
+pub fn min<F: PrimeField + TensorType + PartialOrd + PartialOrd>(
     config: &mut BaseConfig<F>,
     region: &mut Option<&mut Region<F>>,
     values: &[ValTensor<F>; 1],

--- a/src/circuit/ops/lookup.rs
+++ b/src/circuit/ops/lookup.rs
@@ -1,6 +1,5 @@
 use super::*;
 use halo2_proofs::circuit::Region;
-use halo2curves::FieldExt;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 
@@ -12,6 +11,7 @@ use crate::{
 };
 
 use super::Op;
+use halo2curves::ff::PrimeField;
 
 #[allow(missing_docs)]
 /// An enum representing the operations that can be used to express more complex operations via accumulation
@@ -31,7 +31,7 @@ pub enum LookupOp {
 
 impl LookupOp {
     /// a value which is always in the table
-    pub fn default_pair<F: FieldExt + TensorType>(&self) -> (F, F) {
+    pub fn default_pair<F: PrimeField + TensorType + PartialOrd>(&self) -> (F, F) {
         let x = vec![0_i128].into_iter().into();
         (
             <F as TensorType>::zero().unwrap(),
@@ -40,7 +40,7 @@ impl LookupOp {
     }
 }
 
-impl<F: FieldExt + TensorType> Op<F> for LookupOp {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for LookupOp {
     /// Matches a [Op] to an operation in the `tensor::ops` module.
     fn f(&self, x: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError> {
         match &self {

--- a/src/circuit/ops/mod.rs
+++ b/src/circuit/ops/mod.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 
 use halo2_proofs::circuit::Region;
-use halo2curves::FieldExt;
 use serde::{Deserialize, Serialize};
 
 use crate::tensor::{self, Tensor, TensorError, TensorType, ValTensor};
+use halo2curves::ff::PrimeField;
 
 use self::lookup::LookupOp;
 
@@ -20,7 +20,7 @@ pub mod lookup;
 pub mod poly;
 
 ///
-pub trait Op<F: FieldExt + TensorType>: std::fmt::Debug + Send + Sync {
+pub trait Op<F: PrimeField + TensorType + PartialOrd>: std::fmt::Debug + Send + Sync {
     ///
     fn f(&self, x: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError>;
     ///
@@ -62,7 +62,7 @@ pub trait Op<F: FieldExt + TensorType>: std::fmt::Debug + Send + Sync {
     fn clone_dyn(&self) -> Box<dyn Op<F>>;
 }
 
-impl<F: FieldExt + TensorType> Clone for Box<dyn Op<F>> {
+impl<F: PrimeField + TensorType + PartialOrd> Clone for Box<dyn Op<F>> {
     fn clone(&self) -> Self {
         self.clone_dyn()
     }
@@ -72,7 +72,7 @@ impl<F: FieldExt + TensorType> Clone for Box<dyn Op<F>> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Input;
 
-impl<F: FieldExt + TensorType> Op<F> for Input {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for Input {
     fn f(&self, x: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError> {
         Ok(x[0].clone())
     }
@@ -105,14 +105,14 @@ impl<F: FieldExt + TensorType> Op<F> for Input {
 
 ///
 #[derive(Clone, Debug)]
-pub struct Rescaled<F: FieldExt + TensorType> {
+pub struct Rescaled<F: PrimeField + TensorType + PartialOrd> {
     ///
     pub inner: Box<dyn Op<F>>,
     ///
     pub scale: Vec<(usize, usize)>,
 }
 
-impl<F: FieldExt + TensorType> Op<F> for Rescaled<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for Rescaled<F> {
     fn f(&self, x: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError> {
         if self.scale.len() != x.len() {
             return Err(TensorError::DimMismatch("rescaled inputs".to_string()));
@@ -170,7 +170,7 @@ impl<F: FieldExt + TensorType> Op<F> for Rescaled<F> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct Unknown;
 
-impl<F: FieldExt + TensorType> Op<F> for Unknown {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for Unknown {
     fn f(&self, _: &[Tensor<i128>]) -> Result<Tensor<i128>, TensorError> {
         Err(TensorError::WrongMethod)
     }

--- a/src/circuit/ops/poly.rs
+++ b/src/circuit/ops/poly.rs
@@ -8,7 +8,7 @@ use super::{base::BaseOp, *};
 #[allow(missing_docs)]
 /// An enum representing the operations that can be used to express more complex operations via accumulation
 #[derive(Clone, Debug)]
-pub enum PolyOp<F: FieldExt + TensorType> {
+pub enum PolyOp<F: PrimeField + TensorType + PartialOrd> {
     Dot,
     Matmul {
         a: Option<ValTensor<F>>,
@@ -45,7 +45,7 @@ pub enum PolyOp<F: FieldExt + TensorType> {
     RangeCheck(i32),
 }
 
-impl<F: FieldExt + TensorType> Op<F> for PolyOp<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Op<F> for PolyOp<F> {
     fn as_str(&self) -> &'static str {
         match &self {
             PolyOp::Identity => "IDENTITY",

--- a/src/circuit/table.rs
+++ b/src/circuit/table.rs
@@ -1,10 +1,11 @@
 use std::{error::Error, marker::PhantomData};
 
+use halo2curves::ff::PrimeField;
+
 use halo2_proofs::{
     circuit::{Layouter, Value},
     plonk::{ConstraintSystem, TableColumn},
 };
-use halo2curves::FieldExt;
 
 use crate::{
     circuit::CircuitError,
@@ -19,7 +20,7 @@ use super::Op;
 /// Halo2 lookup table for element wise non-linearities.
 // Table that should be reused across all lookups (so no Clone)
 #[derive(Clone, Debug)]
-pub struct Table<F: FieldExt> {
+pub struct Table<F: PrimeField> {
     /// composed operations represented by the table
     pub nonlinearity: LookupOp,
     /// Input to table.
@@ -33,7 +34,7 @@ pub struct Table<F: FieldExt> {
     _marker: PhantomData<F>,
 }
 
-impl<F: FieldExt + TensorType> Table<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Table<F> {
     /// Configures the table.
     pub fn configure(
         cs: &mut ConstraintSystem<F>,

--- a/src/circuit/tests.rs
+++ b/src/circuit/tests.rs
@@ -1,11 +1,11 @@
 use crate::circuit::ops::poly::PolyOp;
 use crate::circuit::*;
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::MockProver,
     plonk::{Circuit, ConstraintSystem, Error},
 };
+use halo2curves::ff::{Field, PrimeField};
 use halo2curves::pasta::pallas;
 use halo2curves::pasta::Fp as F;
 use rand::rngs::OsRng;
@@ -13,18 +13,19 @@ use std::marker::PhantomData;
 
 #[cfg(test)]
 mod matmul {
+
     use super::*;
 
     const K: usize = 9;
     const LEN: usize = 3;
 
     #[derive(Clone)]
-    struct MatmulCircuit<F: FieldExt + TensorType> {
+    struct MatmulCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MatmulCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MatmulCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -92,12 +93,12 @@ mod matmul_col_overflow {
     const LEN: usize = 6;
 
     #[derive(Clone)]
-    struct MatmulCircuit<F: FieldExt + TensorType> {
+    struct MatmulCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MatmulCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MatmulCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -165,12 +166,12 @@ mod dot {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -235,12 +236,12 @@ mod dot_col_overflow {
     const LEN: usize = 50;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -305,12 +306,12 @@ mod sum {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 1],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -373,12 +374,12 @@ mod sum_col_overflow {
     const LEN: usize = 20;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 1],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -441,12 +442,12 @@ mod composition {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -523,7 +524,6 @@ mod composition {
 
 #[cfg(test)]
 mod conv {
-    use halo2_proofs::arithmetic::Field;
 
     use super::*;
 
@@ -531,12 +531,12 @@ mod conv {
     const LEN: usize = 100;
 
     #[derive(Clone)]
-    struct ConvCircuit<F: FieldExt + TensorType> {
+    struct ConvCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: Vec<ValTensor<F>>,
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for ConvCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for ConvCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -650,7 +650,6 @@ mod conv {
 
 #[cfg(test)]
 mod sumpool {
-    use halo2_proofs::arithmetic::Field;
 
     use super::*;
 
@@ -658,12 +657,12 @@ mod sumpool {
     const LEN: usize = 100;
 
     #[derive(Clone)]
-    struct ConvCircuit<F: FieldExt + TensorType> {
+    struct ConvCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: Vec<ValTensor<F>>,
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for ConvCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for ConvCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -736,12 +735,12 @@ mod add_w_shape_casting {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -806,12 +805,12 @@ mod add {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -876,12 +875,12 @@ mod add_with_overflow {
     const LEN: usize = 50;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -946,12 +945,12 @@ mod sub {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1016,12 +1015,12 @@ mod mult {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1086,12 +1085,12 @@ mod pow {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 1],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1154,12 +1153,12 @@ mod pack {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 1],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1222,12 +1221,12 @@ mod rescaled {
     const LEN: usize = 4;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 1],
         _marker: PhantomData<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1295,18 +1294,18 @@ mod matmul_relu {
     use crate::circuit::lookup::LookupOp;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         inputs: [ValTensor<F>; 2],
         _marker: PhantomData<F>,
     }
 
     // A columnar ReLu MLP
     #[derive(Clone)]
-    struct MyConfig<F: FieldExt + TensorType> {
+    struct MyConfig<F: PrimeField + TensorType + PartialOrd> {
         base_config: BaseConfig<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = MyConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1391,7 +1390,6 @@ mod rangecheck {
 
     use crate::tensor::Tensor;
     use halo2_proofs::{
-        arithmetic::FieldExt,
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         plonk::{Circuit, ConstraintSystem, Error},
@@ -1405,12 +1403,12 @@ mod rangecheck {
     use super::*;
 
     #[derive(Clone)]
-    struct MyCircuit<F: FieldExt + TensorType> {
+    struct MyCircuit<F: PrimeField + TensorType + PartialOrd> {
         input: ValTensor<F>,
         output: ValTensor<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for MyCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for MyCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -1491,7 +1489,6 @@ mod rangecheck {
 mod relu {
     use super::*;
     use halo2_proofs::{
-        arithmetic::FieldExt,
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         plonk::{Circuit, ConstraintSystem, Error},
@@ -1499,11 +1496,11 @@ mod relu {
     use halo2curves::pasta::Fp as F;
 
     #[derive(Clone)]
-    struct ReLUCircuit<F: FieldExt + TensorType> {
+    struct ReLUCircuit<F: PrimeField + TensorType + PartialOrd> {
         pub input: ValTensor<F>,
     }
 
-    impl<F: FieldExt + TensorType> Circuit<F> for ReLUCircuit<F> {
+    impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for ReLUCircuit<F> {
         type Config = BaseConfig<F>;
         type FloorPlanner = SimpleFloorPlanner;
 

--- a/src/fieldutils.rs
+++ b/src/fieldutils.rs
@@ -1,8 +1,9 @@
-/// Utilities for converting from Halo2 Field types to integers (and vice-versa).
-use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::arithmetic::Field;
+/// Utilities for converting from Halo2 PrimeField types to integers (and vice-versa).
+use halo2curves::ff::PrimeField;
 
-/// Converts an i32 to a Field element.
-pub fn i32_to_felt<F: FieldExt>(x: i32) -> F {
+/// Converts an i32 to a PrimeField element.
+pub fn i32_to_felt<F: PrimeField>(x: i32) -> F {
     if x >= 0 {
         F::from(x as u64)
     } else {
@@ -10,8 +11,8 @@ pub fn i32_to_felt<F: FieldExt>(x: i32) -> F {
     }
 }
 
-/// Converts an i32 to a Field element.
-pub fn i128_to_felt<F: FieldExt>(x: i128) -> F {
+/// Converts an i32 to a PrimeField element.
+pub fn i128_to_felt<F: PrimeField>(x: i128) -> F {
     if x >= 0 {
         F::from_u128(x as u128)
     } else {
@@ -19,21 +20,33 @@ pub fn i128_to_felt<F: FieldExt>(x: i128) -> F {
     }
 }
 
-/// Converts a Field element to an i32.
-pub fn felt_to_i32<F: FieldExt>(x: F) -> i32 {
+/// Converts a PrimeField element to an i32.
+pub fn felt_to_i32<F: PrimeField + PartialOrd + Field>(x: F) -> i32 {
     if x > F::from(i32::MAX as u64) {
-        -((-x).get_lower_32() as i32)
+        let rep = (-x).to_repr();
+        let negtmp: &[u8] = rep.as_ref();
+        let lower_32 = u32::from_le_bytes(negtmp[..4].try_into().unwrap());
+        -(lower_32 as i32)
     } else {
-        x.get_lower_32() as i32
+        let rep = (x).to_repr();
+        let tmp: &[u8] = rep.as_ref();
+        let lower_32 = u32::from_le_bytes(tmp[..4].try_into().unwrap());
+        lower_32 as i32
     }
 }
 
-/// Converts a Field element to an i32.
-pub fn felt_to_i128<F: FieldExt>(x: F) -> i128 {
+/// Converts a PrimeField element to an i128.
+pub fn felt_to_i128<F: PrimeField + PartialOrd + Field>(x: F) -> i128 {
     if x > F::from_u128(i128::MAX as u128) {
-        -((-x).get_lower_128() as i128)
+        let rep = (-x).to_repr();
+        let negtmp: &[u8] = rep.as_ref();
+        let lower_128: u128 = u128::from_le_bytes(negtmp[..16].try_into().unwrap());
+        -(lower_128 as i128)
     } else {
-        x.get_lower_128() as i128
+        let rep = (x).to_repr();
+        let tmp: &[u8] = rep.as_ref();
+        let lower_128: u128 = u128::from_le_bytes(tmp[..16].try_into().unwrap());
+        lower_128 as i128
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,5 +1,6 @@
 /// Helper functions
 pub mod utilities;
+use halo2curves::ff::PrimeField;
 pub use utilities::*;
 /// Crate for defining a computational graph and building a ZK-circuit from it.
 pub mod model;
@@ -16,7 +17,6 @@ use crate::tensor::TensorType;
 use crate::tensor::{Tensor, ValTensor};
 use anyhow::Result;
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{Circuit, ConstraintSystem, Error as PlonkError},
 };
@@ -80,16 +80,16 @@ pub enum GraphError {
 
 /// Defines the circuit for a computational graph / model loaded from a `.onnx` file.
 #[derive(Clone, Debug)]
-pub struct ModelCircuit<F: FieldExt + TensorType> {
+pub struct ModelCircuit<F: PrimeField + TensorType + PartialOrd> {
     /// Vector of input tensors to the model / graph of computations.
     pub inputs: Vec<Tensor<i128>>,
     ///
     pub model: Model<F>,
-    /// Represents the Field we are using.
+    /// Represents the PrimeField we are using.
     pub _marker: PhantomData<F>,
 }
 
-impl<F: FieldExt + TensorType> ModelCircuit<F> {
+impl<F: PrimeField + TensorType + PartialOrd> ModelCircuit<F> {
     ///
     pub fn new(
         data: &ModelInput,
@@ -171,7 +171,7 @@ impl<F: FieldExt + TensorType> ModelCircuit<F> {
     }
 }
 
-impl<F: FieldExt + TensorType> Circuit<F> for ModelCircuit<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Circuit<F> for ModelCircuit<F> {
     type Config = ModelConfig<F>;
     type FloorPlanner = SimpleFloorPlanner;
 

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -10,6 +10,7 @@ use crate::commands::{Cli, Commands};
 use crate::graph::scale_to_multiplier;
 use crate::tensor::TensorType;
 use crate::tensor::{Tensor, ValTensor};
+use halo2curves::ff::PrimeField;
 use log::warn;
 use serde::Deserialize;
 use serde::Serialize;
@@ -23,7 +24,6 @@ use tract_onnx::tract_hir::internal::GenericFactoid;
 //use clap::Parser;
 use core::panic;
 use halo2_proofs::{
-    arithmetic::FieldExt,
     circuit::{Layouter, Value},
     plonk::ConstraintSystem,
 };
@@ -54,7 +54,7 @@ pub enum Mode {
 
 /// A circuit configuration for the entirety of a model loaded from an Onnx file.
 #[derive(Clone, Debug)]
-pub struct ModelConfig<F: FieldExt + TensorType> {
+pub struct ModelConfig<F: PrimeField + TensorType + PartialOrd> {
     /// The base configuration for the circuit
     pub base: PolyConfig<F>,
     /// The model struct
@@ -65,7 +65,7 @@ pub struct ModelConfig<F: FieldExt + TensorType> {
 
 /// A struct for loading from an Onnx file and converting a computational graph to a circuit.
 #[derive(Clone, Debug)]
-pub struct Model<F: FieldExt + TensorType> {
+pub struct Model<F: PrimeField + TensorType + PartialOrd> {
     /// input indices
     pub inputs: Vec<usize>,
     /// output indices
@@ -80,7 +80,7 @@ pub struct Model<F: FieldExt + TensorType> {
     pub visibility: VarVisibility,
 }
 
-impl<F: FieldExt + TensorType> Model<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Model<F> {
     /// Creates an `Model` from a specified path to an Onnx file.
     /// # Arguments
     /// * `path` - A path to an Onnx file.

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -4,7 +4,7 @@ use crate::graph::new_op_from_onnx;
 use crate::graph::GraphError;
 use crate::tensor::TensorType;
 use anyhow::Result;
-use halo2_proofs::arithmetic::FieldExt;
+use halo2curves::ff::PrimeField;
 use itertools::Itertools;
 use log::{info, trace};
 use std::collections::BTreeMap;
@@ -27,7 +27,7 @@ fn display_vector<T: fmt::Debug>(v: &Vec<T>) -> String {
     }
 }
 
-fn display_opkind<F: FieldExt + TensorType>(v: &Box<dyn Op<F>>) -> String {
+fn display_opkind<F: PrimeField + TensorType + PartialOrd>(v: &Box<dyn Op<F>>) -> String {
     v.as_str().to_string()
 }
 
@@ -42,7 +42,7 @@ fn display_opkind<F: FieldExt + TensorType>(v: &Box<dyn Op<F>>) -> String {
 /// * `idx` - The node's unique identifier.
 /// * `bucket` - The execution bucket this node has been assigned to.
 #[derive(Clone, Debug, Tabled)]
-pub struct Node<F: FieldExt + TensorType> {
+pub struct Node<F: PrimeField + TensorType + PartialOrd> {
     /// [OpKind] enum, i.e what operation this node represents.
     #[tabled(display_with = "display_opkind")]
     pub opkind: Box<dyn Op<F>>,
@@ -60,7 +60,7 @@ pub struct Node<F: FieldExt + TensorType> {
     pub idx: usize,
 }
 
-impl<F: FieldExt + TensorType> Node<F> {
+impl<F: PrimeField + TensorType + PartialOrd> Node<F> {
     /// Converts a tract [OnnxNode] into an ezkl [Node].
     /// # Arguments:
     /// * `node` - [OnnxNode]

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -8,7 +8,7 @@ use crate::fieldutils::i128_to_felt;
 use crate::tensor::{Tensor, TensorError, TensorType, ValTensor};
 use anyhow::Result;
 use halo2_proofs::circuit::Value;
-use halo2curves::FieldExt;
+use halo2curves::ff::PrimeField;
 use log::{trace, warn};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use tract_onnx::prelude::{DatumType, Node as OnnxNode, TypedFact, TypedOp};
@@ -71,7 +71,7 @@ pub fn node_output_shapes(
     Ok(shapes)
 }
 
-fn extract_tensor_value<F: FieldExt + TensorType>(
+fn extract_tensor_value<F: PrimeField + TensorType + PartialOrd>(
     input: Arc<tract_onnx::prelude::Tensor>,
     scale: u32,
     public_params: bool,
@@ -179,7 +179,7 @@ fn load_eltwise_op(
 }
 
 /// Matches an onnx node to a [OpKind] and returns a [Node] with the corresponding [OpKind].  
-pub fn new_op_from_onnx<F: FieldExt + TensorType>(
+pub fn new_op_from_onnx<F: PrimeField + TensorType + PartialOrd>(
     idx: usize,
     scale: u32,
     public_params: bool,

--- a/src/graph/vars.rs
+++ b/src/graph/vars.rs
@@ -3,11 +3,12 @@ use std::error::Error;
 use crate::commands::RunArgs;
 use crate::tensor::TensorType;
 use crate::tensor::{ValTensor, VarTensor};
-use halo2_proofs::{arithmetic::FieldExt, plonk::ConstraintSystem};
+use halo2_proofs::plonk::ConstraintSystem;
+use halo2curves::ff::PrimeField;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use super::GraphError;
+use super::*;
 
 /// Label Enum to track whether model input, model parameters, and model output are public or private
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -84,7 +85,7 @@ impl VarVisibility {
 
 /// A wrapper for holding all columns that will be assigned to by a model.
 #[derive(Clone, Debug)]
-pub struct ModelVars<F: FieldExt + TensorType> {
+pub struct ModelVars<F: PrimeField + TensorType + PartialOrd> {
     #[allow(missing_docs)]
     pub advices: Vec<VarTensor>,
     #[allow(missing_docs)]
@@ -93,7 +94,7 @@ pub struct ModelVars<F: FieldExt + TensorType> {
     pub instances: Vec<ValTensor<F>>,
 }
 
-impl<F: FieldExt + TensorType> ModelVars<F> {
+impl<F: PrimeField + TensorType + PartialOrd> ModelVars<F> {
     /// Allocate all columns that will be assigned to by a model.
     pub fn new(
         cs: &mut ConstraintSystem<F>,

--- a/src/pfsys/evm/aggregation.rs
+++ b/src/pfsys/evm/aggregation.rs
@@ -15,19 +15,12 @@ use halo2_wrong_ecc::{
     EccConfig,
 };
 use halo2curves::bn256::{Bn256, Fq, Fr, G1Affine};
+use halo2curves::ff::PrimeField;
 use itertools::Itertools;
 use log::trace;
 use rand::rngs::OsRng;
 use snark_verifier::{
-    loader::evm::{self, EvmLoader},
-    system::halo2::transcript::evm::EvmTranscript,
-};
-use snark_verifier::{
-    loader::native::NativeLoader,
-    system::halo2::{compile, Config},
-};
-use snark_verifier::{
-    loader::{self},
+    loader,
     pcs::{
         kzg::{
             Gwc19, KzgAccumulator, KzgAs, KzgSuccinctVerifyingKey, LimbsEncoding,
@@ -36,8 +29,16 @@ use snark_verifier::{
         AccumulationScheme, AccumulationSchemeProver,
     },
     system,
-    util::arithmetic::{fe_to_limbs, FieldExt},
+    util::arithmetic::fe_to_limbs,
     verifier::{self, SnarkVerifier},
+};
+use snark_verifier::{
+    loader::evm::{self, EvmLoader},
+    system::halo2::transcript::evm::EvmTranscript,
+};
+use snark_verifier::{
+    loader::native::NativeLoader,
+    system::halo2::{compile, Config},
 };
 use std::rc::Rc;
 use thiserror::Error;
@@ -55,8 +56,7 @@ const R_F: usize = 8;
 const R_P: usize = 60;
 
 type Svk = KzgSuccinctVerifyingKey<G1Affine>;
-type BaseFieldEccChip =
-    snark_verifier::loader::halo2::halo2_wrong_ecc::BaseFieldEccChip<G1Affine, LIMBS, BITS>;
+type BaseFieldEccChip = halo2_wrong_ecc::BaseFieldEccChip<G1Affine, LIMBS, BITS>;
 /// The loader type used in the transcript definition
 type Halo2Loader<'a> = loader::halo2::Halo2Loader<'a, G1Affine, BaseFieldEccChip>;
 /// Application snark transcript
@@ -128,7 +128,7 @@ pub struct AggregationConfig {
 
 impl AggregationConfig {
     /// Configure the aggregation circuit
-    pub fn configure<F: FieldExt>(
+    pub fn configure<F: PrimeField>(
         meta: &mut ConstraintSystem<F>,
         composition_bits: Vec<usize>,
         overflow_bits: Vec<usize>,

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -3,7 +3,7 @@ use halo2_proofs::{arithmetic::Field, plonk::Instance};
 
 #[derive(Debug, Clone)]
 ///
-pub enum ValType<F: FieldExt + TensorType + std::marker::Send + std::marker::Sync> {
+pub enum ValType<F: PrimeField + TensorType + std::marker::Send + std::marker::Sync + PartialOrd> {
     /// value
     Value(Value<F>),
     /// assigned  value
@@ -14,7 +14,7 @@ pub enum ValType<F: FieldExt + TensorType + std::marker::Send + std::marker::Syn
     Constant(F),
 }
 
-impl<F: FieldExt + TensorType> From<ValType<F>> for i32 {
+impl<F: PrimeField + TensorType + PartialOrd> From<ValType<F>> for i32 {
     fn from(val: ValType<F>) -> Self {
         match val {
             ValType::Value(v) => {
@@ -52,43 +52,46 @@ impl<F: FieldExt + TensorType> From<ValType<F>> for i32 {
     }
 }
 
-impl<F: FieldExt + TensorType> From<F> for ValType<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<F> for ValType<F> {
     fn from(t: F) -> ValType<F> {
         ValType::Constant(t)
     }
 }
 
-impl<F: FieldExt + TensorType> From<Value<F>> for ValType<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Value<F>> for ValType<F> {
     fn from(t: Value<F>) -> ValType<F> {
         ValType::Value(t)
     }
 }
 
-impl<F: FieldExt + TensorType> From<Value<Assigned<F>>> for ValType<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Value<Assigned<F>>> for ValType<F> {
     fn from(t: Value<Assigned<F>>) -> ValType<F> {
         ValType::AssignedValue(t)
     }
 }
 
-impl<F: FieldExt + TensorType> From<AssignedCell<F, F>> for ValType<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<AssignedCell<F, F>> for ValType<F> {
     fn from(t: AssignedCell<F, F>) -> ValType<F> {
         ValType::PrevAssigned(t)
     }
 }
 
-impl<F: FieldExt + TensorType> TensorType for ValType<F> {
+impl<F: PrimeField + TensorType + PartialOrd> TensorType for ValType<F>
+where
+    F: Field,
+{
     fn zero() -> Option<Self> {
-        Some(ValType::Value(Value::known(<F as Field>::zero())))
+        Some(ValType::Value(Value::known(<F as Field>::ZERO)))
     }
     fn one() -> Option<Self> {
-        Some(ValType::Value(Value::known(<F as Field>::one())))
+        Some(ValType::Value(Value::known(<F as Field>::ONE)))
     }
 }
 /// A wrapper around a [Tensor] where the inner type is one of Halo2's [`Value<F>`], [`Value<Assigned<F>>`], [`AssignedCell<Assigned<F>, F>`].
 /// This enum is generally used to assign values to variables / advices already configured in a Halo2 circuit (usually represented as a [VarTensor]).
 /// For instance can represent pre-trained neural network weights; or a known input to a network.
 #[derive(Debug, Clone)]
-pub enum ValTensor<F: FieldExt + TensorType> {
+pub enum ValTensor<F: PrimeField + TensorType + PartialOrd> {
     /// A tensor of [Value], each containing a field element
     Value {
         /// Underlying [Tensor].
@@ -109,7 +112,7 @@ pub enum ValTensor<F: FieldExt + TensorType> {
     },
 }
 
-impl<F: FieldExt + TensorType> From<Tensor<ValType<F>>> for ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Tensor<ValType<F>>> for ValTensor<F> {
     fn from(t: Tensor<ValType<F>>) -> ValTensor<F> {
         ValTensor::Value {
             inner: t.map(|x| x),
@@ -119,7 +122,7 @@ impl<F: FieldExt + TensorType> From<Tensor<ValType<F>>> for ValTensor<F> {
     }
 }
 
-impl<F: FieldExt + TensorType> From<Tensor<F>> for ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Tensor<F>> for ValTensor<F> {
     fn from(t: Tensor<F>) -> ValTensor<F> {
         ValTensor::Value {
             inner: t.map(|x| x.into()),
@@ -129,7 +132,7 @@ impl<F: FieldExt + TensorType> From<Tensor<F>> for ValTensor<F> {
     }
 }
 
-impl<F: FieldExt + TensorType> From<Tensor<Value<F>>> for ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Tensor<Value<F>>> for ValTensor<F> {
     fn from(t: Tensor<Value<F>>) -> ValTensor<F> {
         ValTensor::Value {
             inner: t.map(|x| x.into()),
@@ -139,7 +142,7 @@ impl<F: FieldExt + TensorType> From<Tensor<Value<F>>> for ValTensor<F> {
     }
 }
 
-impl<F: FieldExt + TensorType> From<Tensor<Value<Assigned<F>>>> for ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Tensor<Value<Assigned<F>>>> for ValTensor<F> {
     fn from(t: Tensor<Value<Assigned<F>>>) -> ValTensor<F> {
         ValTensor::Value {
             inner: t.map(|x| x.into()),
@@ -149,7 +152,7 @@ impl<F: FieldExt + TensorType> From<Tensor<Value<Assigned<F>>>> for ValTensor<F>
     }
 }
 
-impl<F: FieldExt + TensorType> From<Tensor<AssignedCell<F, F>>> for ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> From<Tensor<AssignedCell<F, F>>> for ValTensor<F> {
     fn from(t: Tensor<AssignedCell<F, F>>) -> ValTensor<F> {
         ValTensor::Value {
             inner: t.map(|x| x.into()),
@@ -159,7 +162,7 @@ impl<F: FieldExt + TensorType> From<Tensor<AssignedCell<F, F>>> for ValTensor<F>
     }
 }
 
-impl<F: FieldExt + TensorType> ValTensor<F> {
+impl<F: PrimeField + TensorType + PartialOrd> ValTensor<F> {
     /// Allocate a new [ValTensor::Instance] from the ConstraintSystem with the given tensor `dims`, optionally enabling `equality`.
     pub fn new_instance(cs: &mut ConstraintSystem<F>, dims: Vec<usize>, scale: u32) -> Self {
         let col = cs.instance_column();

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -51,7 +51,7 @@ impl VarTensor {
     /// * `dims` - `Vec` of dimensions of the tensor we are representing. Note that the shape of the storage and this shape can differ.
     /// * `equality` - true if we want to enable equality constraints for the columns involved.
     /// * `max_rot` - maximum number of rotations that we allow for this VarTensor. Rotations affect performance.
-    pub fn new_advice<F: FieldExt>(
+    pub fn new_advice<F: PrimeField>(
         cs: &mut ConstraintSystem<F>,
         logrows: usize,
         capacity: usize,
@@ -92,7 +92,7 @@ impl VarTensor {
     /// `dims` is the `Vec` of dimensions of the tensor we are representing. Note that the shape of the storage and this shape can differ.
     /// `equality` should be true if we want to enable equality constraints for the columns involved.
     /// `max_rot` is the maximum number of rotations that we allow for this VarTensor. Rotations affect performance.
-    pub fn new_fixed<F: FieldExt>(
+    pub fn new_fixed<F: PrimeField>(
         cs: &mut ConstraintSystem<F>,
         logrows: usize,
         capacity: usize,
@@ -158,7 +158,7 @@ impl VarTensor {
 impl VarTensor {
     /// Retrieve the values represented within the columns of the `VarTensor` (recall that `VarTensor`
     /// is a Tensor of Halo2 columns).
-    pub fn query_rng<F: FieldExt>(
+    pub fn query_rng<F: PrimeField>(
         &self,
         meta: &mut VirtualCells<'_, F>,
         rotation_offset: i32,
@@ -194,7 +194,7 @@ impl VarTensor {
     }
 
     ///
-    pub fn assign_constant<F: FieldExt + TensorType>(
+    pub fn assign_constant<F: PrimeField + TensorType>(
         &self, 
         region: &mut Region<F>,
         offset: usize,
@@ -215,7 +215,7 @@ impl VarTensor {
 
    
     /// Assigns specific values [ValTensor] to the columns of the inner tensor.
-    pub fn assign<F: FieldExt + TensorType>(
+    pub fn assign<F: PrimeField + TensorType + PartialOrd>(
         &self,
         region: &mut Option<&mut Region<F>>,
         offset: usize,
@@ -292,7 +292,7 @@ impl VarTensor {
     }
 
     /// Assigns specific values (`ValTensor`) to the columns of the inner tensor.
-    pub fn assign_with_duplication<F: FieldExt + TensorType>(
+    pub fn assign_with_duplication<F: PrimeField + TensorType + PartialOrd>(
         &self,
         region: &mut Option<&mut Region<F>>,
         offset: usize,


### PR DESCRIPTION
New updates in hhttps://github.com/privacy-scaling-explorations/halo2wrong/pull/69 & https://github.com/privacy-scaling-explorations/poseidon/pull/9 mean we can upgrade halo2proofs to `v2023_04_20`. Which carries a number of useability benefits (listed [here](https://github.com/privacy-scaling-explorations/halo2/releases/tag/v2023_04_20)): 

Notably: 

- Extend Circuit trait to take parameters in config in https://github.com/privacy-scaling-explorations/halo2/pull/168 means we may be able to persist params without the repeated calls to `from_arg()` and will help with python bindings. 

