### PR TITLE
fix: use vendored ssl

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install required libraries
       shell: bash
       run: |
-        sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+        sudo apt-get update && sudo apt-get install -y openssl pkg-config libssl-dev
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,7 +24,7 @@ jobs:
           architecture: x64
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-11-03
+          toolchain: nightly-2023-06-27
           override: true
           components: rustfmt, clippy
 
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.target }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-11-03
+          toolchain: nightly-2023-06-27
           override: true
           components: rustfmt, clippy
 
@@ -221,11 +221,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.7
-
-    - name: Install required libraries
-      shell: bash
-      run: |
-        sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -89,6 +89,11 @@ jobs:
         python-version: 3.7
         architecture: x64
 
+    - name: Install required libraries
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
@@ -172,6 +177,11 @@ jobs:
         python-version: 3.7
         architecture: x64
 
+    - name: Install required libraries
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
+
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
@@ -211,6 +221,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.7
+
+    - name: Install required libraries
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
 
     - name: Build wheels
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Get release version from tag
         shell: bash
         run: |
-          echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          if [[ -z "${{ github.event.inputs.tag }}" ]]; then
+            echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          else
+            echo "EZKL_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          fi
           echo "version is: ${{ env.EZKL_VERSION }}"
 
       - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         cargo install cross -Z sparse-registry
         if [[ "${{ matrix.os }}" == "macos-13" ]]; then
           echo "CC=clang" >> $GITHUB_ENV
-        elif [[ "${{ matrix.os }}" == "ubuntu-20.04" ]]; then
+        elif [[ "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
           echo "CC=gcc" >> $GITHUB_ENV
         fi
         echo "CARGO=cross" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,7 @@ jobs:
       - name: Get release version from tag
         shell: bash
         run: |
-          if [[ -z "${{ github.event.inputs.tag }}" ]]; then
-            echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          else
-            echo "EZKL_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          fi
+          echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "version is: ${{ env.EZKL_VERSION }}"
 
       - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,23 +52,23 @@ jobs:
         include:
         - build: windows-msvc
           os: windows-latest
-          rust: nightly-2023-06-18
+          rust: nightly-2023-06-27
           target: x86_64-pc-windows-msvc
         - build: macos
           os: macos-13
-          rust: nightly-2023-06-18
+          rust: nightly-2023-06-27
           target: x86_64-apple-darwin
         - build: macos-aarch64
           os: macos-13
-          rust: nightly-2023-06-18
+          rust: nightly-2023-06-27
           target: aarch64-apple-darwin
         - build: linux-musl
           os: ubuntu-22.04
-          rust: nightly-2023-06-18
+          rust: nightly-2023-06-27
           target: x86_64-unknown-linux-musl
         - build: linux-gnu
           os: ubuntu-22.04
-          rust: nightly-2023-06-18
+          rust: nightly-2023-06-27
           target: x86_64-unknown-linux-gnu
 
     steps:
@@ -79,7 +79,7 @@ jobs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo apt-get update && sudo apt-get install -y musl-tools openssl pkg-config libssl-dev
+          sudo apt-get update && sudo apt-get install -y musl-tools
         fi
 
     - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,11 @@ jobs:
           rust: nightly-2023-06-18
           target: aarch64-apple-darwin
         - build: linux-musl
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           rust: nightly-2023-06-18
           target: x86_64-unknown-linux-musl
         - build: linux-gnu
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           rust: nightly-2023-06-18
           target: x86_64-unknown-linux-gnu
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,8 @@
-name: ezkl-lib-release
+name: Create Release with Compiled Binaries
+
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'The tag to release' 
-        required: true
-  push:
-    tags:
-      - '*'
+
 jobs:
   create-release:
     name: create-release
@@ -79,7 +74,7 @@ jobs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo apt-get update && sudo apt-get install -y musl-tools
+          sudo apt-get update && sudo apt-get install -y musl-tools pkg-config libssl-dev
         fi
 
     - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash
       run: |
         if [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo apt-get update && sudo apt-get install -y musl-tools pkg-config libssl-dev
+          sudo apt-get update && sudo apt-get install -y musl-tools openssl pkg-config libssl-dev
         fi
 
     - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,7 @@ jobs:
       - name: Get release version from tag
         shell: bash
         run: |
-          if [[ -z "${{ github.event.inputs.tag }}" ]]; then
-            echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          else
-            echo "EZKL_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          fi
+          echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "version is: ${{ env.EZKL_VERSION }}"
 
       - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Create Release with Compiled Binaries
-
 on:
   workflow_dispatch:
-
+    inputs:
+      tag:
+        description: 'The tag to release'
+        required: true
+  push:
+    tags:
+      - '*'
 jobs:
   create-release:
     name: create-release
@@ -17,7 +22,11 @@ jobs:
       - name: Get release version from tag
         shell: bash
         run: |
-          echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          if [[ -z "${{ github.event.inputs.tag }}" ]]; then
+            echo "EZKL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          else
+            echo "EZKL_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          fi
           echo "version is: ${{ env.EZKL_VERSION }}"
 
       - name: Create Github Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mnist",
+ "openssl",
  "plotters",
  "pyo3",
  "pyo3-asyncio",
@@ -2986,6 +2987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.26.0+1.1.1u"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,6 +3003,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { version = "1.26.0",  default_features = false, features = ["macros", "
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-openssl = { version = "0.10.55", features = ["vendored"] }
 
 # python binding related deps
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37", "macros"],  default_features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tokio = { version = "1.26.0",  default_features = false, features = ["macros", "
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }
+openssl = { version = "0.10.55", features = ["vendored"] }
 
 
 # python binding related deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.26.0",  default_features = false, features = ["macros", "
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-
+openssl = { version = "0.10.55", features = ["vendored"] }
 
 # python binding related deps
 pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37", "macros"],  default_features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { version = "1.26.0",  default_features = false, features = ["macros", "
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-openssl = { version = "0.10.55", features = ["vendored"] }
 
 
 # python binding related deps
@@ -55,6 +54,7 @@ indicatif = {version = "0.17.5", features = ["rayon"]}
 gag =  { version = "1.0.0", default_features = false}
 instant = { version = "0.1" }
 reqwest = { version = "0.11.14", default-features = false, features = ["default-tls"] }
+openssl = { version = "0.10.55", features = ["vendored"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.8", features = ["js"] }


### PR DESCRIPTION
Changes:
1. Uses vendored ssl instead of system ssl
2. Updates rust nightly version in ci to 2023-06-27
3. Updates ubuntu version in ci to ubuntu-latest or 22.04