### PR TITLE
feat: python bindings for verify

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -188,7 +188,7 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
 }
 
 /// helper function
-fn verify_proof_circuit_kzg<
+pub fn verify_proof_circuit_kzg<
     'params,
     Strategy: VerificationStrategy<'params, KZGCommitmentScheme<Bn256>, VerifierGWC<'params, Bn256>>,
 >(

--- a/tests/python/binding_tests.py
+++ b/tests/python/binding_tests.py
@@ -128,6 +128,7 @@ def test_prove():
 
     vk_path = os.path.join(folder_path, 'test.vk')
     proof_path = os.path.join(folder_path, 'test.pf')
+    circuit_params_path = os.path.join(folder_path, 'circuit.params')
 
     res = ezkl_lib.prove(
         data_path,
@@ -135,9 +136,29 @@ def test_prove():
         vk_path,
         proof_path,
         params_path,
+        circuit_params_path,
         "poseidon",
         "single",
     )
     assert res == True
     assert os.path.isfile(vk_path)
     assert os.path.isfile(proof_path)
+
+
+def test_verify():
+    """
+    Test for verify
+    """
+
+    vk_path = os.path.join(folder_path, 'test.vk')
+    proof_path = os.path.join(folder_path, 'test.pf')
+    circuit_params_path = os.path.join(folder_path, 'circuit.params')
+
+    res = ezkl_lib.verify(
+        proof_path,
+        circuit_params_path,
+        vk_path,
+        params_path,
+        "poseidon",
+    )
+    assert res == True


### PR DESCRIPTION
Changes:
1. Refactor prove for #216 to `accept circuit_params_path`
2. Create python bindings and test for verify