### PR TITLE
feat: percent error tolerance

### DIFF
--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 ///
 pub mod table;
 
@@ -66,6 +67,36 @@ impl From<String> for CheckMode {
             "safe" => CheckMode::SAFE,
             "unsafe" => CheckMode::UNSAFE,
             _ => panic!("not a valid checkmode"),
+        }
+    }
+}
+
+#[allow(missing_docs)]
+/// An enum representing the tolerance we can accept for the accumulated arguments, either absolute or percentage
+#[derive(
+    Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize, Copy
+)]
+pub enum Tolerance {
+    Abs { val: usize },
+    Percentage { val: f32 },
+}
+
+impl Default for Tolerance {
+    fn default() -> Self {
+        Tolerance::Abs { val: 0 }
+    }
+}
+
+impl FromStr for Tolerance {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(val) = s.parse::<usize>() {
+            Ok(Tolerance::Abs { val })
+        } else if let Ok(val) = s.parse::<f32>() {
+            Ok(Tolerance::Percentage { val })
+        } else {
+            Err("Invalid tolerance value provided. It should be either an absolute value (usize) or a percentage (f32).".to_string())
         }
     }
 }

--- a/src/circuit/tests.rs
+++ b/src/circuit/tests.rs
@@ -1416,6 +1416,7 @@ mod rangecheck {
         plonk::{Circuit, ConstraintSystem, Error},
     };
     use halo2curves::pasta::Fp;
+    use crate::circuit::Tolerance;
 
     const RANGE: usize = 8; // 3-bit value
     const K: usize = 8;
@@ -1460,7 +1461,7 @@ mod rangecheck {
                                 &mut Some(&mut region),
                                 &[self.input.clone(), self.output.clone()],
                                 &mut 0,
-                                Box::new(PolyOp::RangeCheck(RANGE as i32)),
+                                Box::new(PolyOp::RangeCheck(Tolerance::Abs { val: RANGE})),
                             )
                             .map_err(|_| Error::Synthesis)
                     },
@@ -1506,6 +1507,8 @@ mod rangecheck {
         }
     }
 }
+
+// TODO: Write tests for test_range_check_percent.
 
 #[cfg(test)]
 mod relu {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::{stdin, stdout, Read, Write};
 use std::path::PathBuf;
 
-use crate::circuit::CheckMode;
+use crate::circuit::{CheckMode, Tolerance};
 
 #[allow(missing_docs)]
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -48,7 +48,7 @@ impl std::fmt::Display for StrategyType {
 pub struct RunArgs {
     /// The tolerance for error on model outputs
     #[arg(short = 'T', long, default_value = "0")]
-    pub tolerance: usize,
+    pub tolerance: Tolerance,
     /// The denominator in the fixed point representation used when quantizing
     #[arg(short = 'S', long, default_value = "7")]
     pub scale: u32,

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -975,7 +975,7 @@ pub mod nonlinearities {
         output
     }
 
-    /// Elementwise applies exponenial to a tensor of integers.
+    /// Elementwise applies exponential to a tensor of integers.
     /// # Arguments
     ///
     /// * `a` - Tensor


### PR DESCRIPTION
Users can set tolerance as a percent error for floating point inputs to the -T option, (will default to original absolute tolerance for usize inputs). 