### PR TITLE
feat: re-export `init_thread_pool` in wasm modules

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,5 +2,5 @@
 runner = 'wasm-bindgen-test-runner'
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
 
-[unstable]
-build-std = ["panic_abort", "std"]
+# [unstable]
+# build-std = ["panic_abort", "std"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
+
+[unstable]
+build-std = ["panic_abort", "std"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -2,5 +2,4 @@
 runner = 'wasm-bindgen-test-runner'
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
 
-# [unstable]
-# build-std = ["panic_abort", "std"]
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,13 +129,14 @@ jobs:
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
+      - uses: browser-actions/setup-chrome@v1
       - uses: nanasess/setup-chromedriver@v2
       - name: Install wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm runner
         run: cargo install wasm-server-runner
       - name: Run wasm verifier tests
-        run: wasm-pack test --chrome --headless
+        run: wasm-pack test --chrome --headless -- -Z build-std="panic_abort,std"
 
   forward-pass-tests:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -37,20 +36,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
       - name: Install wasm32-wasi
         run: rustup target add wasm32-wasi
       - name: Build wasm
-        run: wasm-pack build -- --bin ezkl --target wasm32-wasi
+        run: cargo build --release --bin ezkl --target=wasm32-wasi
       - name: Run help
         run: wasmtime run './target/wasm32-wasi/release/ezkl.wasm' -- --help
 
@@ -59,7 +56,6 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -90,7 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -103,7 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -119,7 +113,6 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -143,14 +136,11 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Forward Pass
         run: cargo test --release --verbose tests::forward_pass_
 
@@ -159,7 +149,6 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -168,8 +157,6 @@ jobs:
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Circuit Render
         run: cargo test --release --verbose tests::render_circuit_
 
@@ -178,14 +165,11 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Circuit Render
         run: cargo test --release --verbose tests::tutorial_
 
@@ -194,15 +178,11 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
-
       - name: Mock proving tests (public outputs)
         run: cargo test --release --verbose tests::mock_public_outputs_ -- --test-threads 32
       - name: Mock proving tests (public and packed outputs)
@@ -219,13 +199,11 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
@@ -254,14 +232,11 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Install solc
         run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
       - name: Install Anvil
@@ -281,14 +256,11 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: KZG prove and verify tests
         run: cargo test --release --verbose tests::kzg_prove_and_verify_ -- --test-threads 8
 
@@ -304,14 +276,11 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: KZG prove and verify aggr tests
         run: cargo test --release --verbose tests_aggr::kzg_aggr_prove_and_verify_ -- --test-threads 8
 
@@ -327,14 +296,11 @@ jobs:
       ]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Install solc
         run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
       - name: KZG prove and verify aggr tests
@@ -345,14 +311,11 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Download MNIST
         run: sh data.sh
       - name: Examples
@@ -363,7 +326,6 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2022-11-03
@@ -372,8 +334,6 @@ jobs:
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Mock proving tests (should fail)
         run: cargo test neg_tests::neg_examples_
       - name: Mock proving tests (WASI) (should fail)
@@ -384,7 +344,6 @@ jobs:
     needs: [build, build-wasm, library-tests, docs]
     steps:
       - uses: actions/checkout@v3
-      - uses: jetli/wasm-pack-action@v0.4.0
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
@@ -393,8 +352,6 @@ jobs:
           toolchain: nightly-2022-11-03
           override: true
           components: rustfmt, clippy
-      - name: Install wasm32-wasi
-        run: rustup target add wasm32-wasi
       - name: Install solc
         run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.17 && solc --version
       - name: Setup Virtual Env and Install python dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,13 +129,13 @@ jobs:
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
-
+      - uses: nanasess/setup-chromedriver@v2
       - name: Install wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm runner
         run: cargo install wasm-server-runner
       - name: Run wasm verifier tests
