### PR TITLE
refactor: require deployment code path

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -382,9 +382,9 @@ pub enum Commands {
         /// The path to load the desired verfication key file
         #[arg(long)]
         vk_path: PathBuf,
-        /// The path to output to the desired EVM bytecode file (optional)
+        /// The path to output to the desired EVM bytecode file
         #[arg(long)]
-        deployment_code_path: Option<PathBuf>,
+        deployment_code_path: PathBuf,
         /// The path to output the Solidity code
         #[arg(long)]
         sol_code_path: Option<PathBuf>,

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -452,7 +452,7 @@ fn create_evm_verifier(
     vk_path: PathBuf,
     params_path: PathBuf,
     circuit_params_path: PathBuf,
-    deployment_code_path: Option<PathBuf>,
+    deployment_code_path: PathBuf,
     sol_code_path: Option<PathBuf>,
 ) -> Result<(), Box<dyn Error>> {
     let model_circuit_params = ModelParams::load(&circuit_params_path);
@@ -469,7 +469,7 @@ fn create_evm_verifier(
     trace!("params computed");
 
     let (deployment_code, yul_code) = gen_evm_verifier(&params, &vk, num_instance)?;
-    deployment_code.save(deployment_code_path.as_ref().unwrap())?;
+    deployment_code.save(&deployment_code_path)?;
 
     if sol_code_path.is_some() {
         let mut f = File::create(sol_code_path.as_ref().unwrap())?;

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -955,9 +955,8 @@ impl<F: PrimeField + TensorType + PartialOrd> Model<F> {
             .collect_vec()
     }
 
-    /// Number of instances used by the circuit
+    /// Shapes of the computational graph's public inputs (if any)
     pub fn instance_shapes(&self) -> Vec<Vec<usize>> {
-        // for now the number of instances corresponds to the number of graph / model outputs
         let mut instance_shapes = vec![];
         if self.visibility.input.is_public() {
             instance_shapes.extend(self.input_shapes());


### PR DESCRIPTION
Optional deployment code path has caused confusion when creating the EVM verifier. Here we force its passage as an argument