### PR TITLE
feat: wasm setup params

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,15 +1,20 @@
 use std::sync::Arc;
 
 use halo2_proofs::plonk::*;
-use halo2_proofs::poly::commitment::ParamsProver;
+use halo2_proofs::poly::commitment::{ParamsProver, CommitmentScheme};
 use halo2_proofs::poly::kzg::{
-    commitment::ParamsKZG, strategy::SingleStrategy as KZGSingleStrategy,
+    commitment::{KZGCommitmentScheme, ParamsKZG},
+    strategy::SingleStrategy as KZGSingleStrategy,
 };
+use halo2curves::ff::{FromUniformBytes, PrimeField};
 use halo2curves::bn256::{Bn256, Fr, G1Affine};
+
 
 use halo2curves::serde::SerdeObject;
 use snark_verifier::system::halo2::compile;
 use wasm_bindgen::prelude::*;
+use crate::graph::vars::VarVisibility;
+use crate::tensor::TensorType;
 
 use console_error_panic_hook;
 
@@ -25,8 +30,95 @@ use crate::execute::{create_proof_circuit_kzg, verify_proof_circuit_kzg};
 use crate::graph::{ModelCircuit, ModelParams};
 use crate::pfsys::Snarkbytes;
 
+/// Generate circuit params in browser
 #[wasm_bindgen]
+pub fn gen_circuit_params_wasm(
+    circuit_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    run_args_ser: wasm_bindgen::Clamped<Vec<u8>>,
+) -> Vec<u8> {
+    let run_args: crate::commands::RunArgs = bincode::deserialize(&run_args_ser[..]).unwrap();
+    // get Varvisibility
+    let var_visibility = VarVisibility::from_args(run_args.clone()).expect("Failed to create VarVisibility");
+
+    // read in circuit
+    let mut reader = std::io::BufReader::new(&circuit_ser[..]);
+    let model = crate::graph::Model::new(
+        &mut reader,
+        run_args,
+        var_visibility,
+    )
+    .unwrap();
+    let circuit =
+        ModelCircuit::<Fr>::new(Arc::new(model), crate::circuit::CheckMode::UNSAFE).unwrap();
+    let circuit_params = circuit.params;
+    bincode::serialize(&circuit_params).unwrap()
+}
+
+/// Generate proving key in browser
+#[wasm_bindgen]
+pub fn gen_pk_wasm(
+    circuit_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+) -> Vec<u8> {
+    // read in circuit params
+    let circuit_params: ModelParams = bincode::deserialize(&circuit_params_ser[..]).unwrap();
+    // read in kzg params
+    let mut reader = std::io::BufReader::new(&params_ser[..]);
+    let params: ParamsKZG<Bn256> =
+        halo2_proofs::poly::commitment::Params::<'_, G1Affine>::read(&mut reader).unwrap();
+    // read in circuit
+    let mut circuit_reader = std::io::BufReader::new(&circuit_ser[..]);
+    let model = crate::graph::Model::new(
+        &mut circuit_reader,
+        circuit_params.run_args,
+        circuit_params.visibility,
+    )
+    .unwrap();
+
+    let circuit =
+        ModelCircuit::<Fr>::new(Arc::new(model), crate::circuit::CheckMode::UNSAFE).unwrap();
+
+    let pk = create_keys_wasm::<KZGCommitmentScheme<Bn256>, Fr, ModelCircuit<Fr>>(&circuit, &params)
+        .map_err(Box::<dyn std::error::Error>::from)
+        .unwrap();
+
+    let mut serialized_pk = Vec::new();
+    pk.write(&mut serialized_pk, halo2_proofs::SerdeFormat::RawBytes)
+        .unwrap();
+
+    serialized_pk
+}
+
+/// Generate verifying key in browser
+#[wasm_bindgen]
+pub fn gen_vk_wasm(
+    pk: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+) -> Vec<u8> {
+    // read in circuit params
+    let circuit_params: ModelParams = bincode::deserialize(&circuit_params_ser[..]).unwrap();
+
+    // read in proving key
+    let mut reader = std::io::BufReader::new(&pk[..]);
+    let pk = ProvingKey::<G1Affine>::read::<_, ModelCircuit<Fr>>(
+        &mut reader,
+        halo2_proofs::SerdeFormat::RawBytes,
+        circuit_params.clone(),
+    )
+    .unwrap();
+
+    let vk = pk.get_vk();
+
+    let mut serialized_vk = Vec::new();
+    vk.write(&mut serialized_vk, halo2_proofs::SerdeFormat::RawBytes)
+        .unwrap();
+
+    serialized_vk
+}
+
 /// Verify proof in browser using wasm