-        run: wasm-pack test --node
+        run: wasm-pack test --chrome --headless
 
   forward-pass-tests:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,7 +129,9 @@ jobs:
       - name: Install wasm runner
         run: cargo install wasm-server-runner
       - name: Run wasm verifier tests
-        run: wasm-pack test --chrome --headless -- -Z build-std="panic_abort,std"
+        run:
+          rustup component add rust-src --toolchain nightly-2022-11-03-x86_64-unknown-linux-gnu
+          wasm-pack test --chrome --headless -- -Z build-std="panic_abort,std"
 
   forward-pass-tests:
     runs-on: ubuntu-latest-16-cores
@@ -334,6 +336,8 @@ jobs:
       - uses: mwilliamson/setup-wasmtime-action@v2
         with:
           wasmtime-version: "3.0.1"
+      - name: Install wasm32-wasi
+        run: rustup target add wasm32-wasi
       - name: Mock proving tests (should fail)
         run: cargo test neg_tests::neg_examples_
       - name: Mock proving tests (WASI) (should fail)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,10 +128,10 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
       - name: Install wasm runner
         run: cargo install wasm-server-runner
+      - name: Add rust-src
+        run: rustup component add rust-src --toolchain nightly-2022-11-03-x86_64-unknown-linux-gnu
       - name: Run wasm verifier tests
-        run:
-          rustup component add rust-src --toolchain nightly-2022-11-03-x86_64-unknown-linux-gnu
-          wasm-pack test --chrome --headless -- -Z build-std="panic_abort,std"
+        run: wasm-pack test --chrome --headless -- -Z build-std="panic_abort,std"
 
   forward-pass-tests:
     runs-on: ubuntu-latest-16-cores
@@ -160,7 +160,7 @@ jobs:
         with:
           wasmtime-version: "3.0.1"
       - name: Circuit Render
