### PR TITLE
chore: add gas estimate to verify function

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -272,6 +272,11 @@ pub async fn verify_proof_via_solidity(
         return Err(Box::new(EvmVerificationError::InvalidProof));
     }
 
+    info!(
+        "estimated verify gas cost: {:#?}",
+        client.estimate_gas(&tx, None).await?
+    );
+
     drop(anvil);
     Ok(true)
 }


### PR DESCRIPTION
Add gas estimation to verify function to see how much gas units, on-chain verification uses