### PR TITLE
fix: limit the pubinput size to verifiers to be `<` P 

### DIFF
--- a/contracts/AttestData.sol
+++ b/contracts/AttestData.sol
@@ -18,7 +18,13 @@ contract DataAttestationVerifier {
     uint public constant INPUT_SCALE = 1 << 0;
     uint[] public outputScales;
 
-    uint256 constant SIZE_LIMIT = uint256(uint128(type(int128).max));
+
+    /**
+     * @notice EZKL P value 
+     * @dev In order to prevent the verifier from accepting two version of the same pubInput, n and the quantity (n + P),  where n + P <= 2^256, we require that all pubInputs are stricly less than P. a
+     * @dev The reason for this is that the assmebly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P.
+     */
+    uint256 constant SIZE_LIMIT = 21888242871839275222246405745257275088696311157297823662689037894645226208583; 
 
     uint256 constant INPUT_CALLS = 0;
 

--- a/contracts/QuantizeData.sol
+++ b/contracts/QuantizeData.sol
@@ -5,7 +5,12 @@ pragma solidity ^0.8.17;
 contract QuantizeData {
 
 
-    uint256 constant SIZE_LIMIT = uint256(uint128(type(int128).max));
+    /**
+     * @notice EZKL P value
+     * @dev In order to prevent the verifier from accepting two version of the same pubInput, n and the quantity (n + P),  where n + P <= 2^256, we require that all pubInputs are stricly less than P. a
+     * @dev The reason for this is that the assmebly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P.
+     */
+    uint256 constant SIZE_LIMIT = 21888242871839275222246405745257275088696311157297823662689037894645226208583; 
     /**
      * @notice Calculates floor(x * y / denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
      * @dev Original credit to Remco Bloemen under MIT license (https://xn--2-umb.com/21/muldiv)

--- a/contracts/VerifierBase.sol
+++ b/contracts/VerifierBase.sol
@@ -2,12 +2,24 @@
 pragma solidity ^0.8.17;
 
 contract Verifier {
+
+    /**
+     * @notice EZKL P value
+     * @dev In order to prevent the verifier from accepting two version of the same pubInput, n and the quantity (n + P),  where n + P <= 2^256, we require that all pubInputs are stricly less than P.
+     * @dev The reason for this is that the assmebly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P values.
+     */
+
+    uint256 constant SIZE_LIMIT = 21888242871839275222246405745257275088696311157297823662689037894645226208583; 
+
     function verify(
         uint256[] calldata pubInputs,
         bytes calldata proof
     ) public view returns (bool) {
         bool success = true;
         bytes32[] memory transcript;
+        for (uint i = 0; i < pubInputs.length; i++) {
+            require(pubInputs[i] < SIZE_LIMIT);
+        }
         assembly { /* This is where the proof verification happens*/ }
         return success;
     }


### PR DESCRIPTION
*In order to prevent the verifier from accepting two version of the same pubInput, n and the quantity (n + P),  where n + P <= 2^256, we require that all pubInputs are stricly less than P.
*The reason for this is that the assmebly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P values.

Thank you so much to @arielgabizon for flagging this issue to us
:)