### PR TITLE
fix: replace `bincode` with `serde_json` in wasm bindings

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -30,7 +30,7 @@ use crate::graph::{GraphCircuit, GraphSettings};
 /// Generate a poseidon hash in browser. Input message
 #[wasm_bindgen]
 pub fn poseidon_hash_wasm(message: wasm_bindgen::Clamped<Vec<u8>>) -> Vec<u8> {
-    let message: Vec<Fr> = bincode::deserialize(&message[..]).unwrap();
+    let message: Vec<Fr> = serde_json::from_slice(&message[..]).unwrap();
 
     let output =
         PoseidonChip::<PoseidonSpec, POSEIDON_WIDTH, POSEIDON_RATE, POSEIDON_LEN_GRAPH>::run(
@@ -38,7 +38,7 @@ pub fn poseidon_hash_wasm(message: wasm_bindgen::Clamped<Vec<u8>>) -> Vec<u8> {
         )
         .unwrap();
 
-    bincode::serialize(&output).unwrap()
+    serde_json::to_vec(&output).unwrap()
 }
 
 /// Generate circuit params in browser
@@ -47,7 +47,7 @@ pub fn gen_circuit_settings_wasm(
     model_ser: wasm_bindgen::Clamped<Vec<u8>>,
     run_args_ser: wasm_bindgen::Clamped<Vec<u8>>,
 ) -> Vec<u8> {
-    let run_args: crate::commands::RunArgs = bincode::deserialize(&run_args_ser[..]).unwrap();
+    let run_args: crate::commands::RunArgs = serde_json::from_slice(&run_args_ser[..]).unwrap();
 
     // Read in circuit
     let mut reader = std::io::BufReader::new(&model_ser[..]);

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -34,10 +34,10 @@ mod wasm32 {
             message.push(Fr::from(i as u64));
         }
 
-        let message_ser = bincode::serialize(&message).unwrap();
+        let message_ser = serde_json::to_vec(&message).unwrap();
 
         let hash = poseidon_hash_wasm(wasm_bindgen::Clamped(message_ser));
-        let hash: Vec<Vec<Fr>> = bincode::deserialize(&hash[..]).unwrap();
+        let hash: Vec<Vec<Fr>> = serde_json::from_slice(&hash[..]).unwrap();
 
         let reference_hash =
             PoseidonChip::<PoseidonSpec, POSEIDON_WIDTH, POSEIDON_RATE, POSEIDON_LEN_GRAPH>::run(
@@ -118,7 +118,7 @@ mod wasm32 {
         };
 
         let serialized_run_args =
-            bincode::serialize(&run_args).expect("Failed to serialize RunArgs");
+            serde_json::to_vec(&run_args).expect("Failed to serialize RunArgs");
 
         let circuit_settings_ser = gen_circuit_settings_wasm(
             wasm_bindgen::Clamped(NETWORK.to_vec()),
@@ -173,7 +173,7 @@ mod wasm32 {
         };
 
         let serialized_run_args =
-            bincode::serialize(&run_args).expect("Failed to serialize RunArgs");
+            serde_json::to_vec(&run_args).expect("Failed to serialize RunArgs");
 
         let circuit_settings_ser = gen_circuit_settings_wasm(
             wasm_bindgen::Clamped(NETWORK.to_vec()),


### PR DESCRIPTION
Serializing human readable json files is a lot easier to do in a JS client side environment as opposed to bincode. 