+#[wasm_bindgen]
 pub fn verify_wasm(
     proof_js: wasm_bindgen::Clamped<Vec<u8>>,
     vk: wasm_bindgen::Clamped<Vec<u8>>,
@@ -141,4 +233,25 @@ pub fn prove_wasm(
     .unwrap();
 
     bincode::serialize(&proof.to_bytes()).unwrap()
+}
+
+// HELPER FUNCTIONS
+
+/// Creates a [VerifyingKey] and [ProvingKey] for a [ModelCircuit] (`circuit`) with specific [CommitmentScheme] parameters (`params`) for the WASM target
+#[cfg(target_arch = "wasm32")]
+pub fn create_keys_wasm<Scheme: CommitmentScheme, F: PrimeField + TensorType, C: Circuit<F>>(
+    circuit: &C,
+    params: &'_ Scheme::ParamsProver,
+) -> Result<ProvingKey<Scheme::Curve>, halo2_proofs::plonk::Error>
+where
+    C: Circuit<Scheme::Scalar>,
+    <Scheme as CommitmentScheme>::Scalar: FromUniformBytes<64>,
+{
+    //	Real proof
+    let empty_circuit = <C as Circuit<F>>::without_witnesses(circuit);
+
+    // Initialize the proving key
+    let vk = keygen_vk(params, &empty_circuit)?;
+    let pk = keygen_pk(params, vk, &empty_circuit)?;
+    Ok(pk)
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,9 +1,12 @@
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[cfg(test)]
 mod wasm32 {
+    use ezkl_lib::circuit::Tolerance;
+    use ezkl_lib::commands::RunArgs;
     use ezkl_lib::pfsys::Snarkbytes;
-    use ezkl_lib::wasm::{prove_wasm, verify_wasm};
-
+    use ezkl_lib::wasm::{
+        gen_circuit_params_wasm, gen_pk_wasm, gen_vk_wasm, prove_wasm, verify_wasm,
+    };
     pub use wasm_bindgen_rayon::init_thread_pool;
     use wasm_bindgen_test::*;
 
@@ -63,6 +66,94 @@ mod wasm32 {
         let value = verify_wasm(
             wasm_bindgen::Clamped(proof.to_vec()),
             wasm_bindgen::Clamped(VK.to_vec()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
+        );
+        // should not fail
+        assert!(value);
+    }
+
+    #[wasm_bindgen_test]
+    async fn gen_circuit_params_test() {
+        let run_args = RunArgs {
+            tolerance: Tolerance::default(),
+            scale: 7,
+            bits: 16,
+            logrows: 17,
+            batch_size: 1,
+            public_inputs: false,
+            public_outputs: true,
+            public_params: false,
+            pack_base: 1,
+            allocated_constraints: Some(1000), // assuming an arbitrary value here for the sake of the example
+        };
+
+        let serialized_run_args =
+            bincode::serialize(&run_args).expect("Failed to serialize RunArgs");
+
+        let circuit_params = gen_circuit_params_wasm(
+            wasm_bindgen::Clamped(NETWORK.to_vec()),
+            wasm_bindgen::Clamped(serialized_run_args),
+        );
+
+        assert!(circuit_params.len() > 0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn gen_pk_test() {
+        let pk = gen_pk_wasm(
+            wasm_bindgen::Clamped(NETWORK.to_vec()),
+            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+        );
+
+        assert!(pk.len() > 0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn gen_vk_test() {
+        let pk = gen_pk_wasm(
+            wasm_bindgen::Clamped(NETWORK.to_vec()),
+            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+        );
+
+        let vk = gen_vk_wasm(
+            wasm_bindgen::Clamped(pk),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+        );
+
+        assert!(vk.len() > 0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn pk_is_valid_test() {
+        let pk = gen_pk_wasm(
+            wasm_bindgen::Clamped(NETWORK.to_vec()),
+            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+        );
+
+        assert!(pk.len() > 0);
+
+        // prove
+        let proof = prove_wasm(
+            wasm_bindgen::Clamped(INPUT.to_vec()),
+            wasm_bindgen::Clamped(pk.clone()),
+            wasm_bindgen::Clamped(NETWORK.to_vec()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
+        );
+        assert!(proof.len() > 0);
+
+        let vk = gen_vk_wasm(
+            wasm_bindgen::Clamped(pk.clone()),
+            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
+        );
+
+        let value = verify_wasm(
+            wasm_bindgen::Clamped(proof.to_vec()),
+            wasm_bindgen::Clamped(vk),
             wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
             wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
         );


### PR DESCRIPTION
This PR creates WASM bindings for:
- Generating circuit parameters
- Generating proving and verifying keys

Future work:
- When WASM-bindgen multivalue is available, consolidate all three functions to one `setup()` function.