### PR TITLE
fix: add public/public solidity tests

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -87,7 +87,9 @@ pub async fn verify_proof_via_solidity(
     let contract = Verifier::new(addr, client.clone());
 
     let mut public_inputs = vec![];
-    for val in &proof.instances[0] {
+    let flattened_instances = proof.instances.into_iter().flatten();
+    
+    for val in flattened_instances {
         let bytes = val.to_repr();
         let u = U256::from_little_endian(bytes.as_slice());
         public_inputs.push(u);
@@ -306,7 +308,9 @@ pub async fn send_proof<M: 'static + Middleware>(
         let contract = Verifier::new(addr, client.clone());
 
         let mut public_inputs = vec![];
-        for val in &snark.instances[0] {
+        let flattened_instances = snark.instances.into_iter().flatten();
+
+        for val in flattened_instances {
             let bytes = val.to_repr();
             let u = U256::from_little_endian(bytes.as_slice());
             public_inputs.push(u);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -382,7 +382,9 @@ mod native_tests {
                 fn kzg_evm_prove_and_verify_(test: &str) {
                     crate::native_tests::init_binary();
                     crate::native_tests::init_params_17();
-                    kzg_evm_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test));
+                    kzg_evm_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), false, true);
+                    kzg_evm_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), true, true);
+                    kzg_evm_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), true, false);
                 }
 
                 #(#[test_case(TESTS_EVM[N])])*
@@ -397,7 +399,9 @@ mod native_tests {
                 fn kzg_evm_aggr_prove_and_verify_(test: &str) {
                     crate::native_tests::init_binary();
                     crate::native_tests::init_params_23();
-                    kzg_evm_aggr_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test));
+                    kzg_evm_aggr_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), false, true);
+                    kzg_evm_aggr_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), true, true);
+                    kzg_evm_aggr_prove_and_verify(test.to_string(), TESTS_SOLIDITY.contains(&test), true, false);
                 }
 
             });
@@ -791,7 +795,7 @@ mod native_tests {
     }
 
     // prove-serialize-verify, the usual full path
-    fn kzg_evm_aggr_prove_and_verify(example_name: String, with_solidity: bool) {
+    fn kzg_evm_aggr_prove_and_verify(example_name: String, with_solidity: bool, public_inputs: bool, public_outputs: bool) {
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
                 "setup",
@@ -822,6 +826,8 @@ mod native_tests {
                 ),
                 "--bits=16",
                 "-K=17",
+                &format!("--public-inputs={}", public_inputs),
+                &format!("--public-outputs={}", public_outputs)
             ])
             .status()
             .expect("failed to execute process");
@@ -1079,7 +1085,7 @@ mod native_tests {
     }
 
     // prove-serialize-verify, the usual full path
-    fn kzg_evm_prove_and_verify(example_name: String, with_solidity: bool) {
+    fn kzg_evm_prove_and_verify(example_name: String, with_solidity: bool, public_inputs: bool, public_outputs: bool) {
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
                 "setup",
@@ -1102,6 +1108,8 @@ mod native_tests {
                 ),
                 "--bits=16",
                 "-K=17",
+                &format!("--public-inputs={}", public_inputs),
+                &format!("--public-outputs={}", public_outputs)
             ])
             .status()
             .expect("failed to execute process");


### PR DESCRIPTION
Instances in the send_proof and verify_via_solidity functions need to be flatted before they are iterated through to fill in the public_inputs vector. The previous test cases only checked the default case (public-input=false, public-output=true), which passed since the instances were only length 1 in that case. But when both public input and output are set to true the instances length is equal to 2, and therefore only the public input instances in the instances[0] were parsed into public_inputs, omiting the public_outputs which should come after. 