### PR TITLE
fix: use `tokio` (not `rayon`) for calibration parallelism

### DIFF
--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -1,94 +1,11 @@
 use clap::Parser;
-use colored::*;
-use colored_json::prelude::*;
-use env_logger::Builder;
+use colored_json::ToColoredJson;
 use ezkl_lib::commands::Cli;
 use ezkl_lib::execute::run;
-use instant::Instant;
-use log::{error, info, Level, LevelFilter, Record};
-use rand::seq::SliceRandom;
-use std::env;
+use ezkl_lib::logger::init_logger;
+use log::{error, info};
+use rand::prelude::SliceRandom;
 use std::error::Error;
-use std::fmt::Formatter;
-use std::io::Write;
-
-#[allow(dead_code)]
-pub fn level_color(level: &log::Level, msg: &str) -> String {
-    match level {
-        Level::Error => msg.red(),
-        Level::Warn => msg.yellow(),
-        Level::Info => msg.blue(),
-        Level::Debug => msg.green(),
-        Level::Trace => msg.magenta(),
-    }
-    .bold()
-    .to_string()
-}
-
-pub fn level_text_color(level: &log::Level, msg: &str) -> String {
-    match level {
-        Level::Error => msg.red(),
-        Level::Warn => msg.yellow(),
-        Level::Info => msg.white(),
-        Level::Debug => msg.white(),
-        Level::Trace => msg.white(),
-    }
-    .bold()
-    .to_string()
-}
-
-fn level_token(level: &Level) -> &str {
-    match *level {
-        Level::Error => "E",
-        Level::Warn => "W",
-        Level::Info => "*",
-        Level::Debug => "D",
-        Level::Trace => "T",
-    }
-}
-
-fn prefix_token(level: &Level) -> String {
-    format!(
-        "{}{}{}",
-        "[".blue().bold(),
-        level_color(level, level_token(level)),
-        "]".blue().bold()
-    )
-}
-
-pub fn format(buf: &mut Formatter, record: &Record<'_>) -> Result<(), std::fmt::Error> {
-    let sep = format!("\n{} ", " | ".white().bold());
-    let level = record.level();
-    writeln!(
-        buf,
-        "{} {}",
-        prefix_token(&level),
-        level_color(&level, record.args().as_str().unwrap()).replace('\n', &sep),
-    )
-}
-
-pub fn init_logger() {
-    let start = Instant::now();
-    let mut builder = Builder::new();
-
-    builder.format(move |buf, record| {
-        writeln!(
-            buf,
-            "{} [{}s, {}] - {}",
-            prefix_token(&record.level()),
-            start.elapsed().as_secs(),
-            record.metadata().target(),
-            level_text_color(&record.level(), &format!("{}", record.args()))
-                .replace('\n', &format!("\n{} ", " | ".white().bold()))
-        )
-    });
-    builder.target(env_logger::Target::Stdout);
-    builder.filter(None, LevelFilter::Info);
-    if env::var("RUST_LOG").is_ok() {
-        builder.parse_filters(&env::var("RUST_LOG").unwrap());
-    }
-    builder.init();
-}
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1430,14 +1430,15 @@ pub(crate) fn run_fuzz_fn(
     let num_failures = AtomicI64::new(0);
     let _r = Gag::stdout().unwrap();
 
-    let pb = init_spinner();
-    pb.set_message("Fuzzing...");
+    let pb = init_bar(num_runs as u64);
+    pb.set_message("fuzzing...");
     (0..num_runs).into_par_iter().for_each(|_| {
         let result = f();
         if result.is_ok() {
             passed.swap(false, Ordering::Relaxed);
             num_failures.fetch_add(1, Ordering::Relaxed);
         }
+        pb.inc(1);
     });
     pb.finish_with_message("Done.");
     std::mem::drop(_r);

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -50,7 +50,7 @@ use plotters::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use rand::Rng;
 #[cfg(not(target_arch = "wasm32"))]
-use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 #[cfg(not(target_arch = "wasm32"))]
 use snark_verifier::loader::evm;
 use snark_verifier::loader::native::NativeLoader;
@@ -614,7 +614,7 @@ pub(crate) async fn calibrate(
         let _r = Gag::stdout().unwrap();
         // Result<Vec<GraphSettings>, &str>
         let tasks = chunks
-            .par_iter()
+            .iter()
             .map(|chunk| {
                 // we need to create a new run args for each chunk
                 // time it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub mod fieldutils;
 /// a Halo2 circuit.
 #[cfg(feature = "onnx")]
 pub mod graph;
+/// beautiful logging
+pub mod logger;
 /// Tools for proofs and verification used by cli
 pub mod pfsys;
 /// Python bindings

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,91 @@
+use colored::*;
+use env_logger::Builder;
+use instant::Instant;
+use log::{Level, LevelFilter, Record};
+use std::env;
+use std::fmt::Formatter;
+use std::io::Write;
+
+/// sets the log level color
+#[allow(dead_code)]
+pub fn level_color(level: &log::Level, msg: &str) -> String {
+    match level {
+        Level::Error => msg.red(),
+        Level::Warn => msg.yellow(),
+        Level::Info => msg.blue(),
+        Level::Debug => msg.green(),
+        Level::Trace => msg.magenta(),
+    }
+    .bold()
+    .to_string()
+}
+
+/// sets the log level text color
+pub fn level_text_color(level: &log::Level, msg: &str) -> String {
+    match level {
+        Level::Error => msg.red(),
+        Level::Warn => msg.yellow(),
+        Level::Info => msg.white(),
+        Level::Debug => msg.white(),
+        Level::Trace => msg.white(),
+    }
+    .bold()
+    .to_string()
+}
+
+/// sets the log level token
+fn level_token(level: &Level) -> &str {
+    match *level {
+        Level::Error => "E",
+        Level::Warn => "W",
+        Level::Info => "*",
+        Level::Debug => "D",
+        Level::Trace => "T",
+    }
+}
+
+/// sets the log level prefix token
+fn prefix_token(level: &Level) -> String {
+    format!(
+        "{}{}{}",
+        "[".blue().bold(),
+        level_color(level, level_token(level)),
+        "]".blue().bold()
+    )
+}
+
+/// formats the log
+pub fn format(buf: &mut Formatter, record: &Record<'_>) -> Result<(), std::fmt::Error> {
+    let sep = format!("\n{} ", " | ".white().bold());
+    let level = record.level();
+    writeln!(
+        buf,
+        "{} {}",
+        prefix_token(&level),
+        level_color(&level, record.args().as_str().unwrap()).replace('\n', &sep),
+    )
+}
+
+/// initializes the logger
+pub fn init_logger() {
+    let start = Instant::now();
+    let mut builder = Builder::new();
+
+    builder.format(move |buf, record| {
+        writeln!(
+            buf,
+            "{} [{}s, {}] - {}",
+            prefix_token(&record.level()),
+            start.elapsed().as_secs(),
+            record.metadata().target(),
+            level_text_color(&record.level(), &format!("{}", record.args()))
+                .replace('\n', &format!("\n{} ", " | ".white().bold()))
+        )
+    });
+    builder.target(env_logger::Target::Stdout);
+    builder.filter(None, LevelFilter::Info);
+    if env::var("RUST_LOG").is_ok() {
+        builder.parse_filters(&env::var("RUST_LOG").unwrap());
+    }
+    builder.init();
+}


### PR DESCRIPTION
- rayon is not a good fit for async because it operates on ordinary non-async functions, and blocks in operations like `for_each()`.
-  But since we're using async, we could avoid Rayon altogether and just spawn a task for each operation:
```rust
let tasks: Vec<_> = batches
    .iter()
    .map(|(k, v)| {
        tokio::spawn(async move {
           ..do some calibration work 
        })
    })
    .collect();
future::join_all(tasks).await;

```