### PR TITLE
refactor: avoid overloading "params"

### DIFF
--- a/src/circuit/modules/poseidon.rs
+++ b/src/circuit/modules/poseidon.rs
@@ -34,6 +34,8 @@ pub struct PoseidonConfig<const WIDTH: usize, const RATE: usize> {
     pub pow5_config: Pow5Config<Fp, WIDTH, RATE>,
 }
 
+type InputAssignments = (Vec<AssignedCell<Fp, Fp>>, AssignedCell<Fp, Fp>);
+
 /// PoseidonChip is a wrapper around the Pow5Chip that adds a set of advice columns to the gadget Chip to store the inputs of the hash
 #[derive(Debug, Clone)]
 pub struct PoseidonChip<
@@ -96,7 +98,7 @@ impl<S: Spec<Fp, WIDTH, RATE>, const WIDTH: usize, const RATE: usize, const L: u
         &self,
         layouter: &mut impl Layouter<Fp>,
         message: &ValTensor<Fp>,
-    ) -> Result<(Vec<AssignedCell<Fp, Fp>>, AssignedCell<Fp, Fp>), Error> {
+    ) -> Result<InputAssignments, Error> {
         layouter
             .assign_region(
                 || "load message",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -97,7 +97,7 @@ pub struct CalibrationArgs {
     /// The path to the .json calibration data file. If set will finetune the selected parameters to a calibration dataset.
     #[arg(long = "calibration-data")]
     pub data: Option<PathBuf>,
-    #[arg(long = "calibration-target")]
+    #[arg(long = "calibration-target", default_value = "resources")]
     /// Target for calibration.
     pub target: CalibrationTarget,
 }
@@ -267,20 +267,10 @@ pub enum Commands {
         #[arg(short = 'O', long)]
         output: PathBuf,
         /// Scale to use for quantization
-        #[arg(
-            short = 'S',
-            long,
-            default_value = "7",
-            conflicts_with = "circuit_params_path"
-        )]
+        #[arg(short = 'S', long, conflicts_with = "circuit_params_path")]
         scale: Option<u32>,
         /// The number of batches to split the input data into
-        #[arg(
-            short = 'B',
-            long,
-            default_value = "1",
-            conflicts_with = "circuit_params_path"
-        )]
+        #[arg(short = 'B', long, conflicts_with = "circuit_params_path")]
         batch_size: Option<usize>,
         /// optional circuit params path
         #[arg(long)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -99,7 +99,7 @@ pub struct CalibrationArgs {
     pub data: Option<PathBuf>,
     #[arg(long = "calibration-target")]
     /// Target for calibration.
-    pub target: Option<CalibrationTarget>,
+    pub target: CalibrationTarget,
 }
 
 #[derive(clap::ValueEnum, Debug, Default, Copy, Clone, Serialize, Deserialize)]
