### PR TITLE
ci: tag automation

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -17,3 +17,4 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
Changes:

1. Introduce tag automation

Notes:

Only merge this to main after the first release is published, otherwise it will simply start from v0.0.0 instead of the intended first version