### PR TITLE
fix: comment out linux-cross

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -251,7 +251,9 @@ jobs:
     permissions:
       id-token: write
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux, linux-cross, musllinux, musllinux-cross ]
+    # TODO: Uncomment if linux-cross is working
+    # needs: [ macos, windows, linux, linux-cross, musllinux, musllinux-cross ]
+    needs: [ macos, windows, linux, musllinux, musllinux-cross ]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -115,55 +115,56 @@ jobs:
         name: wheels
         path: dist
 
-  linux-cross:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [aarch64, armv7]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
+  # TODO: There's a problem with the maturin-action toolchain for arm arch leading to failed builds
+  # linux-cross:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       target: [aarch64, armv7]
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: 3.7
 
-    - name: Install cross-compilation tools for aarch64
-      if: matrix.target == 'aarch64'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross libusb-1.0-0-dev libatomic1-arm64-cross
+  #   - name: Install cross-compilation tools for aarch64
+  #     if: matrix.target == 'aarch64'
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross libusb-1.0-0-dev libatomic1-arm64-cross
 
-    - name: Install cross-compilation tools for armv7
-      if: matrix.target == 'armv7'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc make gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libc6-dev-armhf-cross libusb-1.0-0-dev libatomic1-armhf-cross
+  #   - name: Install cross-compilation tools for armv7
+  #     if: matrix.target == 'armv7'
+  #     run: |
+  #       sudo apt-get update
+  #       sudo apt-get install -y gcc make gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libc6-dev-armhf-cross libusb-1.0-0-dev libatomic1-armhf-cross
 
-    - name: Build wheels
-      uses: PyO3/maturin-action@v1
-      with:
-        target: ${{ matrix.target }}
-        manylinux: auto
-        args: --release --out dist --features python-bindings
+  #   - name: Build wheels
+  #     uses: PyO3/maturin-action@v1
+  #     with:
+  #       target: ${{ matrix.target }}
+  #       manylinux: auto
+  #       args: --release --out dist --features python-bindings
 
-    - uses: uraimo/run-on-arch-action@v2.5.0
-      name: Install built wheel
-      with:
-        arch: ${{ matrix.target }}
-        distro: ubuntu20.04
-        githubToken: ${{ github.token }}
-        install: |
-          apt-get update
-          apt-get install -y --no-install-recommends python3 python3-pip
-          pip3 install -U pip
-        run: |
-          pip3 install ezkl_lib --no-index --find-links dist/ --force-reinstall
-          python3 -c "import ezkl_lib"
+  #   - uses: uraimo/run-on-arch-action@v2.5.0
+  #     name: Install built wheel
+  #     with:
+  #       arch: ${{ matrix.target }}
+  #       distro: ubuntu20.04
+  #       githubToken: ${{ github.token }}
+  #       install: |
+  #         apt-get update
+  #         apt-get install -y --no-install-recommends python3 python3-pip
+  #         pip3 install -U pip
+  #       run: |
+  #         pip3 install ezkl_lib --no-index --find-links dist/ --force-reinstall
+  #         python3 -c "import ezkl_lib"
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: dist
+  #   - name: Upload wheels
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
 
   musllinux:
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==22.2.0
 exceptiongroup==1.1.1
 importlib-metadata==6.1.0
 iniconfig==2.0.0
-maturin==0.14.17
+maturin==1.0.1
 packaging==23.0
 pluggy==1.0.0
 pytest==7.2.2


### PR DESCRIPTION
Changes:

1. There's a problem with the cross compilation linux toolchain for likely due to some python and gcc dependencies not being properly linked in the maturin-actions container used to compile. This PR will temporarily omit out `linux-cross` to enable builds on other platforms for the time being. 