@@ -295,7 +295,7 @@ pub enum Commands {
         #[arg(short = 'M', long)]
         model: PathBuf,
         /// Path to circuit_params file to output
-        #[arg(short = 'O', long)]
+        #[arg(short = 'O', long, default_value = "circuit.json")]
         circuit_params_path: PathBuf,
         /// proving arguments
         #[clap(flatten)]
@@ -309,7 +309,7 @@ pub enum Commands {
     #[command(name = "gen-srs", arg_required_else_help = true)]
     GenSrs {
         /// The path to output to the desired params file
-        #[arg(long)]
+        #[arg(long, default_value = "kzg.params")]
         params_path: PathBuf,
         /// number of logrows to use for srs
         #[arg(long)]
@@ -345,10 +345,10 @@ pub enum Commands {
         #[arg(long)]
         aggregation_vk_paths: Vec<PathBuf>,
         /// The path to save the desired verfication key file
-        #[arg(long)]
+        #[arg(long, default_value = "vk_aggr.key")]
         vk_path: PathBuf,
         /// The path to the desired output file
-        #[arg(long)]
+        #[arg(long, default_value = "proof_aggr.proof")]
         proof_path: PathBuf,
         /// The transcript type
         #[arg(long)]
@@ -379,10 +379,10 @@ pub enum Commands {
         #[arg(long)]
         params_path: PathBuf,
         /// The path to output the verfication key file
-        #[arg(long)]
+        #[arg(long, default_value = "vk.key")]
         vk_path: PathBuf,
         /// The path to output the proving key file
-        #[arg(long)]
+        #[arg(long, default_value = "pk.key")]
         pk_path: PathBuf,
         /// The path to load circuit params from
         #[arg(long)]
@@ -411,7 +411,7 @@ pub enum Commands {
         #[clap(flatten)]
         args: RunArgs,
         /// number of fuzz iterations
-        #[arg(long)]
+        #[arg(long, default_value = "10")]
         num_runs: usize,
         /// optional circuit params path (overrides any run args set)
         #[arg(long)]
@@ -431,7 +431,7 @@ pub enum Commands {
         #[arg(long)]
         pk_path: PathBuf,
         /// The path to the desired output file
-        #[arg(long)]
+        #[arg(long, default_value = "proof.proof")]
         proof_path: PathBuf,
         /// The parameter path
         #[arg(long)]
@@ -474,13 +474,13 @@ pub enum Commands {
         #[arg(long)]
         vk_path: PathBuf,
         /// The path to the compiled yul bytecode code
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy.yul")]
         deployment_code_path: PathBuf,
         /// The path to output the Solidity code
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy.sol")]
         sol_code_path: Option<PathBuf>,
         /// The path to output the compiled Solidity bytecode
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy.sol.bin")]
         sol_bytecode_path: Option<PathBuf>,
         /// The number of runs set to the SOLC optimizer.
         /// Lower values optimze for deployment size while higher values optimize for execution cost.
@@ -501,13 +501,13 @@ pub enum Commands {
         #[arg(long)]
         vk_path: PathBuf,
         /// The path to the compiled yul bytecode code
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy_aggr.yul")]
         deployment_code_path: Option<PathBuf>,
         /// The path to the Solidity code
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy_aggr.sol")]
         sol_code_path: Option<PathBuf>,
         /// The path to output the compiled Solidity bytecode
-        #[arg(long)]
+        #[arg(long, default_value = "evm_deploy_aggr.sol.bin")]
         sol_bytecode_path: Option<PathBuf>,
         /// The number of runs set to the SOLC optimizer.
         /// Lower values optimze for deployment size while higher values optimize for execution cost.
@@ -520,7 +520,7 @@ pub enum Commands {
     /// Verifies a proof, returning accept or reject
     #[command(arg_required_else_help = true)]
     Verify {
-        /// The path to save circuit params to
+        /// The path to load circuit params from
         #[arg(long)]
         circuit_params_path: PathBuf,
         /// The path to the proof file
@@ -529,7 +529,7 @@ pub enum Commands {
         /// The path to output the desired verfication key file (optional)
         #[arg(long)]
         vk_path: PathBuf,
-        /// The transcript type
+        /// The kzg params path
         #[arg(long)]
         params_path: PathBuf,
     },

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -567,11 +567,6 @@ pub enum Commands {
         /// The path to output the compiled Solidity bytecode
         #[arg(long)]
         sol_bytecode_path: Option<PathBuf>,
-        /// The number of runs set to the SOLC optimizer.
-        /// Lower values optimze for deployment size while higher values optimize for execution cost.
-        /// If not set will just use the default unoptimized SOLC configuration.
-        #[arg(long)]
-        optimizer_runs: Option<usize>,
     },
 
     /// Print the proof in hexadecimal

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -60,13 +60,12 @@ pub async fn verify_proof_via_solidity(
     proof: Snark<Fr, G1Affine>,
     sol_code_path: Option<PathBuf>,
     sol_bytecode_path: Option<PathBuf>,
-    runs: Option<usize>,
 ) -> Result<bool, Box<dyn Error>> {
     let (anvil, client) = setup_eth_backend().await?;
 
     // sol code supercedes deployment code
     let factory = match sol_code_path {
-        Some(path) => get_sol_contract_factory(path, client.clone(), runs).unwrap(),
+        Some(path) => get_sol_contract_factory(path, client.clone()).unwrap(),
         None => match sol_bytecode_path {
             Some(path) => {
                 let bytecode = DeploymentCode::load(&path)?;
@@ -134,11 +133,10 @@ pub async fn verify_proof_via_solidity(
 fn get_sol_contract_factory<M: 'static + Middleware>(
     sol_code_path: PathBuf,
     client: Arc<M>,
-    runs: Option<usize>,
 ) -> Result<ContractFactory<M>, Box<dyn Error>> {
     const MAX_RUNTIME_BYTECODE_SIZE: usize = 24577;
     // call get_contract_artificacts to get the abi and bytecode
-    let (abi, bytecode, runtime_bytecode) = get_contract_artifacts(sol_code_path, runs)?;
+    let (abi, bytecode, runtime_bytecode) = get_contract_artifacts(sol_code_path, None)?;
     let size = runtime_bytecode.len();
     debug!("runtime bytecode size: {:#?}", size);
     if size > MAX_RUNTIME_BYTECODE_SIZE {
@@ -146,7 +144,7 @@ fn get_sol_contract_factory<M: 'static + Middleware>(
         panic!(
             "Solidity runtime bytecode size is: {:#?}, 
             which exceeds 24577 bytes limit.
-            Try setting '--optimzer-runs 1' 
+            Try setting '--optimzer-runs 1' when generating the verifier
             so SOLC can optimize for the smallest deployment",
             size
         );

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -220,14 +220,12 @@ pub async fn run(cli: Cli) -> Result<(), Box<dyn Error>> {
             deployment_code_path,
             sol_code_path,
             sol_bytecode_path,
-            optimizer_runs,
         } => {
             verify_evm(
                 proof_path,
                 deployment_code_path,
                 sol_code_path,
                 sol_bytecode_path,
-                optimizer_runs,
             )
             .await
         }
@@ -677,21 +675,20 @@ pub(crate) async fn verify_evm(
     deployment_code_path: PathBuf,
     sol_code_path: Option<PathBuf>,
     sol_bytecode_path: Option<PathBuf>,
-    runs: Option<usize>,
 ) -> Result<(), Box<dyn Error>> {
     let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path, None, None)?;
     let code = DeploymentCode::load(&deployment_code_path)?;
     evm_verify(code, proof.clone())?;
 
     if sol_code_path.is_some() {
-        let result = verify_proof_via_solidity(proof.clone(), sol_code_path, None, runs).await?;
+        let result = verify_proof_via_solidity(proof.clone(), sol_code_path, None).await?;
 
         info!("Solidity verification result: {}", result);
 
         assert!(result);
 
         if sol_bytecode_path.is_some() {
-            let result = verify_proof_via_solidity(proof, None, sol_bytecode_path, runs).await?;
+            let result = verify_proof_via_solidity(proof, None, sol_bytecode_path).await?;
 
             info!("Solidity bytecode verification result: {}", result);
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -429,21 +429,13 @@ pub(crate) fn gen_circuit_params(
 
     match calibration_args.data {
         None => params.save(&params_output).map_err(Box::<dyn Error>::from),
-        Some(data) => {
-            if let Some(target) = calibration_args.target {
-                calibrate(model_path, run_args, data, params_output, target)
-            } else {
-                // default to resources
-                info!("no calibration target specified, defaulting to resource usage optimization");
-                calibrate(
-                    model_path,
-                    run_args,
-                    data,
-                    params_output,
-                    CalibrationTarget::Resources,
-                )
-            }
-        }
+        Some(data) => calibrate(
+            model_path,
+            run_args,
+            data,
+            params_output,
+            calibration_args.target,
+        ),
     }
 }
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -419,7 +419,7 @@ impl GraphCircuit {
 
         self.params = GraphCircuit::new(
             self.model.clone(),
-            self.params.run_args.clone(),
+            self.params.run_args,
             self.params.check_mode,
         )?
         .params;

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -2,7 +2,7 @@ use super::node::*;
 use super::scale_to_multiplier;
 use super::vars::*;
 use super::GraphError;
-use super::GraphParams;
+use super::GraphSettings;
 use crate::circuit::hybrid::HybridOp;
 
 use crate::circuit::Input;
@@ -224,7 +224,7 @@ impl Model {
         &self,
         run_args: RunArgs,
         check_mode: CheckMode,
-    ) -> Result<GraphParams, Box<dyn Error>> {
+    ) -> Result<GraphSettings, Box<dyn Error>> {
         let instance_shapes = self.instance_shapes();
         // this is the total number of variables we will need to allocate
         // for the circuit
@@ -263,7 +263,7 @@ impl Model {
         let batch_size = self.graph.input_shapes()[0][0];
         assert!(self.graph.input_shapes().iter().all(|x| x[0] == batch_size));
 
-        Ok(GraphParams {
+        Ok(GraphSettings {
             run_args,
             model_instance_shapes: instance_shapes,
             num_hashes: 0,
@@ -532,7 +532,7 @@ impl Model {
 
     /// Creates a `Model` from parsed run_args
     /// # Arguments
-    /// * `params` - A [GraphParams] struct holding parsed CLI arguments.
+    /// * `params` - A [GraphSettings] struct holding parsed CLI arguments.
     pub fn from_run_args(
         run_args: &RunArgs,
         model: &std::path::PathBuf,

--- a/src/python.rs
+++ b/src/python.rs
@@ -85,7 +85,7 @@ struct PyCalArgs {
     #[pyo3(get, set)]
     pub data: Option<PathBuf>,
     #[pyo3(get, set)]
-    pub target: Option<CalibrationTarget>,
+    pub target: CalibrationTarget,
 }
 
 /// default instantiation of PyCalArgs
@@ -95,7 +95,7 @@ impl PyCalArgs {
     fn new() -> Self {
         PyCalArgs {
             data: None::<PathBuf>,
-            target: None::<CalibrationTarget>,
+            target: CalibrationTarget::default(),
         }
     }
 }
@@ -375,14 +375,12 @@ fn create_evm_verifier(
     deployment_code_path,
     sol_code_path=None,
     sol_bytecode_path=None,
-    runs=None
 ))]
 fn verify_evm(
     proof_path: PathBuf,
     deployment_code_path: PathBuf,
     sol_code_path: Option<PathBuf>,
     sol_bytecode_path: Option<PathBuf>,
-    runs: Option<usize>,
 ) -> Result<bool, PyErr> {
 
     Runtime::new()
@@ -392,7 +390,6 @@ fn verify_evm(
         deployment_code_path,
         sol_code_path,
         sol_bytecode_path,
-        runs,
     )).map_err(|e| {
         let err_str = format!("Failed to run verify_evm: {}", e);
         PyRuntimeError::new_err(err_str)})?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,5 +1,5 @@
 use crate::circuit::{CheckMode, Tolerance};
-use crate::commands::{CalibrationArgs, CalibrationTarget, RunArgs, StrategyType};
+use crate::commands::{CalibrationTarget, RunArgs, StrategyType};
 use crate::graph::{Model, Visibility};
 use crate::pfsys::{
     gen_srs as ezkl_gen_srs, save_params,
@@ -78,37 +78,6 @@ impl From<PyRunArgs> for RunArgs {
     }
 }
 
-/// pyclass containing the struct used for calibration_args
-#[pyclass]
-#[derive(Clone)]
-struct PyCalArgs {
-    #[pyo3(get, set)]
-    pub data: Option<PathBuf>,
-    #[pyo3(get, set)]
-    pub target: CalibrationTarget,
-}
-
-/// default instantiation of PyCalArgs
-#[pymethods]
-impl PyCalArgs {
-    #[new]
-    fn new() -> Self {
-        PyCalArgs {
-            data: None::<PathBuf>,
-            target: CalibrationTarget::default(),
-        }
-    }
-}
-
-/// Conversion between PyRunArgs and RunArgs
-impl From<PyCalArgs> for CalibrationArgs {
-    fn from(py_cal_args: PyCalArgs) -> Self {
-        CalibrationArgs {
-            data: py_cal_args.data,
-            target: py_cal_args.target,
-        }
-    }
-}
 
 /// Displays the table as a string in python
 #[pyfunction(signature = (
@@ -128,32 +97,53 @@ fn table(model: String, py_run_args: Option<PyRunArgs>) -> PyResult<String> {
 
 /// generates the srs
 #[pyfunction(signature = (
-    params_path,
+    srs_path,
     logrows,
 ))]
-fn gen_srs(params_path: PathBuf, logrows: usize) -> PyResult<()> {
+fn gen_srs(srs_path: PathBuf, logrows: usize) -> PyResult<()> {
     let params = ezkl_gen_srs::<KZGCommitmentScheme<Bn256>>(logrows as u32);
-    save_params::<KZGCommitmentScheme<Bn256>>(&params_path, &params)?;
+    save_params::<KZGCommitmentScheme<Bn256>>(&srs_path, &params)?;
     Ok(())
 }
 
-/// runs the forward pass operation
+/// generates the circuit settings
 #[pyfunction(signature = (
     model,
     output,
     py_run_args = None,
-    py_cal_args = None
 ))]
-fn gen_circuit_params(
+fn gen_settings(
     model: PathBuf,
     output: PathBuf,
     py_run_args: Option<PyRunArgs>,
-    py_cal_args: Option<PyCalArgs>,
 ) -> Result<bool, PyErr> {
     let run_args: RunArgs = py_run_args.unwrap_or_else(PyRunArgs::new).into();
-    let calibration_args: CalibrationArgs = py_cal_args.unwrap_or_else(PyCalArgs::new).into();
 
-    crate::execute::gen_circuit_params(model, output, run_args, calibration_args).map_err(|e| {
+    crate::execute::gen_circuit_settings(model, output, run_args).map_err(|e| {
+        let err_str = format!("Failed to generate circuit params: {}", e);
+        PyRuntimeError::new_err(err_str)})?;
+
+    Ok(true)
+}
+
+
+/// generates the circuit settings
+#[pyfunction(signature = (
+    data, 
+    model,
+    settings,
+    target,
+))]
+fn calibrate_settings(
+    data: PathBuf,
+    model: PathBuf,
+    settings: PathBuf,
+    target: Option<CalibrationTarget>,
+) -> Result<bool, PyErr> {
+
+    let target = target.unwrap_or(CalibrationTarget::Resources);
+
+    crate::execute::calibrate(model, data, settings, target).map_err(|e| {
         let err_str = format!("Failed to generate circuit params: {}", e);
         PyRuntimeError::new_err(err_str)})?;
 
@@ -167,7 +157,7 @@ fn gen_circuit_params(
     output,
     scale = 7, 
     batch_size = 1,  
-    circuit_params_path = None, 
+    settings_path = None, 
 ))]
 fn forward(
     data: PathBuf,
@@ -175,9 +165,9 @@ fn forward(
     output: PathBuf,
     scale: Option<u32>,
     batch_size: Option<usize>,
-    circuit_params_path: Option<PathBuf>,
+    settings_path: Option<PathBuf>,
 ) -> PyResult<()> {
-    crate::execute::forward(model, data, output, scale, batch_size, circuit_params_path)
+    crate::execute::forward(model, data, output, scale, batch_size, settings_path)
         .map_err(|e| {
             let err_str = format!("Failed to run forward: {}", e);
             PyRuntimeError::new_err(err_str)})?;
@@ -188,13 +178,13 @@ fn forward(
 #[pyfunction(signature = (
     data,
     model,
-    circuit_params_path,
+    settings_path,
     py_run_args = None
 ))]
-fn mock(data: PathBuf, model: PathBuf, circuit_params_path: Option<PathBuf>, py_run_args: Option<PyRunArgs>) -> PyResult<bool> {
+fn mock(data: PathBuf, model: PathBuf, settings_path: Option<PathBuf>, py_run_args: Option<PyRunArgs>) -> PyResult<bool> {
     let run_args = py_run_args.unwrap_or_else(PyRunArgs::new).into();
 
-    crate::execute::mock(model, data, run_args, circuit_params_path).map_err(|e| {
+    crate::execute::mock(model, data, run_args, settings_path).map_err(|e| {
         let err_str = format!("Failed to run setup: {}", e);
         PyRuntimeError::new_err(err_str)})?;
 
@@ -206,18 +196,18 @@ fn mock(data: PathBuf, model: PathBuf, circuit_params_path: Option<PathBuf>, py_
     model,
     vk_path,
     pk_path,
-    params_path,
-    circuit_params_path,
+    srs_path,
+    settings_path,
 ))]
 fn setup(
     model: PathBuf,
     vk_path: PathBuf,
     pk_path: PathBuf,
-    params_path: PathBuf,
-    circuit_params_path: PathBuf,
+    srs_path: PathBuf,
+    settings_path: PathBuf,
 ) -> Result<bool, PyErr> {
 
-    crate::execute::setup(model, params_path, circuit_params_path, vk_path, pk_path).map_err(|e| {
+    crate::execute::setup(model, srs_path, settings_path, vk_path, pk_path).map_err(|e| {
             let err_str = format!("Failed to run setup: {}", e);
             PyRuntimeError::new_err(err_str)})?;
 
@@ -230,23 +220,23 @@ fn setup(
     model,
     pk_path,
     proof_path,
-    params_path,
+    srs_path,
     transcript,
     strategy,
-    circuit_params_path,
+    settings_path,
 ))]
 fn prove(
     data: PathBuf,
     model: PathBuf,
     pk_path: PathBuf,
     proof_path: PathBuf,
-    params_path: PathBuf,
+    srs_path: PathBuf,
     transcript: TranscriptType,
     strategy: StrategyType,
-    circuit_params_path: PathBuf,
+    settings_path: PathBuf,
 ) -> Result<bool, PyErr> {
     
-    crate::execute::prove(data, model, pk_path, proof_path, params_path, transcript, strategy, circuit_params_path, CheckMode::UNSAFE).map_err(|e| {
+    crate::execute::prove(data, model, pk_path, proof_path, srs_path, transcript, strategy, settings_path, CheckMode::UNSAFE).map_err(|e| {
         let err_str = format!("Failed to run prove: {}", e);
         PyRuntimeError::new_err(err_str)})?;
 
@@ -256,18 +246,18 @@ fn prove(
 /// verifies a given proof
 #[pyfunction(signature = (
     proof_path,
-    circuit_params_path,
+    settings_path,
     vk_path,
-    params_path,
+    srs_path,
 ))]
 fn verify(
     proof_path: PathBuf,
-    circuit_params_path: PathBuf,
+    settings_path: PathBuf,
     vk_path: PathBuf,
-    params_path: PathBuf,
+    srs_path: PathBuf,
 ) -> Result<bool, PyErr> {
 
-    crate::execute::verify(proof_path, circuit_params_path, vk_path, params_path).map_err(|e| {
+    crate::execute::verify(proof_path, settings_path, vk_path, srs_path).map_err(|e| {
         let err_str = format!("Failed to run verify: {}", e);
         PyRuntimeError::new_err(err_str)})?;
 
@@ -279,10 +269,10 @@ fn verify(
 #[pyfunction(signature = (
     proof_path,
     aggregation_snarks,
-    circuit_params_paths,
+    settings_paths,
     aggregation_vk_paths,
     vk_path,
-    params_path,
+    srs_path,
     transcript,
     logrows,
     check_mode,
@@ -290,10 +280,10 @@ fn verify(
 fn aggregate(
     proof_path: PathBuf,
     aggregation_snarks: Vec<PathBuf>,
-    circuit_params_paths: Vec<PathBuf>,
+    settings_paths: Vec<PathBuf>,
     aggregation_vk_paths: Vec<PathBuf>,
     vk_path: PathBuf,
-    params_path: PathBuf,
+    srs_path: PathBuf,
     transcript: TranscriptType,
     logrows: u32,
     check_mode: CheckMode,
@@ -301,10 +291,10 @@ fn aggregate(
     // the K used for the aggregation circuit
     crate::execute::aggregate(proof_path,
         aggregation_snarks,
-        circuit_params_paths,
+        settings_paths,
         aggregation_vk_paths,
         vk_path,
-        params_path,
+        srs_path,
         transcript,
         logrows,
         check_mode).map_err(|e| {
@@ -318,17 +308,17 @@ fn aggregate(
 #[pyfunction(signature = (
     proof_path,
     vk_path,
-    params_path,
+    srs_path,
     logrows
 ))]
 fn verify_aggr(
     proof_path: PathBuf,
     vk_path: PathBuf,
-    params_path: PathBuf,
+    srs_path: PathBuf,
     logrows: u32,
 ) -> Result<bool, PyErr> {
 
-    crate::execute::verify_aggr(proof_path, vk_path, params_path, logrows).map_err(|e| {
+    crate::execute::verify_aggr(proof_path, vk_path, srs_path, logrows).map_err(|e| {
         let err_str = format!("Failed to run verify_aggr: {}", e);
         PyRuntimeError::new_err(err_str)})?;
 
@@ -338,8 +328,8 @@ fn verify_aggr(
 /// creates an EVM compatible verifier, you will need solc installed in your environment to run this
 #[pyfunction(signature = (
     vk_path,
-    params_path,
-    circuit_params_path,
+    srs_path,
+    settings_path,
     deployment_code_path,
     sol_code_path=None,
     sol_bytecode_path=None,
@@ -347,8 +337,8 @@ fn verify_aggr(
 ))]
 fn create_evm_verifier(
     vk_path: PathBuf,
-    params_path: PathBuf,
-    circuit_params_path: PathBuf,
+    srs_path: PathBuf,
+    settings_path: PathBuf,
     deployment_code_path: PathBuf,
     sol_code_path: Option<PathBuf>,
     sol_bytecode_path: Option<PathBuf>,
@@ -356,8 +346,8 @@ fn create_evm_verifier(
 ) -> Result<bool, PyErr> {
     crate::execute::create_evm_verifier(
         vk_path,
-        params_path,
-        circuit_params_path,
+        srs_path,
+        settings_path,
         deployment_code_path,
         sol_code_path,
         sol_bytecode_path, 
@@ -400,7 +390,7 @@ fn verify_evm(
 /// creates an evm compatible aggregate verifier, you will need solc installed in your environment to run this
 #[pyfunction(signature = (
     vk_path,
-    params_path,
+    srs_path,
     deployment_code_path,
     sol_code_path=None,
     sol_bytecode_path=None,
@@ -408,7 +398,7 @@ fn verify_evm(
 ))]
 fn create_evm_verifier_aggr(
     vk_path: PathBuf,
-    params_path: PathBuf,
+    srs_path: PathBuf,
     deployment_code_path: Option<PathBuf>,
     sol_code_path: Option<PathBuf>,
     sol_bytecode_path: Option<PathBuf>,
@@ -416,7 +406,7 @@ fn create_evm_verifier_aggr(
 ) -> Result<bool, PyErr> {
     crate::execute::create_evm_aggregate_verifier(
         vk_path,
-        params_path,
+        srs_path,
         deployment_code_path,
         sol_code_path,
         sol_bytecode_path,
@@ -449,7 +439,6 @@ fn ezkl_lib(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // NOTE: DeployVerifierEVM and SendProofEVM will be implemented in python in pyezkl
     pyo3_log::init();
     m.add_class::<PyRunArgs>()?;
-    m.add_class::<PyCalArgs>()?;
     m.add_function(wrap_pyfunction!(table, m)?)?;
     m.add_function(wrap_pyfunction!(gen_srs, m)?)?;
     m.add_function(wrap_pyfunction!(forward, m)?)?;
@@ -457,7 +446,8 @@ fn ezkl_lib(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(setup, m)?)?;
     m.add_function(wrap_pyfunction!(prove, m)?)?;
     m.add_function(wrap_pyfunction!(verify, m)?)?;
-    m.add_function(wrap_pyfunction!(gen_circuit_params, m)?)?;
+    m.add_function(wrap_pyfunction!(gen_settings, m)?)?;
+    m.add_function(wrap_pyfunction!(calibrate_settings, m)?)?;
     m.add_function(wrap_pyfunction!(aggregate, m)?)?;
     m.add_function(wrap_pyfunction!(verify_aggr, m)?)?;
     m.add_function(wrap_pyfunction!(create_evm_verifier, m)?)?;

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -1863,7 +1863,24 @@ pub mod nonlinearities {
     /// ).unwrap();
     /// let result = sigmoid(&x, 1, 1);
     /// let expected = Tensor::<i128>::new(Some(&[1, 1, 1, 1, 1, 1]), &[2, 3]).unwrap();
+    ///
     /// assert_eq!(result, expected);
+    /// let x = Tensor::<i128>::new(
+    ///    Some(&[65536]),
+    ///   &[1],
+    /// ).unwrap();
+    /// let result = sigmoid(&x, 65536, 256);
+    /// let expected = Tensor::<i128>::new(Some(&[187]), &[1]).unwrap();
+    /// assert_eq!(result, expected);
+    ///
+    /// /// assert_eq!(result, expected);
+    /// let x = Tensor::<i128>::new(
+    ///    Some(&[256]),
+    ///   &[1],
+    /// ).unwrap();
+    /// let result = sigmoid(&x, 256, 256);
+    /// let expected = Tensor::<i128>::new(Some(&[187]), &[1]).unwrap();
+    ///
     /// ```
     pub fn sigmoid(a: &Tensor<i128>, scale_input: usize, scale_output: usize) -> Tensor<i128> {
         // calculate value of output

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -25,12 +25,12 @@ pub fn init_panic_hook() {
 }
 
 use crate::execute::{create_proof_circuit_kzg, verify_proof_circuit_kzg};
-use crate::graph::{GraphCircuit, GraphParams};
+use crate::graph::{GraphCircuit, GraphSettings};
 use crate::pfsys::Snarkbytes;
 
 /// Generate circuit params in browser
 #[wasm_bindgen]
-pub fn gen_circuit_params_wasm(
+pub fn gen_circuit_settings_wasm(
     model_ser: wasm_bindgen::Clamped<Vec<u8>>,
     run_args_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> Vec<u8> {
@@ -41,8 +41,8 @@ pub fn gen_circuit_params_wasm(
     let model = crate::graph::Model::new(&mut reader, run_args).unwrap();
     let circuit =
         GraphCircuit::new(Arc::new(model), run_args, crate::circuit::CheckMode::UNSAFE).unwrap();
-    let circuit_params = circuit.params;
-    serde_json::to_vec(&circuit_params).unwrap()
+    let circuit_settings = circuit.settings;
+    serde_json::to_vec(&circuit_settings).unwrap()
 }
 
 /// Generate proving key in browser
@@ -50,21 +50,22 @@ pub fn gen_circuit_params_wasm(
 pub fn gen_pk_wasm(
     circuit_ser: wasm_bindgen::Clamped<Vec<u8>>,
     params_ser: wasm_bindgen::Clamped<Vec<u8>>,
-    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_settings_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> Vec<u8> {
     // Read in circuit params
-    let circuit_params: GraphParams = serde_json::from_slice(&circuit_params_ser[..]).unwrap();
+    let circuit_settings: GraphSettings =
+        serde_json::from_slice(&circuit_settings_ser[..]).unwrap();
     // Read in kzg params
     let mut reader = std::io::BufReader::new(&params_ser[..]);
     let params: ParamsKZG<Bn256> =
         halo2_proofs::poly::commitment::Params::<'_, G1Affine>::read(&mut reader).unwrap();
     // Read in circuit
     let mut circuit_reader = std::io::BufReader::new(&circuit_ser[..]);
-    let model = crate::graph::Model::new(&mut circuit_reader, circuit_params.run_args).unwrap();
+    let model = crate::graph::Model::new(&mut circuit_reader, circuit_settings.run_args).unwrap();
 
     let circuit = GraphCircuit::new(
         Arc::new(model),
-        circuit_params.run_args,
+        circuit_settings.run_args,
         crate::circuit::CheckMode::UNSAFE,
     )
     .unwrap();
@@ -85,17 +86,18 @@ pub fn gen_pk_wasm(
 #[wasm_bindgen]
 pub fn gen_vk_wasm(
     pk: wasm_bindgen::Clamped<Vec<u8>>,
-    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_settings_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> Vec<u8> {
     // Read in circuit params
-    let circuit_params: GraphParams = serde_json::from_slice(&circuit_params_ser[..]).unwrap();
+    let circuit_settings: GraphSettings =
+        serde_json::from_slice(&circuit_settings_ser[..]).unwrap();
 
     // Read in proving key
     let mut reader = std::io::BufReader::new(&pk[..]);
     let pk = ProvingKey::<G1Affine>::read::<_, GraphCircuit>(
         &mut reader,
         halo2_proofs::SerdeFormat::RawBytes,
-        circuit_params.clone(),
+        circuit_settings.clone(),
     )
     .unwrap();
 
@@ -113,14 +115,15 @@ pub fn gen_vk_wasm(
 pub fn verify_wasm(
     proof_js: wasm_bindgen::Clamped<Vec<u8>>,
     vk: wasm_bindgen::Clamped<Vec<u8>>,
-    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_settings_ser: wasm_bindgen::Clamped<Vec<u8>>,
     params_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> bool {
     let mut reader = std::io::BufReader::new(&params_ser[..]);
     let params: ParamsKZG<Bn256> =
         halo2_proofs::poly::commitment::Params::<'_, G1Affine>::read(&mut reader).unwrap();
 
-    let circuit_params: GraphParams = serde_json::from_slice(&circuit_params_ser[..]).unwrap();
+    let circuit_settings: GraphSettings =
+        serde_json::from_slice(&circuit_settings_ser[..]).unwrap();
 
     let snark_bytes: Snarkbytes = bincode::deserialize(&proof_js[..]).unwrap();
 
@@ -138,7 +141,7 @@ pub fn verify_wasm(
     let vk = VerifyingKey::<G1Affine>::read::<_, GraphCircuit>(
         &mut reader,
         halo2_proofs::SerdeFormat::RawBytes,
-        circuit_params,
+        circuit_settings,
     )
     .unwrap();
 
@@ -173,7 +176,7 @@ pub fn prove_wasm(
     data: wasm_bindgen::Clamped<Vec<u8>>,
     pk: wasm_bindgen::Clamped<Vec<u8>>,
     circuit_ser: wasm_bindgen::Clamped<Vec<u8>>,
-    circuit_params_ser: wasm_bindgen::Clamped<Vec<u8>>,
+    circuit_settings_ser: wasm_bindgen::Clamped<Vec<u8>>,
     params_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> Vec<u8> {
     // read in kzg params
@@ -185,24 +188,25 @@ pub fn prove_wasm(
     let data: crate::graph::GraphInput = serde_json::from_slice(&data[..]).unwrap();
 
     // read in circuit params
-    let circuit_params: GraphParams = serde_json::from_slice(&circuit_params_ser[..]).unwrap();
+    let circuit_settings: GraphSettings =
+        serde_json::from_slice(&circuit_settings_ser[..]).unwrap();
 
     // read in proving key
     let mut reader = std::io::BufReader::new(&pk[..]);
     let pk = ProvingKey::<G1Affine>::read::<_, GraphCircuit>(
         &mut reader,
         halo2_proofs::SerdeFormat::RawBytes,
-        circuit_params.clone(),
+        circuit_settings.clone(),
     )
     .unwrap();
 
     // read in circuit
     let mut reader = std::io::BufReader::new(&circuit_ser[..]);
-    let model = crate::graph::Model::new(&mut reader, circuit_params.run_args).unwrap();
+    let model = crate::graph::Model::new(&mut reader, circuit_settings.run_args).unwrap();
 
     let mut circuit = GraphCircuit::new(
         Arc::new(model),
-        circuit_params.run_args,
+        circuit_settings.run_args,
         crate::circuit::CheckMode::UNSAFE,
     )
     .unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -33,10 +33,7 @@ mod native_tests {
             let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
                 .args([
                     "gen-srs",
-                    &format!(
-                        "--params-path={}/kzg17.params",
-                        TEST_DIR.path().to_str().unwrap()
-                    ),
+                    &format!("--srs-path={}/kzg17.srs", TEST_DIR.path().to_str().unwrap()),
                     "--logrows=17",
                 ])
                 .status()
@@ -51,7 +48,7 @@ mod native_tests {
                 .args([
                     "-o",
                     &format!(
-                        "{}/kzg23.params",
+                        "{}/kzg23.srs",
                         TEST_DIR.path().to_str().unwrap()
                     ),
                     "https://trusted-setup-halo2kzg.s3.eu-central-1.amazonaws.com/perpetual-powers-of-tau-raw-23",
@@ -68,7 +65,7 @@ mod native_tests {
                 .args([
                     "-o",
                     &format!(
-                        "{}/kzg24.params",
+                        "{}/kzg24.srs",
                         TEST_DIR.path().to_str().unwrap()
                     ),
                     "https://trusted-setup-halo2kzg.s3.eu-central-1.amazonaws.com/perpetual-powers-of-tau-raw-24",
@@ -722,17 +719,31 @@ mod native_tests {
         let test_dir = TEST_DIR.path().to_str().unwrap();
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
-                "gen-circuit-params",
-                "--calibration-data",
-                format!("{}/{}/input.json", test_dir, example_name).as_str(),
+                "gen-settings",
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "--bits=2",
                 "-K=3",
+            ])
+            .status()
+            .expect("failed to execute process");
+        assert!(status.success());
+
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args([
+                "calibrate-settings",
+                "--data",
+                format!("{}/{}/input.json", test_dir, example_name).as_str(),
+                "-M",
+                format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
+                &format!(
+                    "--settings-path={}/{}/settings.json",
+                    test_dir, example_name
+                ),
             ])
             .status()
             .expect("failed to execute process");
@@ -746,7 +757,7 @@ mod native_tests {
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "-O",
@@ -765,12 +776,9 @@ mod native_tests {
                 &format!("{}/{}/key.pk", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/key.vk", test_dir, example_name),
+                &format!("--srs-path={}/kzg23.srs", TEST_DIR.path().to_str().unwrap()),
                 &format!(
-                    "--params-path={}/kzg23.params",
-                    TEST_DIR.path().to_str().unwrap()
-                ),
-                &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -788,14 +796,11 @@ mod native_tests {
                 &format!("{}/{}/proof.pf", test_dir, example_name),
                 "--pk-path",
                 &format!("{}/{}/key.pk", test_dir, example_name),
-                &format!(
-                    "--params-path={}/kzg23.params",
-                    TEST_DIR.path().to_str().unwrap()
-                ),
+                &format!("--srs-path={}/kzg23.srs", TEST_DIR.path().to_str().unwrap()),
                 "--transcript=poseidon",
                 "--strategy=accum",
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -807,7 +812,7 @@ mod native_tests {
                 "aggregate",
                 "--logrows=23",
                 &format!(
-                    "--circuit-params-paths={}/{}/circuit.params",
+                    "--settings-paths={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "--aggregation-snarks",
@@ -818,10 +823,7 @@ mod native_tests {
                 &format!("{}/{}/aggr.pf", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/aggr.vk", test_dir, example_name),
-                &format!(
-                    "--params-path={}/kzg23.params",
-                    TEST_DIR.path().to_str().unwrap()
-                ),
+                &format!("--srs-path={}/kzg23.srs", TEST_DIR.path().to_str().unwrap()),
                 "--transcript=blake",
             ])
             .status()
@@ -835,10 +837,7 @@ mod native_tests {
                 &format!("{}/{}/aggr.pf", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/aggr.vk", test_dir, example_name),
-                &format!(
-                    "--params-path={}/kzg23.params",
-                    TEST_DIR.path().to_str().unwrap()
-                ),
+                &format!("--srs-path={}/kzg23.srs", TEST_DIR.path().to_str().unwrap()),
             ])
             .status()
             .expect("failed to execute process");
@@ -850,13 +849,27 @@ mod native_tests {
         let test_dir = TEST_DIR.path().to_str().unwrap();
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
-                "gen-circuit-params",
-                "--calibration-data",
+                "gen-settings",
+                "-M",
+                format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
+                &format!(
+                    "--settings-path={}/{}/settings.json",
+                    test_dir, example_name
+                ),
+            ])
+            .status()
+            .expect("failed to execute process");
+        assert!(status.success());
+
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args([
+                "calibrate-settings",
+                "--data",
                 format!("{}/{}/input.json", test_dir, example_name).as_str(),
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -872,7 +885,7 @@ mod native_tests {
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "-O",
@@ -891,9 +904,9 @@ mod native_tests {
                 &format!("{}/{}/evm.vk", test_dir, example_name),
                 "--pk-path",
                 &format!("{}/{}/evm.pk", test_dir, example_name),
-                &format!("--params-path={}/kzg23.params", test_dir),
+                &format!("--srs-path={}/kzg23.srs", test_dir),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -912,9 +925,9 @@ mod native_tests {
                 &format!("{}/{}/evm.pf", test_dir, example_name),
                 "--pk-path",
                 &format!("{}/{}/evm.pk", test_dir, example_name),
-                &format!("--params-path={}/kzg23.params", test_dir),
+                &format!("--srs-path={}/kzg23.srs", test_dir),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "--transcript=poseidon",
@@ -928,7 +941,7 @@ mod native_tests {
                 "aggregate",
                 "--logrows=23",
                 &format!(
-                    "--circuit-params-paths={}/{}/circuit.params",
+                    "--settings-paths={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "--aggregation-snarks",
@@ -939,7 +952,7 @@ mod native_tests {
                 &format!("{}/{}/evm_aggr.pf", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/evm_aggr.vk", test_dir, example_name),
-                &format!("--params-path={}/kzg23.params", test_dir),
+                &format!("--srs-path={}/kzg23.srs", test_dir),
                 "--transcript=evm",
             ])
             .status()
@@ -947,7 +960,7 @@ mod native_tests {
         assert!(status.success());
 
         let code_arg = format!("{}/{}/evm_aggr.code", test_dir, example_name);
-        let param_arg = format!("--params-path={}/kzg23.params", test_dir);
+        let param_arg = format!("--srs-path={}/kzg23.srs", test_dir);
         let vk_arg = format!("{}/{}/evm_aggr.vk", test_dir, example_name);
 
         fn build_args<'a>(
@@ -963,7 +976,6 @@ mod native_tests {
                 args.push(sol_arg);
                 args.push("--sol-bytecode-path");
                 args.push(sol_bytecode_arg);
-                args.push("--optimizer-runs=1");
             }
             args
         }
@@ -978,6 +990,7 @@ mod native_tests {
             param_arg.as_str(),
             "--vk-path",
             vk_arg.as_str(),
+            "--optimizer-runs=1",
         ];
 
         let args = build_args(with_solidity, base_args, &sol_arg, &sol_bytecode_arg);
@@ -1020,16 +1033,30 @@ mod native_tests {
 
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
-                "gen-circuit-params",
-                "--calibration-data",
+                "gen-settings",
+                "-M",
+                format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
+                &format!(
+                    "--settings-path={}/{}/settings.json",
+                    test_dir, example_name
+                ),
+                &format!("--scale={}", scale),
+            ])
+            .status()
+            .expect("failed to execute process");
+        assert!(status.success());
+
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args([
+                "calibrate-settings",
+                "--data",
                 format!("{}/{}/input.json", test_dir, example_name).as_str(),
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
-                &format!("--scale={}", scale),
             ])
             .status()
             .expect("failed to execute process");
@@ -1043,7 +1070,7 @@ mod native_tests {
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "-O",
@@ -1062,9 +1089,9 @@ mod native_tests {
                 &format!("{}/{}/key.pk", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/key.vk", test_dir, example_name),
-                &format!("--params-path={}/kzg{}.params", test_dir, logrows),
+                &format!("--srs-path={}/kzg{}.srs", test_dir, logrows),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -1082,11 +1109,11 @@ mod native_tests {
                 &format!("{}/{}/proof.pf", test_dir, example_name),
                 "--pk-path",
                 &format!("{}/{}/key.pk", test_dir, example_name),
-                &format!("--params-path={}/kzg{}.params", test_dir, logrows),
+                &format!("--srs-path={}/kzg{}.srs", test_dir, logrows),
                 "--transcript=blake",
                 "--strategy=single",
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 &format!("--check-mode={}", checkmode),
@@ -1098,14 +1125,14 @@ mod native_tests {
             .args([
                 "verify",
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "--proof-path",
                 &format!("{}/{}/proof.pf", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/key.vk", test_dir, example_name),
-                &format!("--params-path={}/kzg{}.params", test_dir, logrows),
+                &format!("--srs-path={}/kzg{}.srs", test_dir, logrows),
             ])
             .status()
             .expect("failed to execute process");
@@ -1146,18 +1173,32 @@ mod native_tests {
 
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
             .args([
-                "gen-circuit-params",
-                "--calibration-data",
-                format!("{}/{}/input.json", test_dir, example_name).as_str(),
+                "gen-settings",
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 &format!("--input-visibility={}", input_visibility),
                 &format!("--param-visibility={}", param_visibility),
                 &format!("--output-visibility={}", output_visibility),
+            ])
+            .status()
+            .expect("failed to execute process");
+        assert!(status.success());
+
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args([
+                "calibrate-settings",
+                "--data",
+                format!("{}/{}/input.json", test_dir, example_name).as_str(),
+                "-M",
+                format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
+                &format!(
+                    "--settings-path={}/{}/settings.json",
+                    test_dir, example_name
+                ),
             ])
             .status()
             .expect("failed to execute process");
@@ -1171,7 +1212,7 @@ mod native_tests {
                 "-M",
                 format!("{}/{}/network.onnx", test_dir, example_name).as_str(),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
                 "-O",
@@ -1190,9 +1231,9 @@ mod native_tests {
                 &format!("{}/{}/key.pk", test_dir, example_name),
                 "--vk-path",
                 &format!("{}/{}/key.vk", test_dir, example_name),
-                &format!("--params-path={}/kzg17.params", test_dir),
+                &format!("--srs-path={}/kzg17.srs", test_dir),
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -1211,14 +1252,11 @@ mod native_tests {
                 &format!("{}/{}/proof.pf", test_dir, example_name),
                 "--pk-path",
                 &format!("{}/{}/key.pk", test_dir, example_name),
-                &format!(
-                    "--params-path={}/kzg17.params",
-                    TEST_DIR.path().to_str().unwrap()
-                ),
+                &format!("--srs-path={}/kzg17.srs", TEST_DIR.path().to_str().unwrap()),
                 "--transcript=evm",
                 "--strategy=single",
                 &format!(
-                    "--circuit-params-path={}/{}/circuit.params",
+                    "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
             ])
@@ -1226,19 +1264,19 @@ mod native_tests {
             .expect("failed to execute process");
         assert!(status.success());
 
-        let circuit_params = format!(
-            "--circuit-params-path={}/{}/circuit.params",
+        let circuit_settings = format!(
+            "--settings-path={}/{}/settings.json",
             test_dir, example_name
         );
         let code_arg = format!("{}/{}/deployment.code", test_dir, example_name);
         let vk_arg = format!("{}/{}/key.vk", test_dir, example_name);
-        let param_arg = format!("--params-path={}/kzg17.params", test_dir);
+        let param_arg = format!("--srs-path={}/kzg17.srs", test_dir);
 
         let opt_arg = format!("--optimizer-runs={}", num_runs);
 
         let mut args = vec![
             "create-evm-verifier",
-            circuit_params.as_str(),
+            circuit_settings.as_str(),
             "--deployment-code-path",
             code_arg.as_str(),
             param_arg.as_str(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1271,7 +1271,6 @@ mod native_tests {
             pf_arg.as_str(),
             "--deployment-code-path",
             code_arg.as_str(),
-            opt_arg.as_str(),
         ];
         if with_solidity {
             args.push("--sol-code-path");

--- a/tests/python/1l_relu_circuit.settings
+++ b/tests/python/1l_relu_circuit.settings
@@ -1,0 +1,1 @@
+{"run_args":{"tolerance":{"Abs":{"val":0}},"scale":4,"bits":7,"logrows":8,"batch_size":1,"input_visibility":"Public","output_visibility":"Public","param_visibility":"Private","pack_base":1,"allocated_constraints":null},"num_constraints":6,"model_instance_shapes":[[1,3],[1,3]],"num_hashes":0,"required_lookups":[{"ReLU":{"scale":1}}],"check_mode":"SAFE"}

--- a/tests/python/1l_relu_settings.json
+++ b/tests/python/1l_relu_settings.json
@@ -1,0 +1,1 @@
+{"run_args":{"tolerance":{"Abs":{"val":0}},"scale":4,"bits":7,"logrows":8,"batch_size":1,"input_visibility":"Public","output_visibility":"Public","param_visibility":"Private","pack_base":1,"allocated_constraints":null},"num_constraints":6,"model_instance_shapes":[[1,3],[1,3]],"num_hashes":0,"required_lookups":[{"ReLU":{"scale":1}}],"check_mode":"SAFE"}

--- a/tests/python/settings.json
+++ b/tests/python/settings.json
@@ -1,0 +1,1 @@
+{"run_args":{"tolerance":{"Abs":{"val":0}},"scale":11,"bits":1,"logrows":9,"batch_size":1,"input_visibility":"Public","output_visibility":"Public","param_visibility":"Private","pack_base":1,"allocated_constraints":null},"num_constraints":136,"model_instance_shapes":[[1,3,2,2],[3,3,3]],"num_hashes":0,"required_lookups":[],"check_mode":"SAFE"}

--- a/tests/python/srs_utils.py
+++ b/tests/python/srs_utils.py
@@ -7,7 +7,7 @@ time we run tests.
 import ezkl_lib
 import os
 
-params_path = os.path.abspath(
+srs_path = os.path.abspath(
     os.path.join(
         os.path.dirname(__file__),
         '.',
@@ -15,14 +15,15 @@ params_path = os.path.abspath(
     )
 )
 
+
 def gen_test_srs(logrows=17):
     """Generates a test srs with 17 log rows"""
-    ezkl_lib.gen_srs(params_path, logrows)
+    ezkl_lib.gen_srs(srs_path, logrows)
 
 
 def delete_test_srs():
     """Deletes test srs after tests are done"""
-    os.remove(params_path)
+    os.remove(srs_path)
 
 
 if __name__ == "__main__":

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,10 +3,10 @@
 mod wasm32 {
     use ezkl_lib::circuit::Tolerance;
     use ezkl_lib::commands::RunArgs;
-    use ezkl_lib::graph::GraphParams;
+    use ezkl_lib::graph::GraphSettings;
     use ezkl_lib::pfsys::Snarkbytes;
     use ezkl_lib::wasm::{
-        gen_circuit_params_wasm, gen_pk_wasm, gen_vk_wasm, prove_wasm, verify_wasm,
+        gen_circuit_settings_wasm, gen_pk_wasm, gen_vk_wasm, prove_wasm, verify_wasm,
     };
     pub use wasm_bindgen_rayon::init_thread_pool;
     use wasm_bindgen_test::*;
@@ -75,7 +75,7 @@ mod wasm32 {
     }
 
     #[wasm_bindgen_test]
-    async fn gen_circuit_params_test() {
+    async fn gen_circuit_settings_test() {
         let run_args = RunArgs {
             tolerance: Tolerance::default(),
             scale: 7,
@@ -92,14 +92,15 @@ mod wasm32 {
         let serialized_run_args =
             bincode::serialize(&run_args).expect("Failed to serialize RunArgs");
 
-        let circuit_params_ser = gen_circuit_params_wasm(
+        let circuit_settings_ser = gen_circuit_settings_wasm(
             wasm_bindgen::Clamped(NETWORK.to_vec()),
             wasm_bindgen::Clamped(serialized_run_args),
         );
 
-        assert!(circuit_params_ser.len() > 0);
+        assert!(circuit_settings_ser.len() > 0);
 
-        let _circuit_params: GraphParams = serde_json::from_slice(&circuit_params_ser[..]).unwrap();
+        let _circuit_settings: GraphSettings =
+            serde_json::from_slice(&circuit_settings_ser[..]).unwrap();
     }
 
     #[wasm_bindgen_test]
@@ -130,7 +131,7 @@ mod wasm32 {
     }
 
     #[wasm_bindgen_test]
-    async fn circuit_params_is_valid_test() {
+    async fn circuit_settings_is_valid_test() {
         let run_args = RunArgs {
             tolerance: Tolerance::default(),
             scale: 0,
@@ -147,17 +148,17 @@ mod wasm32 {
         let serialized_run_args =
             bincode::serialize(&run_args).expect("Failed to serialize RunArgs");
 
-        let circuit_params_ser = gen_circuit_params_wasm(
+        let circuit_settings_ser = gen_circuit_settings_wasm(
             wasm_bindgen::Clamped(NETWORK.to_vec()),
             wasm_bindgen::Clamped(serialized_run_args),
         );
 
-        assert!(circuit_params_ser.len() > 0);
+        assert!(circuit_settings_ser.len() > 0);
 
         let pk = gen_pk_wasm(
             wasm_bindgen::Clamped(NETWORK.to_vec()),
             wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
-            wasm_bindgen::Clamped(circuit_params_ser),
+            wasm_bindgen::Clamped(circuit_settings_ser),
         );
 
         assert!(pk.len() > 0);


### PR DESCRIPTION
- Adds defaults for exported filenames
- renames kzg params to srs 
- renames circuit params to settings 
- splits gen_circuit_params into gen_settings and calibrate_settings to avoid conditional flag logic