### PR TITLE
fix: move number of instances calculation as a param to pass to fix_verifier_sol. 

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -798,7 +798,11 @@ pub(crate) fn create_evm_verifier(
     let mut f = File::create(sol_code_path.clone())?;
     let _ = f.write(yul_code.as_bytes());
 
-    let output = fix_verifier_sol(sol_code_path.clone(), None, None)?;
+    let output = fix_verifier_sol(
+        sol_code_path.clone(),
+        num_instance.iter().sum::<usize>().try_into().unwrap(), 
+        None, None
+    )?;
     
     let mut f = File::create(sol_code_path.clone())?;
     let _ = f.write(output.as_bytes());
@@ -866,7 +870,11 @@ pub(crate) fn create_evm_data_attestation_verifier(
     };
 
     if input_data.is_some() || output_data.is_some() {
-        let output = fix_verifier_sol(sol_code_path.clone(), input_data, output_data)?;
+        let output = fix_verifier_sol(
+            sol_code_path.clone(), 
+            num_instance.iter().sum::<usize>().try_into().unwrap(), 
+            input_data, output_data
+        )?;
         let mut f = File::create(sol_code_path.clone())?;
         let _ = f.write(output.as_bytes());
         // fetch abi of the contract
@@ -960,7 +968,12 @@ pub(crate) fn create_evm_aggregate_verifier(
     let mut f = File::create(sol_code_path.clone())?;
     let _ = f.write(yul_code.as_bytes());
 
-    let output = fix_verifier_sol(sol_code_path.clone(), None, None)?;
+    let output = fix_verifier_sol(
+        sol_code_path.clone(),
+        AggregationCircuit::num_instance().iter().sum::<usize>().try_into().unwrap(), 
+        None, 
+        None
+    )?;
     
     
     let mut f = File::create(sol_code_path.clone())?;


### PR DESCRIPTION
Rather than read the number of pub instances for a given verifier from assembly, we read it directly from the circuit instead in the create_evm_verifier execution function and its variants.