-        run: cargo test --release --verbose tests::render_circuit_
+        run: cargo test --release --features render --verbose tests::render_circuit_
 
   tutorial:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,10 @@ dependencies = [
  "tokio",
  "tract-onnx",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-rayon",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -4826,6 +4829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spmc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5840,6 +5849,18 @@ dependencies = [
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df87c67450805c305d3ae44a3ac537b0253d029153c25afc3ecd2edc36ccafb1"
+dependencies = [
+ "js-sys",
+ "rayon",
+ "spmc",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,16 +985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,7 +1746,6 @@ dependencies = [
  "colored_json",
  "console_error_panic_hook",
  "criterion",
- "ctor",
  "ecc",
  "env_logger",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,6 @@ serde_traitobject = "0.2.8"
 bincode = "*"
 wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"]}
 console_error_panic_hook = "0.1.7"
-serde-wasm-bindgen = "0.4"
-wasm-bindgen-rayon = "1.0"
 
 # python binding related deps
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37"], optional = true }
@@ -59,6 +57,12 @@ ethers-solc = "2.0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.8", features = ["js"] }
+wasm-bindgen-test = "0.3.34"
+wasm-bindgen-futures = "0.4.34"
+serde-wasm-bindgen = "0.4"
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen-rayon = "1.0"
 
 
 [dev-dependencies]
@@ -71,12 +75,10 @@ seq-macro = "0.3.1"
 test-case = "2.2.2"
 ctor = "0.1.26"
 tempdir = "0.3.7"
-wasm-bindgen-test = "0.3.34"
-wasm-bindgen-futures = "0.4.34"
-
 
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+
 
 [dependencies.web-sys]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ lazy_static = "1.4.0"
 mnist = "0.5"
 seq-macro = "0.3.1"
 test-case = "2.2.2"
-ctor = "0.1.26"
 tempdir = "0.3.7"
 wasm-bindgen-futures = "0.4.34"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bincode = "*"
 wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"]}
 console_error_panic_hook = "0.1.7"
 serde-wasm-bindgen = "0.4"
+wasm-bindgen-rayon = "1.0"
 
 # python binding related deps
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37"], optional = true }
@@ -71,9 +72,15 @@ test-case = "2.2.2"
 ctor = "0.1.26"
 tempdir = "0.3.7"
 wasm-bindgen-test = "0.3.34"
+wasm-bindgen-futures = "0.4.34"
+
 
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+
+[dependencies.web-sys]
+version = "*"
+features = ["console", "Window", "Navigator"]
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ puruspe = "0.2.0"
 rayon = "*"
 serde_traitobject = "0.2.8"
 bincode = "*"
-wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"]}
-console_error_panic_hook = "0.1.7"
 
 # python binding related deps
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37"], optional = true }
@@ -57,12 +55,14 @@ ethers-solc = "2.0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.8", features = ["js"] }
-wasm-bindgen-test = "0.3.34"
-wasm-bindgen-futures = "0.4.34"
-serde-wasm-bindgen = "0.4"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen-rayon = "1.0"
+wasm-bindgen-test = "0.3.34"
+serde-wasm-bindgen = "0.4"
+wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"]}
+console_error_panic_hook = "0.1.7"
+
 
 
 [dev-dependencies]
@@ -75,6 +75,7 @@ seq-macro = "0.3.1"
 test-case = "2.2.2"
 ctor = "0.1.26"
 tempdir = "0.3.7"
+wasm-bindgen-futures = "0.4.34"
 
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'

--- a/examples/notebook/ezkl_demo.ipynb
+++ b/examples/notebook/ezkl_demo.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "id": "95613ee9",
    "metadata": {},
    "outputs": [],
@@ -89,13 +89,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "id": "2e09b03f",
    "metadata": {},
    "outputs": [],
    "source": [
     "\n",
     "output_path = os.path.join('input.json')\n",
+    "\n",
+    "data_path = os.path.join('input.json')\n",
+    "\n",
+    "model_path = os.path.join('network.onnx')\n",
     "\n",
     "res = ezkl_lib.forward(data_path, model_path, output_path)\n",
     "\n",
@@ -105,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "id": "b1c561a8",
    "metadata": {},
    "outputs": [
@@ -130,11 +134,6 @@
     "# EVERYTHING ANYONE HAS EVER NEEDED FOR ZK \n",
     "\n",
     "\n",
-    "\n",
-    "data_path = os.path.join('input.json')\n",
-    "\n",
-    "model_path = os.path.join('network.onnx')\n",
-    "\n",
     "pk_path = os.path.join('test.pk')\n",
     "vk_path = os.path.join('test.vk')\n",
     "circuit_params_path = os.path.join('circuit.params')\n",
@@ -157,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "id": "c384cbc8",
    "metadata": {},
    "outputs": [
@@ -196,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "id": "76f00d41",
    "metadata": {},
    "outputs": [

--- a/examples/onnx/doodles/gen.py
+++ b/examples/onnx/doodles/gen.py
@@ -1,0 +1,14 @@
+from torch import nn
+from ezkl import export
+
+
+class MyModel(nn.Module):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def forward(self, x):
+        return x
+
+
+circuit = MyModel()
+export(circuit, input_shape=[1, 64, 64])

--- a/examples/onnx/doodles/network.onnx
+++ b/examples/onnx/doodles/network.onnx
@@ -1,0 +1,18 @@
+pytorch1.13.1:‰
+%
+inputoutput
+Identity_0"Identity	torch_jitZ)
+input 
+
+
+batch_size
+
+@
+@b*
+output 
+
+
+batch_size
+
+@
+@B

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -22,10 +22,10 @@ use halo2_proofs::{
 use log::warn;
 #[cfg(feature = "python-bindings")]
 use pyo3::{
+    conversion::{FromPyObject, PyTryFrom},
     exceptions::PyValueError,
     prelude::*,
     types::PyString,
-    conversion::{FromPyObject, PyTryFrom}
 };
 use serde::{Deserialize, Serialize};
 
@@ -97,9 +97,8 @@ impl<'source> FromPyObject<'source> for CheckMode {
         match strval.to_lowercase().as_str() {
             "safe" => Ok(CheckMode::SAFE),
             "unsafe" => Ok(CheckMode::UNSAFE),
-            _ => Err(PyValueError::new_err("Invalid value for CheckMode"))
+            _ => Err(PyValueError::new_err("Invalid value for CheckMode")),
         }
-
     }
 }
 
@@ -284,11 +283,7 @@ impl<F: PrimeField + TensorType + PartialOrd> BaseConfig<F> {
                                 qlookup.clone() * cs.query_advice(advices[x], Rotation(0))
                                     + not_qlookup.clone() * default_x
                             }
-                            VarTensor::Fixed { inner: fixed, .. } => {
-                                qlookup.clone() * cs.query_fixed(fixed[x], Rotation(0))
-                                    + not_qlookup.clone() * default_x
-                            }
-                            _ => panic!("uninitialized Vartensor"),
+                            _ => panic!("wrong input type"),
                         },
                         table.table_input,
                     ),
@@ -298,11 +293,7 @@ impl<F: PrimeField + TensorType + PartialOrd> BaseConfig<F> {
                                 qlookup * cs.query_advice(advices[x], Rotation(0))
                                     + not_qlookup * default_y
                             }
-                            VarTensor::Fixed { inner: fixed, .. } => {
-                                qlookup * cs.query_fixed(fixed[x], Rotation(0))
-                                    + not_qlookup * default_y
-                            }
-                            _ => panic!("uninitialized Vartensor"),
+                            _ => panic!("wrong output type"),
                         },
                         table.table_output,
                     ),

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -443,40 +443,28 @@ pub fn new_op_from_onnx<F: PrimeField + TensorType + PartialOrd>(
             };
 
             let axes = &op.axes;
-            if axes.to_string() == "mk,nk->mn"
-                || axes.to_string() == "mk,k->mn"
-                || axes.to_string() == "mk,nk->n"
-                || axes.to_string() == "k,nk->mn"
-                || axes.to_string() == "abmk,abkn->abmn"
-                || axes.to_string() == "k,nk->n"
-                || axes.to_string() == "amk,kn->mn"
-                || axes.to_string() == "amk,kn->bmn"
-                || axes.to_string() == "mbk,anbk->abmn"
-                || axes.to_string() == "abmk,abkn->mbn"
-                || axes.to_string() == "mk,kn->amn"
-                || axes.to_string() == "amk,kn->amn"
-            {
-                let mut params = None;
 
-                for (idx, inp) in inputs.clone().iter().enumerate() {
-                    let boxed_op = &inp.opkind;
-                    if let Some(c) = boxed_op
-                        .as_any()
-                        .downcast_ref::<crate::circuit::ops::Constant<F>>()
-                    {
-                        inputs.remove(idx);
-                        params = Some(tensor_to_valtensor::<F>(
-                            c.values.clone(),
-                            scale,
-                            public_params,
-                        )?);
-                    }
+            // TODO: this is a hack to get around the fact that tract eplaces matmul with einsum pending this PR: https://github.com/sonos/tract/pull/1070
+            warn!("matching einsum axes {:?} as a matmul operation", axes);
+
+            let mut params = None;
+
+            for (idx, inp) in inputs.clone().iter().enumerate() {
+                let boxed_op = &inp.opkind;
+                if let Some(c) = boxed_op
+                    .as_any()
+                    .downcast_ref::<crate::circuit::ops::Constant<F>>()
+                {
+                    inputs.remove(idx);
+                    params = Some(tensor_to_valtensor::<F>(
+                        c.values.clone(),
+                        scale,
+                        public_params,
+                    )?);
                 }
-
-                Box::new(PolyOp::Matmul { a: params })
-            } else {
-                panic!("einsum not supported")
             }
+
+            Box::new(PolyOp::Matmul { a: params })
         }
         "Softmax" => {
             // Extract the slope layer hyperparams

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -442,10 +442,10 @@ pub fn new_op_from_onnx<F: PrimeField + TensorType + PartialOrd>(
                 }
             };
 
-            let axes = &op.axes;
+            let _axes = &op.axes;
 
             // TODO: this is a hack to get around the fact that tract eplaces matmul with einsum pending this PR: https://github.com/sonos/tract/pull/1070
-            warn!("matching einsum axes {:?} as a matmul operation", axes);
+            warn!("matching einsum as a matmul operation");
 
             let mut params = None;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -13,6 +13,8 @@ use wasm_bindgen::prelude::*;
 
 use console_error_panic_hook;
 
+pub use wasm_bindgen_rayon::init_thread_pool;
+
 #[wasm_bindgen]
 /// Initialize panic hook for wasm
 pub fn init_panic_hook() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -175,12 +175,21 @@ mod native_tests {
             use crate::native_tests::TESTS_AGGR;
             use test_case::test_case;
             use crate::native_tests::kzg_aggr_prove_and_verify;
+            use std::sync::Once;
+            static START: Once = Once::new();
+            //Sure to run this once
+            fn setup_tests() {
+                START.call_once(|| {
+                    crate::native_tests::init_binary();
+                    crate::native_tests::init_params();
+                });
+            }
+
             seq!(N in 0..=17 {
 
             #(#[test_case(TESTS_AGGR[N])])*
             fn kzg_aggr_prove_and_verify_(test: &str) {
-                crate::native_tests::init_binary();
-                crate::native_tests::init_params();
+                setup_tests();
                 kzg_aggr_prove_and_verify(test.to_string());
             }
 
@@ -233,10 +242,20 @@ mod native_tests {
             use crate::native_tests::kzg_prove_and_verify;
             use crate::native_tests::render_circuit;
             use crate::native_tests::tutorial as run_tutorial;
+            use std::sync::Once;
+            static START: Once = Once::new();
 
             #[test]
             fn tutorial_() {
                 run_tutorial();
+            }
+
+            //Sure to run this once
+            fn setup_tests() {
+                START.call_once(|| {
+                    crate::native_tests::init_binary();
+                    crate::native_tests::init_params();
+                });
             }
 
 
@@ -274,8 +293,7 @@ mod native_tests {
 
             #(#[test_case(TESTS[N])])*
             fn kzg_prove_and_verify_(test: &str) {
-                crate::native_tests::init_binary();
-                crate::native_tests::init_params();
+                setup_tests();
                 kzg_prove_and_verify(test.to_string());
             }
 
@@ -310,20 +328,28 @@ mod native_tests {
                 "1l_var"
             ];
 
+            use std::sync::Once;
+            static START: Once = Once::new();
+            //Sure to run this once
+            fn setup_tests() {
+                START.call_once(|| {
+                    crate::native_tests::init_binary();
+                    crate::native_tests::init_params();
+                });
+            }
+
             seq!(N in 0..=17 {
 
                 #(#[test_case(TESTS_EVM[N])])*
                 fn kzg_evm_prove_and_verify_(test: &str) {
-                    crate::native_tests::init_binary();
-                    crate::native_tests::init_params();
+                    setup_tests();
                     kzg_evm_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test));
                 }
                 // these take a particularly long time to run
                 #(#[test_case(TESTS_EVM[N])])*
                 #[ignore]
                 fn kzg_evm_aggr_prove_and_verify_(test: &str) {
-                    crate::native_tests::init_binary();
-                    crate::native_tests::init_params();
+                    setup_tests();
                     kzg_evm_aggr_prove_and_verify(test.to_string());
                 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -21,9 +21,7 @@ mod native_tests {
     fn init_binary() {
         COMPILE.call_once(|| {
             println!("using cargo target dir: {}", *CARGO_TARGET_DIR);
-            if !std::path::Path::new(&format!("{}/release/ezkl", *CARGO_TARGET_DIR)).is_file() {
-                build_ezkl();
-            }
+            build_ezkl();
         });
     }
 

--- a/tests/wasi_integration_tests.rs
+++ b/tests/wasi_integration_tests.rs
@@ -14,9 +14,7 @@ mod wasi_tests {
     fn init() {
         COMPILE.call_once(|| {
             println!("using cargo target dir: {}", *CARGO_TARGET_DIR);
-            if !std::path::Path::new(&format!("{}/release/ezkl", *CARGO_TARGET_DIR)).is_file() {
-                build_ezkl_wasm();
-            }
+            build_ezkl_wasm();
         });
     }
 

--- a/tests/wasi_integration_tests.rs
+++ b/tests/wasi_integration_tests.rs
@@ -3,6 +3,8 @@ mod wasi_tests {
     use lazy_static::lazy_static;
     use std::env::var;
     use std::process::Command;
+    use std::sync::Once;
+    static COMPILE: Once = Once::new();
 
     lazy_static! {
         static ref CARGO_TARGET_DIR: String =
@@ -10,15 +12,12 @@ mod wasi_tests {
     }
 
     fn init() {
-        println!("using cargo target dir: {}", *CARGO_TARGET_DIR);
-        if !std::path::Path::new(&format!(
-            "{}/wasm32-wasi/release/ezkl.wasm",
-            *CARGO_TARGET_DIR
-        ))
-        .is_file()
-        {
-            build_ezkl_wasm();
-        }
+        COMPILE.call_once(|| {
+            println!("using cargo target dir: {}", *CARGO_TARGET_DIR);
+            if !std::path::Path::new(&format!("{}/release/ezkl", *CARGO_TARGET_DIR)).is_file() {
+                build_ezkl_wasm();
+            }
+        });
     }
 
     const TESTS: [&str; 19] = [

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,4 +1,5 @@
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(test)]
 mod wasm32 {
     use ezkl_lib::pfsys::Snarkbytes;
     use ezkl_lib::wasm::{prove_wasm, verify_wasm};

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,7 +3,10 @@ mod wasm32 {
     use ezkl_lib::pfsys::Snarkbytes;
     use ezkl_lib::wasm::{prove_wasm, verify_wasm};
 
+    pub use wasm_bindgen_rayon::init_thread_pool;
     use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
 
     pub const KZG_PARAMS: &[u8] = include_bytes!("../tests/wasm/kzg");
     pub const CIRCUIT_PARAMS: &[u8] = include_bytes!("../tests/wasm/circuit");
@@ -14,7 +17,7 @@ mod wasm32 {
     pub const NETWORK: &[u8] = include_bytes!("../tests/wasm/test.onnx");
 
     #[wasm_bindgen_test]
-    fn verify_pass() {
+    async fn verify_pass() {
         let value = verify_wasm(
             wasm_bindgen::Clamped(PROOF.to_vec()),
             wasm_bindgen::Clamped(VK.to_vec()),
@@ -25,7 +28,7 @@ mod wasm32 {
     }
 
     #[wasm_bindgen_test]
-    fn verify_fail() {
+    async fn verify_fail() {
         let proof = Snarkbytes {
             proof: vec![0; 32],
             num_instance: vec![1],
@@ -44,7 +47,7 @@ mod wasm32 {
     }
 
     #[wasm_bindgen_test]
-    fn prove_pass() {
+    async fn prove_pass() {
         // prove
         let proof = prove_wasm(
             wasm_bindgen::Clamped(INPUT.to_vec()),


### PR DESCRIPTION
- Building on #225 and #219, here we re-export `init_thread_pool` to enable for thread pools in web workers :) 
- CI tests also explicitly test in the browser rather than node