### PR TITLE
docs: update default demo example and update readme

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -501,6 +501,8 @@ jobs:
           run: source .env/bin/activate; cargo nextest run py_tests::tests::run_notebook_::tests_5_expects
         - name: Variance tutorial
           run: source .env/bin/activate; cargo nextest run py_tests::tests::run_notebook_::tests_6_expects
+        - name: End to end demo tutorial
+          run: source .env/bin/activate; cargo nextest run py_tests::tests::run_notebook_::tests_10_expects
 
 
 

--- a/README.md
+++ b/README.md
@@ -33,38 +33,37 @@ The generated proofs can then be used on-chain to verify computation, only the E
 - If you have any questions, we'd love for you to open up a discussion topic in [Discussions](https://github.com/zkonduit/ezkl/discussions). Alternatively, you can join the ✨[EZKL Community Telegram Group](https://t.me/+QRzaRvTPIthlYWMx)💫.
 
 
-### resources 📖
-
-|  |  |
-| --- | --- |
-| [docs](https://docs.ezkl.xyz ) | the official ezkl docs page |
-| `cargo doc --open` | compile and open the docs in your default browser locally |
-| [![Simple Example](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/zkonduit/ezkl/blob/master/examples/notebooks/simple_demo.ipynb)| a simple demo of the python bindings in action on Colab |
-
 ----------------------
 
-You can find a range of python based tutorials in the `examples/notebooks` section. These all assume you have the `ezkl` python library installed. If you want the bleeding edge version of the library, you can install it from the `main` branch with:
+### getting started ⚙️
+
+#### Python
+Install the python bindings by calling.
 
 ```bash
-python -m venv .env
-source .env/bin/activate
-pip install -r requirements.txt
-maturin develop --release --features python-bindings
-# dependencies specific to tutorials
-pip install torch pandas numpy seaborn jupyter onnx kaggle py-solc-x web3 librosa tensorflow keras tf2onnx
+pip install ezkl
 ```
 
+Google Colab Example to learn how you can train a neural net and deploy an inference verifier onchain for use in other smart contracts. [(https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/zkonduit/ezkl/blob/master/examples/notebooks/ezkl_demo.ipynb)
 
-----------------------
+More notebook tutorials can be found within `examples/notebooks`.
 
-## Getting Started ⚙️
-
-
+#### CLI
+Install the CLI
+```bash
+curl https://hub.ezkl.xyz/install_ezkl_cli.sh | bash
+```
 
 https://user-images.githubusercontent.com/45801863/236771676-5bbbbfd1-ba6f-418a-902e-20738ce0e9f0.mp4
 
+For more details visit the [docs](https://docs.ezkl.xyz).
+
+Build the auto-generated rust documentation and open the docs in your browser locally. `cargo doc --open`
+
 
 ### building the project 🔨
+
+#### Rust CLI
 Note that the library requires a nightly version of the rust toolchain. You can change the default toolchain by running:
 
 ```bash
@@ -98,8 +97,20 @@ You will need a functioning installation of `solc` in order to run `ezkl` proper
 Follow the instructions on [solc-select](https://github.com/crytic/solc-select) to activate `solc` in your environment.
 
 
+#### building python bindings
+Python bindings exists and can be built using `maturin`. You will need `rust` and `cargo` to be installed.
 
-### Repos
+```bash
+python -m venv .env
+source .env/bin/activate
+pip install -r requirements.txt
+maturin develop --release --features python-bindings
+# dependencies specific to tutorials
+pip install torch pandas numpy seaborn jupyter onnx kaggle py-solc-x web3 librosa tensorflow keras tf2onnx
+```
+
+
+### repos
 
 The EZKL project has several libraries and repos. 
 
@@ -110,7 +121,7 @@ The EZKL project has several libraries and repos.
 
 ----------------------
 
-## Contributing 🌎
+### contributing 🌎
 
 If you're interested in contributing and are unsure where to start, reach out to one of the maintainers:
 
@@ -128,7 +139,7 @@ More broadly:
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed to Zkonduit Inc. under the terms and conditions specified in the [CLA](https://github.com/zkonduit/ezkl/blob/main/cla.md), which you agree to by intentionally submitting a contribution. In particular, you have the right to submit the contribution and we can distribute it under the Apache 2.0 license, among other terms and conditions. 
 
-## No security guarantees
+### no security guarantees
 
 Ezkl is unaudited, beta software undergoing rapid development. There may be bugs. No guarantees of security are made and it should not be relied on in production.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install the python bindings by calling.
 pip install ezkl
 ```
 
-Google Colab Example to learn how you can train a neural net and deploy an inference verifier onchain for use in other smart contracts. [(https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/zkonduit/ezkl/blob/master/examples/notebooks/ezkl_demo.ipynb)
+Google Colab Example to learn how you can train a neural net and deploy an inference verifier onchain for use in other smart contracts. [(https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/zkonduit/ezkl/blob/main/examples/notebooks/ezkl_demo.ipynb)
 
 More notebook tutorials can be found within `examples/notebooks`.
 

--- a/examples/notebooks/ezkl_demo.ipynb
+++ b/examples/notebooks/ezkl_demo.ipynb
@@ -1,0 +1,1158 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# EZKL DEMO\n",
+        "\n",
+        "**Learning Objectives**\n",
+        "1. Learn some basic AI/ML techniques by training a toy model in pytorch to perform classification\n",
+        "2. Convert the toy model into zk circuit with ezkl to do provable inference\n",
+        "3. Create a solidity verifier and deploy it on Remix (you can deploy it however you like but we will use Remix as it's quite easy to setup)\n",
+        "\n",
+        "\n",
+        "**Important Note**: You might want to avoid calling \"Run All\". There's some file locking issue with Colab which can cause weird bugs. To mitigate this issue you should run cell by cell on Colab."
+      ],
+      "metadata": {
+        "id": "n8QlFzjPRIGN"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Step 1: Training a toy model\n",
+        "\n",
+        "For this demo we will use a toy data set called the Iris dataset to demonstrate how training can be performed. The Iris dataset is a collection of Iris flowers and is one of the earliest dataset used to validate classification methodologies.\n",
+        "\n",
+        "[More info in the dataset](https://archive.ics.uci.edu/dataset/53/iris)\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "dx81GOIySIpa"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "First, we will need to import all the various dependencies required to train the model"
+      ],
+      "metadata": {
+        "id": "JhHE2WMvS9NP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "from sklearn.datasets import load_iris\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import accuracy_score, precision_score, recall_score\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from torch.autograd import Variable\n",
+        "import tqdm"
+      ],
+      "metadata": {
+        "id": "gvQ5HL1bTDWF"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Inspect the dataset. Note that for the Iris dataset we have 3 targets.\n",
+        "\n",
+        "0 = Iris-setosa\n",
+        "\n",
+        "1 = Iris-versicolor\n",
+        "\n",
+        "2 = Iris-virginica"
+      ],
+      "metadata": {
+        "id": "Op9SHfZHUkaR"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "iris = load_iris()\n",
+        "dataset = pd.DataFrame(\n",
+        "    data= np.c_[iris['data'], iris['target']],\n",
+        "    columns= iris['feature_names'] + ['target'])\n",
+        "dataset"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 424
+        },
+        "id": "C4XXA1hoU30c",
+        "outputId": "4fbd47ec-88d1-4ef7-baee-3e3894cc29db"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "     sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
+              "0                  5.1               3.5                1.4               0.2   \n",
+              "1                  4.9               3.0                1.4               0.2   \n",
+              "2                  4.7               3.2                1.3               0.2   \n",
+              "3                  4.6               3.1                1.5               0.2   \n",
+              "4                  5.0               3.6                1.4               0.2   \n",
+              "..                 ...               ...                ...               ...   \n",
+              "145                6.7               3.0                5.2               2.3   \n",
+              "146                6.3               2.5                5.0               1.9   \n",
+              "147                6.5               3.0                5.2               2.0   \n",
+              "148                6.2               3.4                5.4               2.3   \n",
+              "149                5.9               3.0                5.1               1.8   \n",
+              "\n",
+              "     target  \n",
+              "0       0.0  \n",
+              "1       0.0  \n",
+              "2       0.0  \n",
+              "3       0.0  \n",
+              "4       0.0  \n",
+              "..      ...  \n",
+              "145     2.0  \n",
+              "146     2.0  \n",
+              "147     2.0  \n",
+              "148     2.0  \n",
+              "149     2.0  \n",
+              "\n",
+              "[150 rows x 5 columns]"
+            ],
+            "text/html": [
+              "\n",
+              "\n",
+              "  <div id=\"df-af285907-4394-4eda-a976-6ee50cb1b204\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>sepal length (cm)</th>\n",
+              "      <th>sepal width (cm)</th>\n",
+              "      <th>petal length (cm)</th>\n",
+              "      <th>petal width (cm)</th>\n",
+              "      <th>target</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>5.1</td>\n",
+              "      <td>3.5</td>\n",
+              "      <td>1.4</td>\n",
+              "      <td>0.2</td>\n",
+              "      <td>0.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>4.9</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>1.4</td>\n",
+              "      <td>0.2</td>\n",
+              "      <td>0.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>4.7</td>\n",
+              "      <td>3.2</td>\n",
+              "      <td>1.3</td>\n",
+              "      <td>0.2</td>\n",
+              "      <td>0.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>4.6</td>\n",
+              "      <td>3.1</td>\n",
+              "      <td>1.5</td>\n",
+              "      <td>0.2</td>\n",
+              "      <td>0.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>5.0</td>\n",
+              "      <td>3.6</td>\n",
+              "      <td>1.4</td>\n",
+              "      <td>0.2</td>\n",
+              "      <td>0.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>145</th>\n",
+              "      <td>6.7</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>5.2</td>\n",
+              "      <td>2.3</td>\n",
+              "      <td>2.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>146</th>\n",
+              "      <td>6.3</td>\n",
+              "      <td>2.5</td>\n",
+              "      <td>5.0</td>\n",
+              "      <td>1.9</td>\n",
+              "      <td>2.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>147</th>\n",
+              "      <td>6.5</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>5.2</td>\n",
+              "      <td>2.0</td>\n",
+              "      <td>2.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>148</th>\n",
+              "      <td>6.2</td>\n",
+              "      <td>3.4</td>\n",
+              "      <td>5.4</td>\n",
+              "      <td>2.3</td>\n",
+              "      <td>2.0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>149</th>\n",
+              "      <td>5.9</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>5.1</td>\n",
+              "      <td>1.8</td>\n",
+              "      <td>2.0</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>150 rows × 5 columns</p>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-af285907-4394-4eda-a976-6ee50cb1b204')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "\n",
+              "\n",
+              "\n",
+              "    <div id=\"df-d1fa601d-55b3-43b0-bad5-604254ad7a3b\">\n",
+              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-d1fa601d-55b3-43b0-bad5-604254ad7a3b')\"\n",
+              "              title=\"Suggest charts.\"\n",
+              "              style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "      </button>\n",
+              "    </div>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: #E8F0FE;\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: #1967D2;\n",
+              "    height: 32px;\n",
+              "    padding: 0 0 0 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: #E2EBFA;\n",
+              "    box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: #174EA6;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "    background-color: #3B4455;\n",
+              "    fill: #D2E3FC;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart:hover {\n",
+              "    background-color: #434B5C;\n",
+              "    box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "    fill: #FFFFFF;\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "    <script>\n",
+              "      async function quickchart(key) {\n",
+              "        const containerElement = document.querySelector('#' + key);\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      }\n",
+              "    </script>\n",
+              "\n",
+              "      <script>\n",
+              "\n",
+              "function displayQuickchartButton(domScope) {\n",
+              "  let quickchartButtonEl =\n",
+              "    domScope.querySelector('#df-d1fa601d-55b3-43b0-bad5-604254ad7a3b button.colab-df-quickchart');\n",
+              "  quickchartButtonEl.style.display =\n",
+              "    google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "}\n",
+              "\n",
+              "        displayQuickchartButton(document);\n",
+              "      </script>\n",
+              "      <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-af285907-4394-4eda-a976-6ee50cb1b204 button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-af285907-4394-4eda-a976-6ee50cb1b204');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 3
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, we can begin defining the neural net model. For this dataset we will use a small fully connected neural net.\n",
+        "\n",
+        "<br />\n",
+        "\n",
+        "**Note:**\n",
+        "For the 1st layer we use 4x20, because there are 4 features we want as inputs.\n",
+        "\n",
+        "For the 3rd and last layer we use 20x3, because there are 3 classes we want to classify.\n",
+        "\n",
+        "The softmax function then picks the highest value of the 3 neurons and returns [0,1,2]\n",
+        "\n",
+        "\n",
+        "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcMAAAENCAIAAAD8BplNAAAMPWlDQ1BJQ0MgUHJvZmlsZQAASImVVwdYU8kWnltSIbQAAlJCb4J0AkgJoQWQXgQbIQkQSoyBoGJHFxVcu1jAhq6KKHZA7IidRbD3xYKAsi4W7MqbFNB1X/ne+b6597//nPnPmXPnlgFA/RRXLM5FNQDIExVI4kIDGWNSUhmkLkAEZIAAe6DD5eWLWTExkQDa4Pnv9u4m9IR2zUGm9c/+/2qafEE+DwAkBuJ0fj4vD+JDAOCVPLGkAACijDefUiCWYdiAtgQmCPFCGc5U4EoZTlfgfXKfhDg2xM0AkFW5XEkmAGptkGcU8jKhhlofxE4ivlAEgDoDYr+8vEl8iNMgtoE+Yohl+sz0H3Qy/6aZPqTJ5WYOYcVc5EYOEuaLc7nT/s9y/G/Ly5UOxrCCTTVLEhYnmzOs2+2cSREyrApxryg9KhpiLYg/CPlyf4hRapY0LFHhjxry8tmwZkAXYic+NygCYkOIQ0S5UZFKPj1DGMKBGK4QdKqwgJMAsR7ECwX5wfFKn82SSXHKWGhdhoTNUvIXuBJ5XFmsh9KcRJZS/3WWgKPUx9SKshKSIaZCbFEoTIqCWA1ix/yc+Ailz6iiLHbUoI9EGifL3wLiOIEoNFChjxVmSELilP6lefmD88U2Zwk5UUp8oCArIUxRH6yZx5XnD+eCtQlErMRBHUH+mMjBufAFQcGKuWPdAlFivFLng7ggME4xFqeKc2OU/riZIDdUxptB7JZfGK8ciycVwAWp0MczxAUxCYo88aJsbniMIh98GYgEbBAEGEAKWzqYBLKBsLW3vhdeKXpCABdIQCYQAAclMzgiWd4jgsd4UAT+hEgA8ofGBcp7BaAQ8l+HWMXRAWTIewvlI3LAM4jzQATIhddS+SjRULQk8BQywn9E58LGg/nmwibr//f8IPudYUEmUslIByMy1Ac9icHEIGIYMYRoixvgfrgPHgmPAbC54Ezca3Ae3/0JzwjthMeEG4QOwp2JwmLJT1mOBh1QP0RZi/Qfa4FbQU13PBD3hepQGdfFDYAD7gbjsHB/GNkdsmxl3rKqMH7S/tsMfrgbSj+KEwWlDKMEUGx+Hqlmp+Y+pCKr9Y/1UeSaPlRv9lDPz/HZP1SfD88RP3tiC7GD2HnsNHYRO4bVAwZ2EmvAWrDjMjy0up7KV9dgtDh5PjlQR/iPeIN3VlbJfKcapx6nL4q+AsFU2TsasCeJp0mEmVkFDBb8IggYHBHPcQTDxcnFFQDZ90Xx+noTK/9uILot37l5fwDge3JgYODody78JAD7PeHjf+Q7Z8OEnw4VAC4c4UklhQoOlx0I8C2hDp80fWAMzIENnI8L8AA+IAAEg3AQDRJACpgAs8+C61wCpoAZYC4oAWVgGVgN1oNNYCvYCfaAA6AeHAOnwTlwGbSBG+AeXD2d4AXoA+/AZwRBSAgNoSP6iAliidgjLggT8UOCkUgkDklB0pBMRIRIkRnIPKQMWYGsR7Yg1ch+5AhyGrmItCN3kEdID/Ia+YRiqCqqjRqhVuhIlImy0Ag0AR2PZqKT0SJ0ProEXYtWobvROvQ0ehm9gXagL9B+DGAqmC5mijlgTIyNRWOpWAYmwWZhpVg5VoXVYo3wPl/DOrBe7CNOxOk4A3eAKzgMT8R5+GR8Fr4YX4/vxOvwZvwa/gjvw78RaARDgj3Bm8AhjCFkEqYQSgjlhO2Ew4Sz8FnqJLwjEom6RGuiJ3wWU4jZxOnExcQNxL3EU8R24hNiP4lE0ifZk3xJ0SQuqYBUQlpH2k06SbpK6iR9IKuQTcgu5BByKllELiaXk3eRT5CvkrvInykaFEuKNyWawqdMoyylbKM0Uq5QOimfqZpUa6ovNYGaTZ1LXUutpZ6l3qe+UVFRMVPxUolVEarMUVmrsk/lgsojlY+qWqp2qmzVcapS1SWqO1RPqd5RfUOj0axoAbRUWgFtCa2adob2kPZBja7mqMZR46vNVqtQq1O7qvZSnaJuqc5Sn6BepF6uflD9inqvBkXDSoOtwdWYpVGhcUTjlka/Jl3TWTNaM09zseYuzYua3VokLSutYC2+1nytrVpntJ7QMbo5nU3n0efRt9HP0ju1idrW2hztbO0y7T3ardp9Olo6bjpJOlN1KnSO63ToYrpWuhzdXN2lugd0b+p+GmY0jDVMMGzRsNphV4e91xuuF6An0CvV26t3Q++TPkM/WD9Hf7l+vf4DA9zAziDWYIrBRoOzBr3DtYf7DOcNLx1+YPhdQ9TQzjDOcLrhVsMWw34jY6NQI7HROqMzRr3GusYBxtnGq4xPGPeY0E38TIQmq0xOmjxn6DBYjFzGWkYzo8/U0DTMVGq6xbTV9LOZtVmiWbHZXrMH5lRzpnmG+SrzJvM+CxOL0RYzLGos7lpSLJmWWZZrLM9bvreytkq2WmBVb9VtrWfNsS6yrrG+b0Oz8beZbFNlc92WaMu0zbHdYNtmh9q522XZVdhdsUftPeyF9hvs20cQRniNEI2oGnHLQdWB5VDoUOPwyFHXMdKx2LHe8eVIi5GpI5ePPD/ym5O7U67TNqd7zlrO4c7Fzo3Or13sXHguFS7XXWmuIa6zXRtcX7nZuwncNrrddqe7j3Zf4N7k/tXD00PiUevR42nhmeZZ6XmLqc2MYS5mXvAieAV6zfY65vXR28O7wPuA918+Dj45Prt8ukdZjxKM2jbqia+ZL9d3i2+HH8MvzW+zX4e/qT/Xv8r/cYB5AD9ge0AXy5aVzdrNehnoFCgJPBz4nu3Nnsk+FYQFhQaVBrUGawUnBq8PfhhiFpIZUhPSF+oeOj30VBghLCJsedgtjhGHx6nm9IV7hs8Mb45QjYiPWB/xONIuUhLZOBodHT565ej7UZZRoqj6aBDNiV4Z/SDGOmZyzNFYYmxMbEXsszjnuBlx5+Pp8RPjd8W/SwhMWJpwL9EmUZrYlKSeNC6pOul9clDyiuSOMSPHzBxzOcUgRZjSkEpKTUrdnto/Nnjs6rGd49zHlYy7Od56/NTxFycYTMidcHyi+kTuxINphLTktF1pX7jR3CpufzonvTK9j8fmreG94AfwV/F7BL6CFYKuDN+MFRndmb6ZKzN7svyzyrN6hWzheuGr7LDsTdnvc6JzduQM5Cbn7s0j56XlHRFpiXJEzZOMJ02d1C62F5eIOyZ7T149uU8SIdmej+SPz28o0IY/8i1SG+kv0keFfoUVhR+mJE05OFVzqmhqyzS7aYumdRWFFP02HZ/Om940w3TG3BmPZrJmbpmFzEqf1TTbfPb82Z1zQufsnEudmzP392Kn4hXFb+clz2ucbzR/zvwnv4T+UlOiViIpubXAZ8GmhfhC4cLWRa6L1i36VsovvVTmVFZe9mUxb/GlX51/XfvrwJKMJa1LPZZuXEZcJlp2c7n/8p0rNFcUrXiycvTKulWMVaWr3q6euPpiuVv5pjXUNdI1HWsj1zass1i3bN2X9Vnrb1QEVuytNKxcVPl+A3/D1Y0BG2s3GW0q2/Rps3Dz7S2hW+qqrKrKtxK3Fm59ti1p2/nfmL9VbzfYXrb96w7Rjo6dcTubqz2rq3cZ7lpag9ZIa3p2j9vdtidoT0OtQ+2Wvbp7y/aBfdJ9z/en7b95IOJA00HmwdpDlocqD9MPl9YhddPq+uqz6jsaUhraj4QfaWr0aTx81PHojmOmxyqO6xxfeoJ6Yv6JgZNFJ/tPiU/1ns48/aRpYtO9M2POXG+ObW49G3H2wrmQc2fOs86fvOB74dhF74tHLjEv1V/2uFzX4t5y+Hf33w+3erTWXfG80tDm1dbYPqr9xFX/q6evBV07d51z/fKNqBvtNxNv3r417lbHbf7t7ju5d17dLbz7+d6c+4T7pQ80HpQ/NHxY9YftH3s7PDqOPwp61PI4/vG9J7wnL57mP/3SOf8Z7Vl5l0lXdbdL97GekJ6252Ofd74Qv/jcW/Kn5p+VL21eHvor4K+WvjF9na8krwZeL36j/2bHW7e3Tf0x/Q/f5b37/L70g/6HnR+ZH89/Sv7U9XnKF9KXtV9tvzZ+i/h2fyBvYEDMlXDlvwIYbGhGBgCvdwBASwGADvdn1LGK/Z/cEMWeVY7Af8KKPaLcPACohf/vsb3w7+YWAPu2we0X1FcfB0AMDYAEL4C6ug61wb2afF8pMyLcB2yO+Zqelw7+jSn2nD/k/fMZyFTdwM/nfwFGJnxZflARVQAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAABw6ADAAQAAAABAAABDQAAAAAI4glaAABAAElEQVR4Aezde7hvVVX/8Z+plZmZmZWlKVpeKi+lpRLo4aAm4V3TSDBEvEtGT8bj7ZHiIcseVPTxhiBpKhKSJHnLIxKhdjNTNCsvaWVpVmRmd/P32vvNma725ex9LsD5nr3mH3OPNeeYY4451hyfNeac67v2Nb785S//vznNFrj6LPC///u/Ov+qr/qqf/u3f/u6r/s6tJL/+I//QP/Xf/3XV3/1V6O/9mu/Vvm//uu/Iq51rWtVMvhVRQ9ODbGRqepv/uZvbnKTmwyZyfn6r//6mOtC4WiL0FC/Cuc0W2CTFrjGjKSbtNTMdiVZYCDp//zP/6ChGBDU17/8y798wzd8A4iEnnLYlwL//M///I3f+I1oBIZ/+Id/+JZv+RaXmmsIbYHgChxMLB5yQKfm4DKe0FaVcrSEOQUUzmm2wCYtMCPpJg01s11ZFghJP/nJT77nPe+Bni7h4wMf+MC/+Iu/eMtb3nKb29xG1X3ucx/dP+EJT3jUox51/PHHowtCVT372c/+pm/6plNPPRUUQlsg+KEPfej0008Hl6pwKoS5oPPbvu3bXJIv6UgrhQM0B4FnTrMFdtcCS8ufOc0WuNotIBi87LLLfn45IQAlaHv/+99/zDHHnHfeeX/1V38lMj3iiCPueMc7ij3V4qez8s985jMAFw06NQGOav/4j//4oosuApda4VcVjGLWEBsYrQu0BIWnFlhxOa2a6dkCa1rgmieffPKaFXPhbIGrxgLtL93gBje47W1v+6d/+qff8R3f8bKXvex617ve9a9//dvd7nY7dux48pOf/PCHPxz23eEOdwCIl19+OWbwJ/b8whe+YJFugX/3u9/9hje8IYUVXvOa1/z7v/979F3vetcb3/jGat/3vvd99KMf/c7v/E7RrqovfvGL173udT/+8Y8D1utc5zpf8zVfc41rXAM/Tb70pS+BWhKumrHPvRwwFljakJrTbIGr3QIiRxBml9PSGzhaj1PJ4v2f/umfEC7PPPPMc845x+r+p37qp8SMT3va0z72sY/B0z/6oz+yA3CrW91K2+c85zniU3HrJZdccvOb3xx0Cktf/OIXC10RF1544bOe9ayLL774tNNOUwWm3/jGNz7oQQ867rjjHEllgel6/2q3yazAAllgRtIFulkHsqoA1GG9kBMUHnXUUWDxe77neyzSrcEVqoJx4s1M8Eu/9EsXXHABQPyBH/iBpzzlKaJOUHvGGWe86U1vskOK/2//9m9b5sPfSy+9lEAbBS984Qu/9Vu/9bu+67tAMDknnXQS7H7FK16xffv2gaSgWRVlVB3I5p7Htq8tMCPpvrboLG+PLNAiXQQKQJ/61Kfa2YSPlvPQ0xocwDmDgnr2PcHc29/+9kMOOUSJSPb7vu/7hKUKzz333Dvf+c5gES1KLby1rnf5qU99CjI+8YlP1Orbv/3bsd3jHveQC1Qhb69e4e/Aao/UnxttdQvMSLrVZ8DVO34wlwIW7HZCIaPw0PIc8H3zN38zeG3VD0kRSsSeRYveEkUDXNup4lbrd83/7M/+jDSX9kx/7/d+T1jqBSlAecoppyj/4Ac/2CaAhkCTwGQmUBeUQQepV69Z5t4XzgLzidPC3bIDSmGHPMBLDshe8pKXWLN//vOfd+xzy1veEvH85z/fOf61r31tR0Af/vCHbWuKSb0RBR8t2x1P4RGK/u7v/u4P/dAPHXbYYY6n3vve9zpKete73vUnf/Int7/97Z1NWdfbB7CiVwVV3/3ud7/uda9z9ASy7Qa84x3vIO2ggw5yxkWHjEuB+dDpgJpnV/5gZiS98m0897C+BWCopB78gTzHRAAumBNmOnA/+OCDRZ3iTblzdst2+Hizm93s3ve+9yc+8Qn7oXe60528Z3q3u93NST2gtJAXkHoBAMOPLCdxKIgUaeL57u/+bnHrLW5xixvd6EYAWvRqc+CmN72pEgGvEFVYqnxG0vXv2FyztgXmN/PXtstcetVYoAV1uf1Qh0X6tdK3rpcLV4GgzVNIqhzwKVcC8tAAtyqXdjzjwYbG0+6nS2v89kz7KZS3oBCVkKAtIWBUXzjxC3vlc5otsFsWmJF0t8w1M+9jC8DQJAIy25dQDAFD7WNWHoPCQYSnUG/wDKiNwBAaQklCgG+iICy6qrC78pGPLtasHWwzMVtgtQVmJF1tk7nkKrVAsAX+iiJBZGBXaAn7wKgEFkWaNBvEANAkFMkO1acHR0QJP0dbVfoKN0NktOYDZHHqcYiaidkCG1pgni4bmmhmuBItEJzJgZ1uECC1/lqhh56jMH7wp6TlvK3SUA8UqoWzCBKCRZxoMNqvnpIvmB3QXGDrUkfFsGgpHeZ8tsAmLTDHpJs01Mx2pVgAtIEtubdHX/SiF+nDeZES50UOl2AidJvueMI7SVCp3CtQGFq8k4AOPREkYAOjEWpdKpfXnVxfGDQZ4TDCpapRcqWMeRZ6IFpgfvYeiHd1ccYUrtEXMgpLvdv00pe+FERCT3CpFlDCwTEgUIhNIInHvmowCvgwAEFYicAjVUJCAOoyUaQpdFmJfCA1oqpRssw1Z7MFNrbAHJNubKOZ40q1QEAJwpzdn3DCCUDQb5lgZZAHYSUo6af0FukwzltNVvTekcLjEqTCXPDq3N8RvJ/qq8Xpt0xqCzO9xm91r2HH9yHvDJdX6m3dasLn3zhttTu+n44XGtIM3kHG9i6VIACrl+p9rwT8LYWa17qWT5Fi83Uo0Alz7ZaeddZZr371q32+xCulXuaHm9o+5CEPedjDHuad/Ne//vXe2/ca/yMe8Yijjz46hNUXpCazvvZTo8xqLY4F5tX94tyrA1pTiNZbUMLJotS2LAWkzujFjyeeeOKRRx7pN6Bve9vbvK7vR/TKhaKQF7D6RhS49DUThdiYymef3vCGN/hkic1QX37yRSgwCnwt9uEssaLgGUYP6Dl1lQ5ujkmvUnPPne3CAnAtgBMqgrmxNvfBpwc84AG+WqJEAoVAFrD6cMn555/fij4M/YM/+IP73ve+oPPQQw89/PDDHVv58L6g9TGPeQy29knlEjXgte6id6HVXDVbYDMWmJF0M1aaea4KC1h3Fy0Gqbq0N2pVDgSt32GlrzeJSX3dWZVQFLyKNJUISB30+/AoCXe5y10e+chHwkcYKhT1SgBmQauP6U3HAENdzjA6tclM740FZiTdG+vNbfeZBXxwxIdEnSMB0+c973niSl8n+e3f/m2bm5bkfizv+3i+VCIOFZD6binofOxjH+uQylm/2JMecFZA+oxnPMM3SpwsWfgLS7Ui03aqX/R3YIUTjNpv7Zh+nw1gFrS1LTCf3W/t+78fjL5dUZjoH9j5wojLz372s5DOKl5w+qQnPUnkKN5snW51Dxkf/OAH+4wp3dXe+ta39u9J2jBVAnwt+X3BxIdKoa2TqH/8x3/0/0U6a4LC5EvkY+590v3ABrMKC2+BGUkX/hYe2AOAeg1wwB/QtOR/7Wtfa+0PTwWhvueEB/LKg8iaiDpH8zkCzSZzfiVZYF7dX0mGncXuMwsMEASLaCGqxbv1vsN670KBUav13meKMza5RAmFEftMoVnQbIFVFphj0lUmmQv2MwvAwSASYiIke6nFnlbrlBWNdnbkPSqboamPrYYDT/ezYc3qHFAWmJH0gLqdB+RgOiAyNJgohaHQ0y4nAIWYGBDTdf0BaYd5UPuzBWYk3Z/vzqzbkgWAJpSEmGhIOoLNqXWgqvLBNq2a6dkCV4EF5n3Sq8DIcxf7zALhaUEoVLU9Cmcd8bfMb/m/zzqbBc0W2LQF5ph006aaGa8mC4zV/SCgJxgNPYdSahW2YToKZ2K2wFVjgfl391eNnede9tAC0zATnRSr+N4MLSZVCENnGN1DE8/N9oUFZiTdwIo24LzAGFOezHs3aLNOtd8sjpoBCqNkJrIAQGTzaKYe26NBanZT2KUX9aGqJkpEowgN5YNwyi+AnW07W+DKtsC8ut+shXk1v+WinBa2jrdtVrTPh1cUugwREFM5q9m2ckm4WbA5tVg2WULHZZDFJnmldJzXKweXLAxVEZ07gdqx0gfNK7YCtrKd57FfGRaYT5w2sKqghhNy3dzSG4u+LeSIYxfNuDTfXpEHvvk8RObbAwh2IWrrVLEwO/e8AYLQ0NgV+gSJ7416D1/+7//+78MgBac3uMENbn/723s532/zayKPYF48EmKG0WG3mbiSLDDHpLtnWL49HHW3WoatIqYQeY6SVluvZXj28QD74Ac/6Esll112GZsXcnqAWQoMA3qqeT4VhPrs0z3ucQ9fevY5KJIVhqHdrNnaq609l+xbC8xIuoE9OSQOzsyH5cJJJfnnBi1XVfNnMRcg4OfBwSBW8W7FAvZhWI+cD33oQ74L9dGPfhRWtopnLl8hUctiIlOcbgRjKsT/d3/3dz6A4tJy4bDDDvMr0lvc4hYsOAB0tvNWnE9X7ZhnJN3A3sWSmPx3IJ90u8lNbuKr7CKgFd+7HFJan47LKREQEyiS8nnNadVMZwG2fc973vPOd74ThjKRVfl1rnOdL33pS2p7pAFTJYCVGS+//HIQeb3rXU+sinApkiXhDne4w33uc5873vGOWrG5OzKv7ucJdmVbYEbSzVoYjL785S+/4IILrB/9j6BnPvOZXDScXZGvKXEwV8vzfaKYt693crWmkAO70CdKfd7pIx/5CFvd7GY3g482SdHQE3QixvAHzfKwUpSKEJ9CzM997nP9R7wf+ZEf8WE95gXBrC2GHc1nYrbAPrfANU8++eR9LvQAE+jtpete97oAlFu+613vetCDHuRLmsb45S9/eXXOpZWvTpxf0KT82te+Nsf2z4h+5Vd+xX8Z8nnNA8xcezac/pXIn//5n1uYOz6yWgejDpSucY1rgNGRWO+ayylLKoeeUNINYmGQKrchAF7hsi+TkgaRRbXgeM8Um1vNFtiMBebptYGVRDQ8Uy5Z0ctvdKMbWUWeccYZ3JUP284Dtb6SKcB87nOf60vvN77xjd/73vdyYP8wwyr1lFNOcb7sP1/6CLGPt/sQ3LZt2xTCDpKxOSchBwQTDgj4PGLRPd9wVljW0Cpp5c6Gxti6G+r53qhLmyf/+Z//afg3vOENQ09NlEeTkJBybHrxWHIZzYxuCn6PKIb9/d//fVWPf/zj9YKNKHI0kfDIk7NCz/lytsAeWOArK6Y9aLx1mnA8Xsf5uZ9zDMl/whCZ+ucWjoxV+U+Wzkl+53d+5wUveAGeY445xjfeH/3oR8NQ/9DtN37jNxxDW2yqetWrXkWafz0El61ABU38PCBQnkkHsbgWZpNpMhBjlxA2QO0UQzoDRzDUG9/4RsxGbYUu6kRIoad1wJpJc+UjR0iQVMpoolQljv5/67d+S7+k6YKd1RKePnHO+WyBvbfAHJNuYENeBzcHKPBeDbilf1cpqDzhhBP8x2ARaJue97vf/eCps+NDDjmESws//bdL/1FD7OlYWS7m8s8zVIFRJdr6/0IEcvW6yNU30GkBq41uCUd3/ot5GNogEI6Y/Ed7lmFqbGwbjKpCQ0OXaLmkFR550kSaLIZt3KMYXGLwr/S8iPrmN7+ZcM8zDfGPrjGkw5zPFth7C8xIuikb8lV8nDY/FFXZyxOiAlYOyT/BIgbr1gIotCaYeS9OkRdaTsJ4h9zBCH6FCQkg0obM6WWFi54bkQQZ2xUxRnjnSWMNHoyKRhmtxFwS2lNnZ9lSUDkSS5IgZ3xplGc6mMu217/+9T2oPvGJT/zmb/4mwj1SPmwbLi+6VWf99xMLzEi6wY3g9rwUE8gTeDoGsTFqX8//aFPo7XEOCRG8fCNE9W+FwCs2uS1Rh1TiU0t7G6nWmBby1vhiUv8vExZrqAlOreALaUrqC31gJLDVQMa4oF4WA5RQEsYpsRJ3KIRH1UDSMNRjZhQiSMMmkSyFpPK2RxEYmFRbuUv/Gg+kul/ulO1pEnSni+RgSGZKzvlsgT22wHx2v4Hp2rbjfqIn61BIykX9RzaHy05FODAY/cAHPgArv//7vx8cXHTRRVyX3/Lzpz3tabe61a14tQPot771rY6bHUZZZoLXm970pl73sRVw6KGHAlxQwqWx0UYerGyg2f5dbfjGS0eEEaEbnQMlGGqwDOWknhE8VDqOZ+reZMLgpdGSEsCnBKFVOc6agFREHZXrsRN8/bo7OsXzhS98Qa33TImKLQvjUbt/G3LWbjEsML9PusF94mwiF/4GQOEpt3cJPTXj3n4M7i39GHjpC1/4wvPOOw+AejO8wAeqakII5NVKWKohQlvSFMJZ23lDiaKk8lG4iIQhU3vglBEpkQxcdG9j9KlPfSoTMYio09v1mFWxhoQQpEsICYDKMSMILCVQXgKaEsNK7pQumFfukmQ/gkI4FbTG11wJZh3Rp0slc5otsDcWmFf3G1iPp/E3bhyGcmau266ociGn9rmlV0TPPffcT37yk1asjpI4P1/VCoMmAs+82iWZ/FwOheuezwcWZCrRS+WLm68GKUYwanG9PQ2/YsIA16AeYwpUeyHUwKVAM4INEeUIRisRRYKU2Aylyr0gkD3RMFo5Bg09tOzA9NqZwtriWVwLz5rvVxZYeI+9CqwJ4zi8EInjcWCXo1Meq5znc2AvPHkvCg/E5PkSAj9/VovAyYFjyMmTo9YlBpdq8USMXvYfYjO6xQO8IFePHFvDxmjHQyh6m9vcxlqbPY844gjLcE8aS3Vr7YZs+JK2EqsOern4Kxlmd0FHjAYoB5tyRrYDo1aVu4MHg3vBwvZS7nznO2dMDFqplVcy57MF9sYCM5JuYD0QwKW5Ir4gUgk/t2zntAMQ+aRF+r3vfW9VOCGFnDNjaIHvMlFyDZOGYYrLRU+qQgfE/pMCnXCHel02WHThdrEkHuOiORi1++F1UbmQUAT6Ez/xEyzjR7e+g7d9+/YdO3ZA1f/+7//GrFWJzJLLBHYZsMYzzOJS7dBtcNJwKlNbGkLYYeEkaD5EzcRsgb2xwIykG1gvDMXkZRqH8t5hgox292BBPuysSSFwLG4VB2nikuuGs7wXsqiFLGBUbQ4MQyW1dZG3AwUEtoHRG+h3VVWn8xRA69kwjWJYqUJDEIcyl9c5DUQcCjetrOHp2Wef7QUGby8Q6C0IpusQyaXEpIOY0hVOc5roS0l5zPWu0OUAUzSwxu/XupXL45zz2QL7ygLzlNqUJaGntaFfNNrmgwvewLdDCjSBY9hqlQo9Cz/hIF8NJQFoB0phjRyqYtNw4AINwiNN0mZ/g9FhIzoHYUpCsYYJtqCnEnEf9LRZjGAEQainjiZowanz+ksvvXTbtm33ve997ZYqZxBrfJukaImciBW57pTUI6LLodXqy0qGEJfUiz8h0XM+W2BfWWBG0g0sWRQJKDk/VhjhN6DHH388Gojw1WCxqJOXKoEO2CxmhasOmqADEPHSqI1Ce6kYeHVhEXp0D3rCXK1IaAdg1F7tRHaghjGiaW74RlE5wg8NBJsGjoG5HvjAB7IAswSyLKD205/+NIP4fa22Bth3DPBA0ukAM8swDmKkFHCZqVe30p1CDIFyDGj8vSEwbTLTswX2lQVmJN3AknweWGCCbtan1vjiR54JO3LmQMSHncRiaF8ahrPexvdbcuHqL//yL8NNv7UHJWeddZbmvl2CTTzroydg5bTTTgOdSnpj/6EPfaheNtDp6qg2/LDJcNCpAATRonULeUgq0PaosO+BsJDHw0SGZoCXXHIJS5IAQP2iCeGxwZJOpXxAb/WA6msA6CAGpxL0KB+XFcZW70TRE4N+B5uqIWomZgvsvQVmJN3AhlwOdnBFfAFH/unSSbSoykr8zDPPFG+KVZU4Ttm+nPpSCUzhvUBWgAZGvUTpk1HexvcFEx5+1FFH+a2UWqh6u9vdDgyBG/wgZqDVBvpdtdV0bvhMATrBpV8c+IWCJfzd7353Y2QrGtHfU8RAPITE7Bby8BSGanXb2972rne9K6PFafcDm4RBTv404ZcILMeg95JCl8rxLzHtTDV3hYgfQR+GtSGD1m/lV63l5t4OcAvMSLrBDc4z4Rr3AwrgYDg/GNWYlx577LH8U/m73/1uPgxfvJnvk3riTZEmxAETXte3SwhM/cbJ25T2CoVIciXnn3++MNaKWBe6gxT7IYyOVbwBemxAf8M0dlvGnhaCa1DFGumPVoWGmL6Nrckhhxzi97IYoK2g20jZ5KCDDhKTfvazn0WEfVkbrVbOFHKtEHKFEXISJPw6qm0EeqR4vGKlikq6rrnyCM3JJHlOswX20gLzNNrAgDwNRAJKvgcyAIodT66o3M6mNTu/FYpeeOGFzqN9TO/000+HiYQ6bIGYAlWhkCU/+PAykCVt39Pj2GFT3k4+b9dKOffOzzfQbK+rgy19DYQist6HAgN0gHunSdbynihCTpE3U6TF4A+YCDEQVa985SvR97///T1FEH4sa+2PubEffPDBfULUpYYsmTUw6M4lm6A1JGpFLIlTIR61chIkBGjWdcbEo8TPSYG+dYDbl7b6srsC5dO2wjmfLbA3FpiRdGPrcTn+zBvBAVSFj0Wg8pNOOunEE0/81Kc+5aTFovVFL3qRcxVslvC81Iv6PrDfkp/Dw1Y/f/qxH/uxF7/4xfBILAZ5//AP/xDC+gi0Ixqq5Py6kzbWbO84aCgNGTSUgnIAVC01IBTcoSEApZ6FPFUhqYYAixHi0aRHCEIhUY7pNXzyk5/sMwV+Yi/wJEpgqCEGuZ94+ViBb7yivaJkl6BgnJGVkEYH0tC60LVcGpdKllW+IizFSR8S2BObSy+rglE5OT/6oz/aYJWrdU/JwR/io+c0W2BvLDB/wWQD68GCnO1Nb3qTPcFb3vKW3M8q3t6f/0Ti26Mnn3yyUAtYQEkBFwav9YjXsPkQEYRVwo19SsMJ9eGHH2457zxKfPeEJzzBwh+O+JEPZLnTne4EGmijuz72sYFme1dNPYBSR8DFEpgaIRf0QasFnRDfMD0bbGt4PPjpgc1cbMyibapqTn8fHIFraM21dQbl57M/+ZM/qeE555wjenXu5AUy+6TYSKCAKq1YAHSCZjjrZ6OgkFhvgBLVz5/oxjJyhRjK1bKzS60Q5dWSTz3JYT37e2vV04vlQap3V6mnbajKhFTdO0POrWcLLFlg/oLJxvOg1T1n5q4t8NGgUHgVKJTbEhVk8VKwAmdFZOJNl86gRECaSDi5bpGXjnm7Kjyk2WokvyooE3xvrNzecRgarfRVkDiEQb2+REdh8AcH+8JAGBT6qNJc5NgotHUJHBHGzgKQd9u2bW95y1vAsWeMx4ZLRtOj7sB0geHLXvYy/4AAwsJBkn1UlBEgnYQNLS+plciXL1lzZ0xKExaTqEcHtfLYfOZZrbUCZehJvSTUllhsc5otsPcW+Mribu9lHagS+J7E6yAOX839QgS7cjZA+bxyMAoK1cIIUOK4CQCdeuqpwJczK8dDAmYujRMGgZKqRGRqhwF1N+griYA7VAr4dEENCb7Yi3CaJHCmql+pOx8L76i3bIYrIAxtIIagHIOGBPYYEJ5758lRvlMmiOwSbdNDX53R6UiPLjOIgB3wiUztG/gXeCwjeERgCBCXVVuKdjPLMM4USdWWqJF8bP2Gysf0HJF5HtBTrVb0VGv46CHtSrLzLHaLWGCOSTe40Zw5uAF/PJDv8UDezl0L5fJbOWSRVGHj1Za3AjHeq1Afok6Qym9VkVCvpEloPBEYiJJLG2i219U6giy6pg/1RI5gFPZ5SIjgoJ4B6oRi2NBpqCTdXK4YtSq/AfMhV48Q+wBMISDtTQYbGgJSH2bFM+Cs3ing4M6HsV2SbLdUX6yknOXphijVr1zSewqU00QTudvkWM+2rCWC59MDHvAA2xE2eUmwvUvgcrulA8M0aYzoOc0W2BsLzPukG1iPJ3PRL37xiwhJuKSB/TvbbS6BhSoboHzYZVXwyP8fhQgWqny+wMqenW8MY7bNZ7dO3EosN8aglYUtme0Atke5gVp7XU0rvdPZ+cw73vEOQbQS0POQhzzkB3/wB/1vzoE11MYpbwOUwrYsJZdDVbRtU6L8T0AjJYRBfBXUKw33vOc9na1JNivBnLE33n5uz4B0YCtd+6fKdgDI9CiCqlI2IarUNujYJ3WJpzwCzcJakUMf0HnkkUfSR+wM4hlc2Et/hLwRtVO81+acBWx1C8wx6QYzgIsWtohluB9ufghl0MK3fo+kJBjl8NjQlcjBU6t7NICoM4XFuQqV4AcxotdxOfraQLm9qKaDNa9FN0y3LyFwsxM6NGwgxljST6EcYlqCzaWciWwIOGICiN6ldYn/Na95jaG59MsFLzaIc41xjD3DYqMAE5FsV4GE97///czrZVsICGfRIzXcoUBKkhDBevBdTo6x+L+t3rKiCfmQtHcqwLqFgiYUG3c2sXM+W2BvLLDl9kl5EVdkMi7HnRA8iq+GCJVw4DBl6my1wh8POb1hrkRV0shBcOx45HwYQ1iA0EpSjqdybYvLXCpXOxRTsjphSJMlQcs7Ay4rwawkWKlwlCfHJQaQZzUNWaAeWLGWB2SQfcpM4RVdJ7AuaOiyQUFG+GhzAAgifJ2g0Vnj/+Vf/qXXaa2yBZuQtCH3CCEHxsnJYSJaIWxlWpgLG71nBuXR/kdLrdS6F42urpVXpbvM7j0q29Z0g6EQ07iUa0IrORz35NuxY4d+daTrbi4hqwc7JgC2Oc0W2IwFVjrMZtosNA8/zAMRBpIP86Ulv1yOsNBgNDpvX3O8NVeFiObDnJPfKtR8SEbENmVGS6qG0yKU6Bo07BpMl5t+pV+XS6ovwzdNNK+kfpU3CpAnWLPzAPVUWflSNQxNoEJpNaxUK08rXeDBSbISQgR9XpPSC5l61xEaFDrqwQyyEZrvQrLa7AA9vcZvm9Vug/99ba9AvEwm/JXaENAvO2vS0+5zn/ucXYUA3XD85goWg9FuCjapcTk90wswxUZtCE5OY4lHk1olebnpnM0W2JQFtuLqnitK4Qss4DzDyQeE8T10PGsaEkOJKAwkSES5rNylcst2Ry7AC0ZwYHnlhGPLb+WSy+TICYkNvTqplZTjWcG2Yjh1YdOw06TW0Y7UW+HqdAgnMAUC4lE+JQboB0C6Tn6vxwoDQVj8gBUUPv7xjzdw3x/w5qx3vPBPexyS61cV5anB5mjIKHAWz9rDRUvY6FYtmjLy1GZYYO0NAePCM3rBED0IpnAIBij9SkJht3jUIghcT8+h8EzMFlhtgS0XkzJBEJAt0AgQw+XEKfwwvHBZ1WqTVYJB4ntTx3MJZcR9AjHHx/w/5/f+OTaLXMKBqR/2iI+Ai1rStJISyJOV7LprtZImU92SkEBCqCFBCiGYNS/hUMbRuchOK+OFJgqTkKgUmMpcQeu0EvLHc8ixOLi0IwlGe2CQJpb0QRa7H/DUaZIIURPyU3KF2HHZoOKhJxPZvQXQQk4mhaoeS0ZkMxSPZCPVdqqluq6BqRLmTTG0HofCunAvyGTzbdu22YjoBQMlS4J2Am4GSdVp26HhTMwWWM8CWy4mzcHyFkbhPGh+ZTVqj49n8lWuNRwy71ptPmycbdRyci9Ocvi3v/3tiVVLCGjDI3HyUMxunaQKtH3v934vvGhHjxpktq5EhImr+01zAqtyKVF4uiCFGjTxar2dSt+sg0cSgXTAjJNumqwQPmSuKB+XtEKPUYNjRmO6Bz/4wdbgyrPJr//6rwvDjzvuOFDurXtQaJNUQ/L1jm0IjEgTVdMhE1V5N8IlBhKkWg3m2MrVIgZPnSrRVk4UlRSKdv3vQr+/cjClXFK4WrE6mvPZApuxwMppvZk2C82TM+c8cg4pF/X4RaO4xudBleBpjLGtOV48OTMM5Zlg1HvgFo+9qL/i08UkhAicHOjAa2CHGd7ZuyxaVJgz6zREWLNftVJV+EtdghuBm3CYTOXeq/dsEAJXqxUdQhmcA4nW7GXNQhLGqIFyP4Lavn27kHApAF7+9ScFPvCBD3gLSoB/ySWXeGPJUY+qgH6KcSu6oDDhS2PbiWtp6FIrdJdadXcMQZMEjibJHL0ksOaqsGmC8FxxyyC+T3A5dos/seguEzXnswU2aYEth6T5CbcBK1xLWvadr4I4DrUBIlzjb8qzoNp4VuRBA0CEXH4Z6X1J/L0UpUmvWyaBNCkkJUTSO6BJgrCxD6B4ld1Ji1oYURV6de8BSlXJh1NwTXjoeSDaNRCHNta89YhHdxJilFRYc10gyitZL9e1fiXSwKju9CKmVqIJnUWpfo9w61vfWqzXA8bHBJTXu5wd1hNOgRU64CdZk6Uul7uIZypEeYXEontCxFyufIgdgK7QI/O5z32ugNq+RA8bbBiMEbFrVdcbwly+lS2w5d7M9w65+y1W4jPezZZ4JlCwgwaPIKDY0Bmxcu4k781thFbTXLlWwi7YYTELpMShnJBYycaoEgnhUheqNJF6od3b4xX6ygkAEs/CYhKooXcoMO1rStMwiGkgdPDOuY+MwFCv08MFS2kvD+mu/UQEzfVLDQTJjV15iXCEqmpxRq/OU17vAk/fcKGnL10RCIAMU3c+F0KTH/7hHxalXnbZZR/+8If9xIhwnKQVRa4W2+jSVm0KEItIwylRczqkc8zDIEyqpFRb/ORL5FODDoavUBMnVK973evY3G2y8aIVnqyU8Pqa89kCm7HAwiDpcB6j4rrmuqlfIa/z45ZRojCUWXP8okjeoi1+nBANm69kkmBN6k1GTtWLotjIwamqH9twVD7ZcY3cp4vx6x38qSog4q4S59SkRI4SWLNc8zUBKDkUID/vFRaBQpio0Lc81JKma0mJy8IlhESs8o985CM+z+FIhxBxNFDzYSo/V1eLx6AywrKMJSFZw2XlwzhKVtBTU6vKvNSmA+HOzXz1ys+3jj76aFWYDVZOYcfihDMjGg9l7DAUkyqJbWgy7ZQOyqWhDKI02KYEzhWXK0pG7U4xS2McNOaG4+jvDW94Az0lt8koJFVNkiFkJmYLbGiBdVdbG7a8ihnMb35bpzwBLZdMfR7eYY6gcqyLB/MKPfnzKCETjROhrS0zy1VwBpgIJLkqtWieVqe2U6Gej+zZ6PROYgChClbqHTOtMEuEL+u4lNUpNqLACja5S/1CWAx6J1BMp8ryPD0xJ0Fh0qyaRcGWpSDYOtppj6U0HqKk0VHjqtPdyocNETqVyKQM4UYk+gY9njQPe9jDljtcKiTfWOw8dtCkIfsAI2ZUawgJidgtZfYh87AMtYl1SSvjspV88cUXt1vq9lHeWJpO+7D3WdQBb4GFQVJ3Yvhk3isq5LGiOW/5QDcOwHtBGzZ03hu4TPOqcIaViXVJGu+yOoYI1uyWfsFinQJrApOjCd/zITh9ScI0JXwyfrrlonKJzBIezSUKkFmMmXA5fISnVuUiTW9QgioLZLm2RmdTlSiK2ZC1glbuQNymqt6H/nrH7LKE1te0ZGfNBn91hENbeXZu7Mq95OT9IR1t37598CCgj9zrUD56IjxH2zvWtYMdrWruMsurvRoTUw+z0M1YwH2PByG28SoxGRr41ajn3PXCWWBhkJQDmPpBA3+AoUIz7y0edNBBfNV3KyARBu7aPUCveTOUE4WNzyAkMj/+8Y/7iSFabOIjb+eddx6A7sNF9SgfqOdsx4dHATEJYFQVx3NZ4IbQBVohQm2JMsu9LXUtqZKTWS0wQkNMu7SGZmnsX5BqggcDDN2xYwesVysYxAZDyScwCUrQ0/G61HBaskmaWJ1qbnSaIKiKAOgeMFAG4ugdqsqrogMN3YJDDjmkR5SDO6jaO54E1vWe6bNJtTfJlg5DEwT17CzbbvaQ8Lq+EbmDPZs3KXNmmy3AAmvDzX5oGu4NnlLMdOfGLvmts2OeYF2sEKCIL3jCcJXVA6kKQHAhEIAgBxYL9DC7FElZ4IMGr3kWFSrHDOx0AUECtf63MGkKSZAQEgDC7FJeCR6J5JKBSKp0SgFiceoIUBqOt80Vcmy7B8IlaojvyBSB2nNMyfQkLcUQmujCpVRf47LC3cqpxJKaABTGpB5VwSgjWwuzvO48aeR49E5tAem97nUv0ElVOw8KvfykFo/mxksfhPK9UWy3RrEms95ZfkWVEfmd6+tf/3qj8BzF4Pat4JkvZwvs2gIrZ9Wuua/G2uEAvNpE57EiIC4q/LESh3rpxlU4P49dT9WcWT4SD+dL+JXk+dbODk+86OPNpCEHG9qbUhbgRVsuFQad2qJ1HYbKJTqnNq0w1MUSju78iSoCJMHQRPlknxMbpx+wzPutd7nLXeyBPvKRjzS6tMVPIGkJDMsqIaGEU+3Oqz35ayBJaGg69fAQKW9b/uK9y4TqlwK6YyglnkD4EbY+xM5i0oasZErspW51vcf56J1KkkvDcac8otxrb5halHg2N5A97mVuuAUtsFcud1XaK0gy+3mvXcVAxGYi0BFCKqcMr8gHcpg183BHLnEh/LGRiVAIqYkFYTBahEusviRVYjQ7lXqBmP53EH6gsyRopyjSShgi6qJ8WoWhBJTVkk+agBSNwOmlfe9F6UvE560jsbBewjiDVS53WQkj0FPDkSP2OOmdfM0pwxp2UTw/4IsYuY50Sqvk9xKuT+cpVNIyvx1Sg1JIFDkICqfhHiu2lw2bJFMh9Bkq2eEVkHoMWBAY9ZRtpmcLbGiBhXkLykh4ppCNT3bYLRe+gRivLorawJBXBW1c8na5V140WZ0Totx7QjwcNqG95CR38i53IJ7/E+h3n9icj/NAhZhtp9pNcwn+dEEBOR6EX5f3uyYwBDiUBB8Y6CwhOC0hw3V7V0kcqmvlxNKWVtwYv5dDL7roIi9aff7zn4fgdmYN03ETxFcriCZHEwoj2IS0BDZkY9mzRAHyiZWTYFEP071g7/PPLo2id8L0yM6GCXrcAl9xzpjePbBhesQRR9CKJnL6Z9sa7plW+6RVJso+2Q1dMhYPNpEpbd1iqwED3CedzkK2iAUWBkmhBt+GaJzTvQE3BTt+fMnb4ZGIiTNbhEIZEdN6npCH8588nyiEwoAMASygFef33Xu40Ofc8XA2789DN69SKuSWOEEJAIWeukNrBUDlSmirVTxykuuID2vrUtdomhgUlPEYcCkpTx9eTQg1bF8ICe0D+EGU1zl9iN6plz0BsSq1PU4EyA2ENIRC0sIIlyMpJ1+ux4ASjU1OpbqmJNui6SwA9wa+ly7vdre7xanKMGlLQ0O2rmcivxeipF7o45UGO6TebG2wCoNRhJKhySDqut6zSVU0RNBNj3Xd0BS6pB6GBpiEakerIX/wEx5/VV2iFbqzGhqXQhvEhHuI2pXuNqllinSgzJqjmHY301vTAguDpLmKmxRGhFMKebV1GYwz3cVxyvkDr9jd20lUfiIvugTHYBFYeD0AMvIrvVjyQ1LletGXjgCKhCgFpkrogyGCcGnqhC55LJl8GGFQHgwDTJWIBJ0yOUyzRwkrxciSwNBvooTJgmKRIGWcR0nC1UJXDXWqa33pYoURlFA7zfVbwqNJVXKF6WxRb9vksMMO06nywI5YzbsLwMVLDiAebrKPS/pQWxPqreh6vcvQSk4HPIxgCLpLJTIzY4q51Du6IVTY5ZCvyhDAHyKa8KnlB2cE5m6c+66kG+3B7KHlJxIIsSqtiNLRLuSsEDtfbjULrBEm7J8myIuWvWMpfmxOI4Ca842//uu/FpzannPJN7DtwSg01Gp4i91S+6RW9PmYvoSBUAZDCqRMucKRlKBHHjG00rY0eEbDSvBTw6Bgpc9uwlMfM/ZREkfnTkU8NqQxOjy+PQr07Vfao9QLIQIrPA5PIBo5g1mtpHclPQzqy6XCatEkGDgkJaQj+J4xmCW0tngsBQTvBctagRuRsgUyxHe5+ZQ+eieTeUfDrKQ7RFV6V+tSX6lBEyVwUzJqzRHQEPzFqWFEbdErUv0qJFNOIP3RFh+Ss8fMQrIe5evJWSF2vtxqFlgkJM2j8g3z25yWm9xCJ5GLw2I3Lx6eoHx372VuST6A0NwlkBJwWVYnGZKSr19JyciXC76yB9rlqE2NLodKo3YwDyLJLqkBB71ddPbZZ9u507X/jNTnnQxQLeyg27Zt2zRhCiUQULKvaqENfLGBFTweMxJsbYxDDTIHVKnKaI5cLrjgAg8SJzAYMCtv4OggTHd+QSD8DLPgl30V/wLPj1bxDObR0S4II8XfbaVw99Rl5fT3tDAc8j0w1JYMB6F3wGdc2FJ12jsJ9YtzvfmQQbQlKn4ldorca/PKb95Ybyp8FwOZq7ayBRYGSbkWH87fzHu+kedzMwtwq+CQlCsql6/nObu42YTXMO8iFiR50zCBGmLQtZQauxCFZ7jxINbkX68WLOJfBsDv9Nl5+Cgg5dLOoPwQi4fTKh5E6CYClcSwGqqCBRIMMgqg4GVJNhEzkimXADGBUoqFUHJvgNFq+/IPmZgXTils7Di1cmnPwdOL2Y1Uodymqu1jilWSzM3k8ZOJ0G/6AE0htr0C/yDPWAyhOwvvjJcyb33rW40O4WFju8O7FuAPqmpOjuaxEUuHXU8GkgdPc4xYv8tQ/tKXvvSkk07K1ANqNzOomWerWWBhkLQbk7Pl2EoQ3mA3xbn09M4pmV5unubJoRLvPf/8833WaArQcCpRqSF3KS+FBdGVk7bicmiiPJ5pqykzwAKClIFNTsYFgBAQmJLp1XfA6nVaPANMayvHIKliBMtzOx46wgYTl+LVz3wGPHlI6NdwBFxyqIpTE5DhnUpg5Of8cpEmGB06Q67eGbDP4NMtj3jEIyCOhAFy+Syp34mR0NBGqw0J2moCtvSIGUFDGwW9q6BHhUXTHV45XsPjI9nK0cbl1Muv3TxCfKjfbgNUbQK00sdmsOmJXpF0PXA2NvrgUWhpTxP/W8XTNDX0O5hXyJkvt7gFFglJlxBieZY3+817q29LUd/7gAK5DU8OCnf3vpI55GvrGMdBhANcHlgVQi86demYSy1iJOWlStD45WRWQibiCqblP4NzdSFm2AfgIALvhQ5gxWrdpbX8xRdfzMPhjripgSdcX1O8yFYwjvNjkyzYdcpQeiQBMrIeAiek0FZfgEk0GowyJskDPrBJLm2hOtyD0UQRTpobwSAgDP/uJippEozSR/gsDhWE0geAinPJdwwVGwW87obfWRAatvqxme8VuPSQYCKGsh8ibKfYsEZt11RMFTmq9CKviTEqN3w/i3je855nvD3D8MxIuqYZ58KFObs3iccprVnubBcQiIycZR9++OFu5KiFpHsw3YEjL+Kx2nptU6grwrJJSnKHv+Qr5+fO7vWOeZosdSU+WcKQ92oroYMD8nXEUV0iqCqXxFYO7iVVcvx9rtQb79ATqioxXrWQxdudehGFeXPTepbCDVlH5Cec2njorJYyY6JXAiMEoYBVwCu4E3djFgayp3KvAXh9VXf6hZV6hFOAMmD1/6m8cenNJ8GsEorp1IcCSIOtbGI4416Mftcj6KxruVaW8166EtuiPUXIZ1I0/XXEDnLyidIprUbvJHhOeMNBE4G8p6AdWwjr8cDOhjDexFqthrZ4CCQZ3XDo79K48HvBi1YIawL6rJYwl8wWYIGFiUlzoSY9dECIFDj8iSeeyAP5gNQd5Qy7uLXYtJXnPEI2TivnqCIgvUCiSy+9FA0ayMGskDdqYg9BldN8CmiOU1XKwLLoyjEr19zl6K5LJaUBecLA+EVkeAAEIABk/ZIds61ASZiGFpBaktsTVOIASqFvmqShsI4cElzipLMSvQxNVMWgFl0VaXp0ngNDn/Oc5xCra4GqxwbD4tEEg0N8wASq7Id6w7Td2ARi0xcYxVYInD4aIuQSzpH0rkQTtXRLTxsO4NhwPBqVe7SoQpAZ27KYr8hJiEKExMhylxb4XmDyH569ePu4xz3OcLq53Uc6DGLoQ/6gRy8ZR5VxMYX77qlj+BgoyRSIWjGXyyFhJramBb4yh/bz8fMHuDAmvUuJzs61V2ueU60uV8IBgjY5L+XGcoHMUUcdtW3bNnjKpf2y3j8WRuPXY77HscVoEFYtISLHqkhwSQhmTiXnhJoEBHjUSnVKMbUlDSWjAOV2Hi1OBVbYwCg2De0tJI0mYE6opXds9klt4enRbqYY+XWve53QlZOTptXAJuYivFEQSDJpNJG7xJbOlAGFO3bs8CUkvSgnqqeIKooxDjnMIhcpe93qHve4Bx2AFOH4Le01DE10Sr40iC71GNEjJwbyleM0ClBFf0IIzLaph1OJZGhJaAhoI5IaGoI0VXKLfXI8lp7//Of7t3egkOZD2pCTtPVyPQ6I3L59O8meW0xUsFwr84Hy+qL5ivGuJ3YuP1AtsDBIGiLkMJzB9PU+kB//5FfcSdrMTdKWkFyOd3E8l8JbaGJzzSVM8Uo2mCCNzMHpUltbk5afIrhb3vKWFp4YclFepy0oDM6WtFlGK4VaJUSuUEkJpkhKxDhK4sGsI+Al7hMEKW9QlpZgFL+VOFCzqEewCYygueV2v3wnBD+v1pDkAaMpk6hyDdUq19yxPmgWnIIPtbU1Lpc6kmoCMR2/eB8rWL/ooos0Zyi/COpf4GGjQPdI3mXDTzF5iGMgasnXF8hjc//MivXaA20nQW1tEYMecnStCzkJ9YgZAd0w+20FyBNZ++0AbT0bdIdTFSLdMrXL9VKqEkgxc8PvDiD+vZffoGA9tcoNhBxqrCdkLt8iFliYfdLuB0eyV9XGHwIW8BnJtEbLuSLCFFe4Zm7LDAM2DDErEWdxGG9H2igU9B177LHCIptlOuJ1OsqBEeDMNiIwJdylRDEuaqcvrRAS15JrK7V3SaCEk+9JCJiLUGgdCpSJkhPOS61trUyd6ihpjw8EYLBotUmqoV9bCbX0gkf8aMX9vve9z46nQanVIzCiMx3Q8oEaKWZo1FYu/vXqqJW7Z5IutE0NY5EwUw+zhO6XVMcccwx+q3td++GAPUTWs0cJ39Gf/vSnDRmzfUw6kEYOTYYQA9S1Epu8GORnnHGG9bh7AcpVad59wUNtI2IByc2VNJFCeQThcpyIujBerdxN+5sEOrxi3kMOOUStsaSJXvDLd5GCXQORGMqcse3AzraMPVrIwWB0JLiJlNyFqLlqK1hgYZDUfOVjAxHMY3CjxGw217tVvGW4Clrh6pxX4MemFo2QnPnyQHGfj1R6t1ycxdP4PAeeOky9wwgAJJQLqWEBvONpXJoDk6kJaeGmKprLS6AKP80ltCQg1ZZ/oskXRqEFPhI50I0oEugjyAKXCv0KHpQbu5+xGgUGL1QKirV1KQSTG6MmqoxuoIYm1FCrRBL5ejuVEG/g650lM6CqRqq5pJACIkf/7UokLlhWa7D0sTKgkqM5iVmYy3MIyluqY/Yf8WwBd9cSSCtoiNYFCcYisLXzC5SJgke6o7AzvfgRjAM3l6B0+X8LauVSwkBhqQFSkuXlJJOjUwaByB5LNijYh7Y4jR2PhJDoM+hKRk4OIeaAu0wrd42SSjzMyLeBoGtGo49+MY+GM7E1LbAwSMpzeAJ4MnHdKrRJbDab3LlQXhGNwSV6dVJFCGmqtOUDfMl5NH9zsCC28iYAuAFhXBeDjiSEhphhpUhHZGqpy804GG+HDuAPOGpCOMcjnAIIYKEkGEW45H4VgiepKsIV+s0rgaJO/5KTu1KSbvgHxEAQ7046VIE7VppAEFjoVw4sLD8hLGbq0ZlwowgpKKN3WikhVncGS4JyG8RyheQwqSpEmhsUIDNqdhZv2iSF73QgnB0wi1Id+oFRyKJTGw7iYtu7DsRYCQOrglqbqjiNDs7qiFg5maDWOxKUJ5OF6SYxphJqay6uVLIEostJSUnbEjndwYZJ+QZCILsZBWlU1bUHABobO2uCU48MYizoNROGBpsFSBOWul8eEuAVNGuuSmLAocCaoubCA94CC4Ok7oTJataa+gjTOhhqriupfExoxHqJh/A3tcORwKKPGJEAVmAH4RxVjzj1iA2zJkqqEn9xS8giOA1JRUD0QYMh/FxLWynQRChH40GEnl3qiBz8PN86FIzacxRX4kyHYI5uSgTL3lUCDdiAlL1FS3sKa0tD+AUurUDpSQKFlac8ITQHQ9goA9EgsnjtuOOOc5k1dIcNgwS/XMoNH4PDLmgIIi3qlZBPFP2Fk+xgse8u6EgXmpCmVoBPN2+YSgBIObXtL9sE8PIDwnCgMIyDm6owEAUwtSUNYVySB0OXVaUVHgRNJN0xDpWklDcuBLH0UUh/0To12AQn42urnALkLDVbK1WLnw3xE4igiaeXB4DtCIPyPNOU/PpdS8xctlUssDAnTpzcPRk+w3+k1XcJW5xr1sZv6o+GMXMbYHq/+92Ps6lyWc5zMIxOYQdv5/ZCkm3btrnkXXYJhWN9Vg5CQQTlcomQ0TY5crXKEdTQET2Bhe1FbUGhoA8GYdCRWgpIEakNEWws6JcCr371q+1LADjMiXUwokdoiwGtHKELhRKxknU6OFPutfOsRHLEUBJbGioHTAJYhB4VqvLYACKgXCxvMwTeJZxlAhfMiVoGw6/3AHAp6Yg0vYNmP8SkszBWK+9+qspi2HTBwg2KQNKWzXnF10PqC5tyrab21JCt3A66oTHIHTcBbkazs0ysJgo3TMweJzUw60UJQr9embC5LKL3k5AVd3lDsTPDgWqBhYlJN/nYx7aEGTtRY83bZvbzB+FbsYbFpvjF6s/5CU8riCvY4T95Y3IUIkYgY9MQ6vlQkyArT9OvkJNwl/xQTDRyvbgkXJWwSE4BnGRCQ7hmV+HHf/zHydSFcpyq5BI9lehXDnr8Lp5X+9id7QUrTa8TkKxrtYZPJcNx0kIra21CVGFovEDQiwqQUTRqaFl1mAtBMfahtqpiNwGd36rSTaeZLn0uueQSg/VR50ykC7WJorNRkAA3EXRAk3n55Zfr2qsCO3bs8NAi0FMEzmJDYwNbboHwUxfGC4jlxE6T7lzqqKHVVzqgEYyJoA9U1bvcoDzw7EKQpqMM1egwrJd0IVVbX2gltLWbwYwIt0OJoUl4dCTHpoqS60meyw88CywMku4r05vxpn4IIifW1Od+AEgsUzknjOCQw5dWKMBn8NgsE0jyfCEPXwWRQ4iOgBe21vIAwqVtUCXkK0QLx5xg2OL0G3Z7ozYH9MLzMfDzepdLysvVggNAabdUtCX4gpieAdAhlzYcfUEoMCdu4uqqeDWBVAJ/DpqOPPJIPDilxoVnuZ8rkEgXtFWrO//gXiBsCU9meKFQLTS8+c1vTnmSmYIEtXLKN3a7FnZLCQErAmFybBGg7T/AevpDVYtlogAo5cnRr5y28E5CsG2XypfUXb5Z7pce5bqjv7aIUk+pdJArlLM5nf2wwrYMfm0b9R7kHkWEEGtoHmO08kggn+YKqUSm4VMegTliDzqamyyWBbYikvJGNwlw8DFOKHHXMeN5hRLOJiHWu52E5K5QwI9KAxRH1d7bt93Jn7XN+UNAgZKUVzuvhzIuCYGhcA0U6o63S7wxt0xJckiY5g6RHXnDNWCEX3CkxPbC4EFYFEugij7AFFrBI0Bme9RJPW0Jx6bTBpiSSlxSHrOcerYynWJZxjqLU8s41FNuXW8/5F73uhdASYJaSS2ZpLEnsGYQnXojAvSL+g899FC4b3PZnoB9RkI8itgBM1tJBo4uRwwMJTYGhF4oUKf6CkAR8It5qY2gQGgem3IPLe/n2kbAXyt5tbuVa54mDO5ZyJ5kZgQRt4lEmpuCB2eXuyV/Zl5QC6yx1bigI9mk2vxwcOaElcAIvqeK93LXwbMewTMhhVpBFjB1FAOwbFDCNZEIsBCiqsIQIuiLg7lsAQt8fZdEoGdtWxeY9Ws96xKznGJpOEpcUo+qUAlCeU2SBGGpE3CREeis71XA/AAAQABJREFUFzzaAimg6VDI552szemGFvkKorFhkOp69FVHNEQQAgdFteCPcMaRhmUMk+YC+R48iRq5tgJPu5OiNojT5i9zaWU7GEFt+uvIBoUh40+TJZ2W4VhHUgNJPeWDZ00ihtG8yzFSyhtODfcmp7M75Z6SbFwCfJstdpyNokL94lHLMkr2pq+57QJZYGPIWKDBbEbVHCxOvoow6cMIVaVR6DKe1ZI5eV7KhXIbJQ5/JNLAqHiwE2ptCeFX2AQvMNeimLMlU7laHYWhFeJUmPwVOQZNYKhoETA5Vtq2bZudVpC3ffv2RJGWHNiqVvD4kpe8xEH/Yx7zGBAGUKhBSTyDc9B17ZIoWwEuvbSf2DRRpTuH10BZuUvlHhKNyFPEgRIGcTf89S6EviRsVvdgVHQMmu2BaKI5NYRv8gGaOEtDN0R0udrlgqXHTEQl5amaBAwIwiPKq9rjnBAjdQt0jfb70TPPPNNGh4eW8p6dbmW1us5Ee9zd3HBRLLAVkTSPMtfHTcohpyWqpj45OAch3OBOUm6DGS23VgUKNhalmHWnqvAkHuVwhJvpMQCKs0LNpZRcnePUIwaLSphl789uqR/OCktFiOLNRBFOGk5galV72mmnwTWIplCeWJwIOnTZ8A0hxQCuV0HtPBRq4VEFKAmE4De+8Y0boBFRxig8OcShYjS0vhxwU0wTvRAlItYWgGIWyslb11MGthKuJM3TqjzFolOvXMkKtZWUNCmNy3ZUFNJnJ9cVjxCFQ+Co2pDQqrvJUAZ7z3veszM0YMrgDEKCXFX0hgL3hoEyazbfg3GtKWcu3KQFthySsstwwmGjHN6leSlhkEbtmkQIwv+5k8S1wgK+tEIOUWrtBoSAScOcN+ZseOhQyehOYcpMc33VkWj0bW97G4Tyco9IE4qhQRVsCs0bFGgTDD7lKU+BI34176Af+GLg5zqqixTuUq4LWll9g0tbEI1UTqAkrrSfINQ1HEG33CtNMF04pnfBstdI6WC8mLWSBMVOnATj0JYaOgXoOoKw0N+mZ2rod8n6ywk9LhFEybGVsLgcqnY5zWuLWUPyVaGpF6HhHidyWK+7TLjHg3GxAwvY7nAv3J02anTRndrjvjbZkEqNa5pvsu3Mtq8ssBWRlO1MPnneiO6y8qmzQYH1nGGUcydJWw2l6ARWokpqU1UJmfKaDwKDcq1qDmgwqFW+IsdAbblI07mTdTQY1VZA9PKXv1ygB+MgMlGEgDOnPQJVew4KlUA9+CWGXdJpZ9JFvVSga9Bgi9O5UICrPIUhCLwmCgICFL+qItAlEAEocnRCjFdHIBUPJIXgJEDS448/nsxGqlNIZCNVWFrDZUW+MmojlQgsN+oMmxEqX2ZZyhhBTkIlCMzxpxJlVDWQSuKJ3mTOhoygL/ykidARbG6wNlhUeZDotOFgHgbZpPw9YDMKrVbk04Hvgcy5ye5aYMud3U8NZLZJK85wlQyecUY8SnZBkDNt2+VSB8uphgqhgJ1BZSv4C81iw6N2zcR71fJkiMBLea+De8l7RV57cs7uVUdHxuQ7Aff2uyN+m5WYoaqXVaGYNbu3C8SbYYpeMMMyMjWpUw1t5gp7lSinm/J0u/DCC70bawiWtN6lhdGHHXYYsIZTGPQSdtBTX34k6qujXuSEL695zWu8ouCszPG6IVASsDpxsvr2+pdcX1SCCGpBkk4Lrh3E612Oh56t1l1SDK0jhcYOtpQ4QCfHqxHdO68KKFHldQXxMt0oj4GqWbJB6XQMEE0sm1S1Ileu626QHF3y/TCD9QQSdEtaiUxZIGn6wraezBVd7PqSwJ19Lv01NEbzFkGTim27gw2BARuXnA7sQ2f3SEOEklRq+EQpNARzZqoDIYTjGaYjYTpdY8bQnZ223Tr0lkbSBb3NnMTMpjxP8OMoE50bcxLYBzh8QMRL+zzEKROEAqP4zXLwoVCJMEoAhRO/VmCIVxDIIR0TATgQySXgju1OvWDgYCTAX6f/b3zjG4nyTiVs8pFpPBhABlH8kxMiODY5XsByZuXAypqXTNsCj3rUo+iQtMJbi2Kf6QN8ngTUkDAYF6/WNSEgYAkwlt+opUM0QqdBA1UlSBqYEm5Dw1iMCIYqhNd6cbzu5QrlwWgARIJeEp5kOQUk5WumqT7Y4k8CANURa3uYUYkpyG9E5QQ2hNBtTfkbFqbAYDMivXhCGKl3k1/4whe+4AUvsJFtgNQofGYKl7TFTAHMrEQCrFdFYW0bMqv2UrNa95HaZpeb6xKMkqZ3eztF92miOQXQJCR26LaliBlJF+x2m7KcoXnPMTiDONSLpUGY9bXfI5noYlXBheW590A5gynOZ4QSvMJqmhDvaV166aWizhAHZoFRWMDl/AhVCCl+DHQ0h6F2Eizk/UrSsv0XfuEXgLWoNoAoCOWNhLCmQBXO9m4WZ/bbLT9b8K9Ajz32WF5Kc/rzPSoh7Mbq1KVyXVPMQIjl0kTRDQ9fRcvRASha0gpgKdFQ7xLnj6a5ZwxA99gIT4kSktMQP1rv6aDHaQpPlaw3LehA1QAUjS0YVQhoXHpJlg7T/d8hDb9Ud+vJ37CchCmP3hmBNX5lOXmmenQZo+9/2zq3zd2PEQxWQ6NmJcMnwctbNl5MFTfURKI/s2NQZctFzoYmjEG5VGvm0Nyt9FD0LjBLYlaSNfZyUNMRLSg9I+mC3Tj+YMantKks2YXkJwIuK2XLfND5cz/3c2DOl1DMeG4AmzgPnlzIpOddjl+cAlnpAzI0gTyHB77zne8EBP03TW0/9rGP+baLbznrNP/xSWlbtKTxXr1zNg01KXKB7ATKX/va1wpaITU/B+vc1T9q5fbkcGauiyaQzl5u9wAgxNDIxJBjY9CLXLlcVYmSyuU6JZw0BLiXoz0POL8c+gNuQwCv/jkrQNdRvwUoKAMBq1epjFNfatecGRiUjxxRUkhPAOpBYpnPwuygis6q5HTu3q0nec3uVheSScNRTibT+RcP3hp+1rOe9TM/8zN+IgxM3dOzzz6beRnT1rZHGuyzM2PIwn/b6zitGEwbqwprAqYzkSQPYC87Q0z/KMxccuO8byfMx+bnFVp5mppmnrXuflMxMKWVRL2h25YiZiRdsNsNQUxfbmn6ynkF3xB9CCG5LjThFW9+85tFqX6AxCu4GeDgb0AHbaKDOd7Fr/DwMc7DYXJ7KCCk9b6nS0J6N4DPiG05p/UdJPJ11KCZI1GATP4TRsOv1oY2FkCJ/QEhj8U1LAbNdUoTFtfWQLQSIPNnEjRUSL3wMdBxiZAgkVwTCTLKQWdJ4CkBAuOSK8TJCLom1scAQcDjH/94WxnAxbaGQEwXupYMxBCwUSnI06Pksnzzk0O/TIG/XtqwdnfcJqJSfkBPt2/zwqecRE0vKa9rSOrx5r+t6Mulcbn08VlLAbQ3Xg3Zg+2cc86x9geONHnlK19p5niRw7vPz3zmM1/2spfhgZ4+vA0oGfOEE06wcPFdBXJ++qd/WkcCfFPCwxXUOufUFxsaIJUa5u4abTqQRadnJF2wO2hCh6FmLec3lQGl0BJyCfHs09nK9IsmMQWQAiIQs4mOkwMbLYdHhCbwV9gCTwEZadbvmmNwcA+VfBxr+/btPFAtfm5JiLdBi0SIyn/gmhIAJxjkgd61Ip8Och4LkTmz3QC1NJEI0bYm1KYh3KEGaTh7TmCImVbkEyW1eC93qZxWkhLPCUmhy6pcMoKx2Cm25lVOuB1bKtnWAKlgTi+0ahS601dDY+TdBQWDIkGnYnODsg3txwti7UJ1XSQToVMa1hF6dxPFiBqtyLGR4p+sWMi7WewP7wzWMN1NmycCVZrARJvUlHnFK17hHWEvbwhL3Vmvx7GAFzzsgQBiuOmbgabT05/+dAxuiuNEQa5g1lRhSesYZjz99NPlkl6M2nBoJQ2ttiCxRd+CWtw7be5SvhksykMLvhyIC0sVwkQeZU0tMIFo/AHKSLwFZw7W2jY5Srjfjh077Jp5gwrqkQZ/vbQkiBO8DEPxK+gDRpUQKOdCcIEcOVoJjxJgWgked9xxdOO3LqHkKaec4lItZnkSKkHzarGzaKj9ODBEQ2yGUBOcUgrjD4xc5sN4pOVRLr0FhVAFZMXCWvmPeAaoFZkGiwCmAM6ZjNdsrW2N1JCpmm4NCtseJCEeFCOhd9FY1U0hvxiQMtRLbEPYgy40ydTTtoYmibWJtZhgAZfYBI9upTHSx3JBE4TbisCjxJBNDO9dbNu2DTOzUNWK5NRTT3UTiYLLRBkUyfad8XumOjk0UszpoEqK3hvrJWFx87U3gxZ3PFtBcw5p7uZRXALtVSRxh7Wb3x1Zhpv9Vta8AljkLdgkbqMqf9ZccinK4DOW7VZzvP3nf/7nQQ+40ZzPZE8exdPU6ogcDdHaLvnQzsWdEstA/vzQhz40f9ZR/yxPv2ppMu6OKnLgV+jmHQAPA5cg1cIchiqX8MhdlqIpI4HdaeLbJbrZIaW5tvZGg36FaulAAaJAg9dvITg5YnD7G2rxGMvQcHcJ3RErJ8TobJjq2t4CTfSSNF1k/L3paHVb+wk2gj05LMwboI6EmYbmnqrtKct6NGFhd5wa7q87SGHMUJUFXApvzQSzyL1gqNBWk+yP0NB9dH8ZX6FLiUppRdTu2u2A4d/Sq3uToHtvYYJoeaLQ3a3ECrel6Hr3e2keTZY26KaUCWqp2Ep8tNVFK1A89WVyo7FJlUyZpyXa4iGTZIigYbtygi8OwA0svW13Oh83vzFYMlu92vTkSHwGs7EQTkIjsulpKwD2OU/QxH6ZYJAEQQci0IGAuqOG/VMntl4LJdNyUqIPzdXyK4Mi07GSE4k++E9VWsFxoEYlEjihxaBW4Sl+QujTKHQnMuKcngdkUl6VMbInYsnEk6jTECrEoOvW/nLCyTQWoE/s0UcfDSspqa3yRk2xFEDY/QDf7OCAyD6AsUvKG44uCNQXCegup3ekwpHjVNvd1J2kBJ7+2q/9mp0NwEQsrSgT22i4uwStpk1IYwddwHF7ndCTGc866yyLDItxB0Rsa6ViQ8PrcTZtjNTdtGb33wrsX0NVuGkvAr+bZTJYl9h19Y+4LfNJ82jUys0l1pmhLWkHd6DZEZZ51Q6JW2bgezmu6aAWkd6iSGo6duObAe5c/ilvplae+615X3ksCdySzyBMJm3xcxVtl13pih9BciFz3YSOX5P66pLr6rFcW1VoEuQYRtcu0XJyzGkYh1mnAMuJgaUxAr/VHOhUngKYoZvzAdrytArx8w0vzNsF4+pOk0SagkfbrGjvJGKjEh302Fhas3M/IKsXiSbxyAEEUIabPudhLZlWdgOs6w8++GCAxSxglA70GSNaQaiyE2ftyeE1pIOGJBuskTZ8fRFOjthKzqvZlj0lPDjFUDwfrPgHqJ4NDSSTognJsCMn0KgdsFi62hwkxDsPOqWbW2aYODXXqaouV6g9Lslfssvy5rVWyqGnR4JxeZ75SII4jnpu0zDdaLtbhC6yRq3QzEtn/5DGk4OqLG/p7WuNPlhDK09Zh4RutK6tVHwPQWJqt9Jiv/+7BT01tK7HbOfU45BwL405k2Rh951kApm0SNYOEglGxPL0wawjOSs19nTbUvn/uStbZOT8x0int9wMMCfG8DFI05JRtYIw/2JLApka4pErqdAMVmKOcq0hExCoVW5qDplLve6EMIVTDZUrkU8lEMg5xZWqrCVtzBFrj5JWqhRarDmiBWcW7No6grCSDYZsAvAuXbT6c2RhJcgDBSk+hqI5f6MbgXgsG2G0EjSIMSLSGjt9wKhtR9Lo4JJ8QK9fA6QMCS41RKQVxdZMJGtiRM5JvIxlXYzfqQhmIaccZJBPFDpQpgaxgiytKhQ4ezAAdJeq8A9OJasTaQaiHAR7YAQ3xtKzinwMhGBoyN3N1XLiVJ60OnXJGo7OPcb8NICojJMNVwvZTImOpmyZl0D9ul9qpXEX2FOVsaj1pAGdahUOmyi3LeAwikznSHZ1EQolrdDdNU1o7nZkfPLJiZ4qgy1bTQu3CL3lYtJmgAcpwvO8JO7wUFXSA7ac9yKiV88GE1Qh345H84IXz3Al+bz5amKZXiQLT8w8rVwiVIkjJJfk1ItcVQIpVmFdu0TI+QNR5MjNcsdKuvbCEy/StXjEMhldL3hEeaJFWGPhJtyjD2D1TpLVmaUZb3GOZE9NiCHiIFygAbwsxuGj1a7TGLhGrKjEwl+PdDA6gzUE2lotiogFOGTqVK0uOKf1oBWiiA8zNp4Jg9KqEa3IVWnIIHrx3hUopJsdiX6C6TmEIQsLpelsKSqQ1JGzEVrBPi+6emFA2GUI3Updd1tZBk03mqzI3WUDwWakBx10EEOJiEW7sE+5RE9q6JoEGq5Qe1ySQ4jLcdcQ1DAizyo2hEQGRSBTKBwNd5cg1hBGq0RRjHp0MMCGrFyPypkdoYkRpZ4NDYXUUIvfj9bcX6q6FJYqZ2priJ5kGKrShGSXkudWD0VVJDdSRBYYum0p4v/cla0w8jzWSE2CaDPDJVoJIueJoSr06gR0mprNvBXRlqlWAgHmMeDDYC5yV3EfVydZQz0qJFzvkqlc72ky7b0SOR4NseEHkSAPfIg1CDH1RYK+JAJTtMWsRJwlvsP8uMc9ThUFijJopWvlwkn7aM58OLwqDZUjvDmouWAWJurRdmeOh0EruQTFvKcNxXxZroAFpwSaCXH0RKt6UYhBPsy7wqRMhFPhNHgHlGJkyQ9P0UEDOYTQENR6HhiUnT7Ku0xDoupXrkd2WK9TDEZBLIbBoyObwm6fZ0O/QcDQvaabp5RWm0wMRSU5C1900UWC5W3btpFG1U1KWM3WTBjlVBrz0BDUGnKW1G9sdEB0c40XjXPcxKEPu0mZd8iPIBO/RBThhOjIJSLh0Qlf0XaLXG45JB3ObCpIzYPpzVbocpNzwgQi0OTTBM3nLRIBkC18tFmu3KzVC7Zo895mnLDLZhNHVVjS75iOCE2mOqRVCpvuqni7oxVn0HCEBFUKd+zYoV/uqmuBhkMDASYG5wmO40EDNgl/Ayfh7LPP9hahUA52gHhVIj6Ai+D8hiMqfNKTnqS5kmnSEbE4dachh2QHOoi/bMJaMBqjvnTEh1UNy0+FDNqQG1fGjA4aVGkrJ23QrWQJx49tyMFDBzkJ9R6sYBhVMZQPJEKEkgaCWUjuXIVwRmtRPDhHX6sJXUjZtlqXdKah0xtPNaG9+75rU6wWu6KEzFFiFJlXCc11JDXZlNBk6FOnLjUxlqoQ7h2akPGQyMjGbiaoHeYiUHOGVYVHuZQmKy4r3FL5uquVA9UK494bYDPeJDCfTJHgA8OY6E27NU1hPik3a80qhOiM48EdL5GQoNy85IE9wK169GWRqJUkwnIQ5CBCj748bwEuUNWqyU3aVMnVvZMAJQEZ+IOSuY0eG8L555/v5RsnCYDs4Q9/OOE05CdCSxDPMXAmk5yW8Nb1SgRKmYJWCG4pIBWgib7p4xKDvijpUrnBamVvVLmu5XhY0m6skworWfINX1V2RqweyyjBQ4JLXeAc1ohYbRkajoFopS+cSipHd1+Sb/jhaTpMcw+2huZ+EaJ5arCtWNuRtzDfhoknFk61jWWoPSWInUqmQ7XpaWPatrXHjCB6hfJTIRvSdTFl+9Vf/VXTSXeG6XMw1ijNZPfCoJQj0kG/mhvCsE+DbYEV26h1I5KjSXOsybwaRpNJJcQY9VTDrUBvuX3S7rRbbla1rcORrJGhm50mm3RVYbP7Y3dsvZlhwkl4hHLeC3FiYzbbqDI1bS/aN7QLOVy9jS2SlcAyp9J2ME0v/HzVLp4Zj79O5VLbT2MKJkGuylLRpqfQxvmAUVCbniJH5+9iTLuHYl7nG17xcSqtFg+VuLEdQE10Ryw5DvHFsM7rsfElW2MKKcaj5NwGYe0PlBmH5oVmBEIca387ldbvOPXOFGyoFyBu5xSC52/K22HkinbuaKKLMagpgaFtviWz7ny9oRvEyJKGUhZwqYo9NVmuvKK2cr1IaMwxUL7LISE5cuUK9S43NJxowo3RTfRIoIwReUBmganOU5oyJJTqy8AVEpVAhe47mzMRVJ223S064aOJIZhR7qx1gBvkxVLPMLeY2mN32K10SRkDpI+fM5nntPJopzBRbqLxyjEoySw6krBp6N6RYD5ojoF5XWqoqruG06UhJ3Cot3WIxUNSt9YNc0dX3yT3tTu6umpaYtI0pRRqIreT6HcdDhzECyRgMHU84eVqYaVJhoC53AmBgRqEgCeY4r08c8vpNjDCIJlPktmGhxBTmVi5qjREYCYWIcAUG+K36+eSZKNzroJfXySr0opjqHX47p0VO26CJrXCTK80CW9FxPQXOolK7C148wmmUyA9idKXaJE0VQRqe+6554qztm3bhg3DGB2F0RggCOHW6ZzTGP0nKG2NyDYo44hGe8OJ4/ExuANMvdbqJSQApHnOVl/dr2hVqxMG/BlHrcs1mQcDHjS2SuQRyjWsXMlgiH/NHP+KrrEpMShDa8XgEWWrBAaJ9OvIHGAE1nDJqgCl8WprUpEpISQ87IlgbVPXktnTjiXdUDy6GM+Dbj0Ju0jkTGt17S54bnmFw9sXtsgJ1CMe52YmjKegjSC33uxSZWkCys3bzhu9pyECMCjKm0K+IWtQbjdNrDlAreZufTeawiatqmGuFRY2nKluW4peGCQ1Y9yY7hz3QCvppnbDmmHmitRc38WN7JZrgjAtvBBufpNmV9FcIUFhDoABUY9oSSslktnpzMeBuHmslSo91tAMhkdoaRBdyqmXhsvylv6jsjkqrOBgVusQEHaL74I2PLk0mbAMcHtB2huCfNtCXnyqLZT0Gjb84h4U89J1v1TRteb6ItCZjFFARh4lJOlE3qG/ADZEIJ9JBafhO/fWl1ZiWyiJINYmhpytFLZKxaYhINbWA0lHnJk1dmH8hahik/EoYlWDdZvME6jkdov+2Jl5IWPPXbfVxAA9rM3OaET3t/EqdMmM+L27SqYtHc0ZkBwNzTqW3NA4xOIcbPpFuyl2IYS63iolkDSTR6zaS756MVc9gK0VQOfP/uzPmmnerDDHfvEXfxGP3VvlPt9laD7Hl1ZeR7WHblECYantkyUmhr4c/UcMHWaCBRZmn7QZE542QZVUaBgm7vR2rricVmnbJVdBm7tJ8xqQJbYH+3HHHTf41YJX00uJrnFyg6a72NABAhjVCnDo0fwLg1JMXl9DycSSM9LQ06TXEQfTl2ktvMWsOU7NdeFSHEE9W1c4TXfRKFfs2IrPE5V6aEt4v3LJlzQExCSQ49QI8tpPAHZy510AApsm2Ig1NHhhjJCRfMDhFXdVkr60es5zniNUecYzniEoZkDaYlard+qBab4KZRK13G5Rs+6ycUkM65K5mFGc7uzIMkJI7q51l5nCOFlDQnTXIrRlDfYkpxthVxpBCGmCQbXjFmzGWORM2TR3C7oL6UylCE81/T72sY89/PDDYaLP7lHer57EmJ6FJoOcNF9FsOfu8yXeF/bIhJsKzR+LFSGqTQNC3NOGo7tm41SHmWaBhYlJu1vmpeSx3OwxZYUGqpRsMmEmQe7RDfi0IoRjCBkc/nhucw9HDSaT9TWIVI6nmZoOZqoZ6WV1D2czD/TgAaMmHEeSEyuXxBrT3CVtNZcaBckIfqiJVy/1AkwFFCK+BKqlCTYnPCJQkSaBmivhHsIKmItHEpni1EoX0FbISY71vsuCVj5APSMyWAmzI3uX3El8ZGj4eSDJqjSxFcvhdbGs79IT10KPc3IqyEuUVgauNme2rtfWrmu2VZ65FjRnUuNiCncN0UpZLO82+cGS7U4/BjNGs4UR2M10aioar7byzJicDGtzwCWB7ospZLvAOhowmQBuK34G3NBceFbEpAS6id4s9jaogIAmROnLpCLc7jmgdL/0ImilvOjSO6R6NwoTxicHXXpAqjVSmzneOPaEtuo3ATw+LdQMrccDggIWLhTeUNUtxXBFgLb/j9nkSEmE5Ebmz12uzjc/IviluUnDK8xFS1oxgsKevcMres7LTSMHNXh0odYM0xwzSDVfS3STFE7TKNzJtfTXQGxCQTEHOCTgN8UttZKvi4BedGBm21yzPWpyezWHE+qXMnTIFelGYKDPK8ClQTUQRNCmleeEHVLRaIEGLFZLFPUw65ccuaDbmTXh+YzloTBWtCuo4W9eI7XSH0YWwFKbVql9ALgZsxu7hGAQ9wXNPmhLXeGb0NKipFd62YHl2dDw5ZkFoZDZWaNCDTVnPaIc1iHsFWB2393Bbtww6XrEkD8YyHEH9UXVunPp/3K7RyJNqxC//jSx4alReBaaAJYaNLe97oRKQ3tKVLLs8B1Ss8uUUNjDo2mj01L3l8Kj95nIAgsTk3oO98T2FEVIpovtIYGh4FHuHiPKVaF3nfAQ5WEOwixjPcM9e33I0hJVYR+yNbnNJLlHsakmmfHCRu9RmnYsSIInv2nHQ4QG0Qgl0rjkSwrxSASSU6grN1/NS0hKMkIrvYtAfRvUoGyevupVr3LCIxp69KMf3buNpDW/2UQXWYMyghECWQCD43hBJWnCnxhqgsHyzaaEsFd4UhU5BoJBCpTBoq7vf//7e7rggapCG5uz8FcYqyHduCjLeAwYGqDnftu3b+fMIzRbaB8DHKxhCJmosTCOSwNkRtvNfplu51r4z/LuqXvk/mLA1oQhRHRfYXMJW6sHt4bprPFZ3j1qIuHB4HasTsSmA0LtsK2Z47Vf/zDGtDSlPfCs4q3l3WX7D6aHp76Pk3rswX1tITjdbKlb41tVPPGJT6SeDVM7pz62Al7NbQP3aPS5bi+EuNcSCDbkdEA0lqHDTLDAwizBAITbuaTx8vz2aPU8txgXWJl8kiq5udt9HUSXIx8ewudFYWI6M8nj2gcaEBI48F1boZ81ssvBnwQYZ0ZGqwUitEIooRj3kFzCMrmSZdWWsvTRqaTKXJSjEWIKgAVG0QQiHIL712Z2slTxUhDmN0hhN5kKE5hMuU7HADUnlgICDY4qrlRFvkIED+FUQhKEBR1kJBCzKp0ypubke5cATABH5WJbYEGa1C3QnR81KeSuRoHHjyyhPEIVfSRiXS5uoj+LdfuMAjgqafjhiCrmAkweM6aiiWHv2F6qsY9RkyB1ieimd7MItD7QRHP2R2BjeTQJ3d9pPmRO5SskjRqeiw4PdQFMFQoILM8t0klw6x1OQlVnkm49WokTfAGyOa87TdCiVzGsWlPCDimtnv3sZ1MYQ7dyaSTL84r8bvpQaSZY4P883/Z/i5hq7m4TGkzYDj/xxBNNF4ny5Sum2upBmRk4m7WQtDMchWGQKe6pbtL4slEdkeBSuUtPbEGiN2NMJg98uYZmsyq4TKxcofnXFFRSolWJKEOQKIBWyAl14VLsIK4hUCyglY9xqNUv2AKjmiQKA34OkHqGoFOFODHoF0El/A4TfCBdfO1SX3i8xe2Z5FTNBgIwtZojKv6UoTzodIzL8TgVeGVnzy1NNCc/tQlEcDxLfvuntpg9ezCkFbVxkry4yRBSvrEYDqLERKqY13glhUzhMJA9QZKbZSKplRBxal4rzEMUQhIGatj3YtxHDGsaDecon/IUYWR291EVId1QtLkBNxGaNwGsb0xgkOps8OlPfzr96WnOJNxAEFStC3kMSlIAM4bBP1SaiYVZ3btVJg3wErWZN3IIiLDA90A2XVSZQ3LJDLZyWTNZnEIBPGCoANAsWW609HIyWqHZA8sQ8MuKxnyyIiMcrNhhBHY4XZpbFkrYakUI4WjzTBfJIUpJ68FWfAZCpnJrNJJbkstdaqIjC2e6WV9DWHhHlBWcsyb7D447NDHd6xdhVahTMknQL7G8CKELuwSqHIz4KhpOJdbjokhBt50y1rMStLNBJjaWpL+FG3+zU4zZ9gKDO4sgUPCilmI01CP5LIC2PqWnAMfGiBf4tW1oeBhHQ3rSTXmjltPfSLGh10wxDJ7V/KOEWOPS0S6k6QJ/+qzZ3XqFZJaGfJfRdJNa7SJIQBs+s3iTVzSH09o/K7kjFNBQQkj40XL6a+ipbIug9UHm1VzVcoullf7gR5RSrJyF8Zhjcn11iTAfMLtrSWABXcu18sax7VExrDmsEGf2wTntVPO6IA1R12gpes6nFlgkJHXXu4tuvBlj9phwJq5y0zEsMBWaENNBTukmlpJBVEsmgTm/TUbS2iQCx6rMNrW2U51Qm/1gSEfmPTU4jPkqB3nykhK1EoU1xKYVWqtmZ3rqekxlhOFICLXQDXKRCc5AITDlbyJiYaBjX1EMLCOTMxBos1UXWhHoUjlCla5BJ/0tJPHbtXBmJUSlpFpKXnLJJVaCPVSMXS86hbCg1kJVnCWo8etDaqSwIRCennoU2njf0HYqNjfChhqxFNYvNTAYC5nZlkq6yAjoacKmX5L1kn3cHSlajhnPtMRwFLJwtVRS4jlEPjY94pfwkClNu9sbmvA1mysXkIribXTYajdVmMKTBtazBk3oQFUEgyihqktDZiXPZk9KSUwQm3L3FI0wFj02zNVdr6dPdh615JTMbfGBjVETm0wMlMloq4Xvot81mbdy4SIhaZPM3TK33HuECeGfVfDhXkpvppoxIxpafWu1NXtGqklTinzzWy6RbN1q3oMeAjmqXPwFemAcDyFByTJaLmVQiedEmJqgSs5JJKpKZOKXNESnGPkl8pWjEarQ3lABcNbUAN27Vk5U/XYI6pGMDZjaprSbaSUOVbVSbhR1NEZNB1GnNz29HOMASkxqv8yr+PjpQCw5EtzUFlzS39v1TOq3Us4xSLYGNIQ6RegaJ8zCLPczWZGyX6baqiPf7oRnjPUBM0IQ/JilCJ0i6KZkaIggkzK6RmuYbkpic6mcQeQKMaMlohhToY485wzcYKWl/paDx8GMwLavkq7XFKUXSxbTwD0SoXuAtUUDuRgqAzoCZTdKek7TH0GUWjdCuWkMPb1h2qNIrWmMAadJu94o1tOHEbRVy4DTlFmYDgO7qcKmcNdy8Mxp1xZYJCRtcuTMZoBLk4wPW8CaqcJShVxRoSkiX2/kGo6EB11uMvFn8skpFAU9UEbIYOaZ8WDL8s3WgSZcVyF+M17vpf/P3r3sSHZUCx/XEd+D2MA7ICEPyuUpI4YgwBhs7hiBjcHiIm4WFwuBuIMNGJAQggdAqGm1jMU7nAHywLzDmZzB98v8Vy/2ycwqZ3VVV3faFYPotSNWrFusWLEi9s5qj/hqCeCgSpiGgNXoKzjiAsDUOhEOPCo5t3YEvQfzX2hYY8I3IpIdOYuEwlr1U5beb1hsrilJ5VWsz6S8lLeeZT0oJAaDiKSWqLDrGyZJE1J6W960M4pUAO3WsEjKktY8mt3PEpu0hgCIamAaMQ7LOydiJHrazGTNIogNQPhIXxoZpRhOEpjaUVsWFsgIupiUAcMxFi+PhmupMSB87egYsmJwmwXZhvi0syq0ab8IgPXO4XJqRsBFlOQ8vpHiJ3Ya78S5qNmkjr1WbcogwMw4bTn2ZpqaaM7mZkBjehV8M/5OvqfJw9qNYpBlMYMeWYYlY4FCkuykn9l3dl03Li1wMJGUW5hUNel5QNGH8wk0woQDqdXLd3MO7Usll3BLcWfN+TgZFiIRCrID0URu6JzrERcfBolT0i6Ysg/IIqZFIkB4LKrCVLTkr9UclwzJj76S+9JCQW0ZSS37EBz3vIH1JaDViAvVvPmx0jACo0YS6Y8fjyoAK5mQTtwivgRHsumMySbuW/0xZrHSKyx0cCQVIYmEFNbSTxFWBHRbR0FHdQII1miKrVQrEuFIEcMb5exviGgrdtBXo5AhRcUXmswXfcSJhKmxVCb2ci6CiwX1ZqKiwNqQJ1E1OkgpIhEEhVQr863/CIOBCr0EX8LXXqMa8aZgm/t5WyK1XVMfKXKSodlxrLHzmQKHfWYUH2lEDLZisWzYRJDZWJcDwrHNyZ7Eq8210w9AryGnybktSS0YIU73BmYTtXaNQieymS5pte8kNRROE+C6PQscTCQ1zcslAeYWfEXtYx2xgM9Z+RyCC1r8dzDBUeNeSBU7hFQ5mnAmieB5PtmT34lllgT/U1sPikihLpi2NiaSkhMmqciT/ARWqMOb8cJIQVxdgLAa9VpsCHqP4XqBRoIp7ZygieQwiKMhcFot4ot1aylahBJPXz4JoBod7YVFf7HCizLRFl+NJDEcdxzJaZRQ60Rv53AglUbhe3R0hC9M9MlPTgDBwAB0vGUS6H0YIJhKtTI7uxEYR4airMiOERb0is527oMULmoIAEoZaAhGkAWg1fXhf/+321hT7JLaTbEvW70Tc9Mi7hObFoYoZFBiZLh2ZgQgq0AIuGAdne2a5MMa3yzGQ2zwNjzSsgnDmpccjGrMlUmJzURcyFbkhsQsM74JTVSYzHia2NuSLFuMYlvyrG2zquoFkI3APUIABG/Xp7G+bl9a4D9HoWXrfQibez6hHtmsNy08WHTjr7ywriXOIO8DoAatJY247Mzrb59V8mNd/F6j5S2WCaxLgg1U64Wjq5ZwwNvCzxBAZQiGTAzJlyAFcFR00hc3fZjlR4HwvTUSAfXGa1aaLsNFNwiKXsYR2gwXVR3w9bbmRVujpKLWubxSbHIvLCGi9TPPPEOLaBoLJkl6JSRqcl6puhdZWix1koibuHtE01hnf9ZwBUF+YzHVmG0jslFjQbaY6iK2i2DJtTCaffSiYxbwEpLEUBuAOw00sTZNPsOyi2AKBwWkwBtc7t5j7ETG5CQV7grZFJu9ew+fndKInHw1U0BmYeE1mU2ci2w/RLZRAUgLTeMdiM3gSaKe4U1Q9kyAYAjL+R38a2B/CxxMJF2qNF7CD6xAwcXtocyR4+ril0vkDThn2mjsUUTIa0UTvm4xyw58VmklFAgEHX6Jo0i6XiYnFZrzGFydsyKuN77TC6iMJB6XTk8YTF1ZGksAy09eKXIJpr5AdLL2Usj6hGaUdWj4rI3YaVcQEXp870lsr4a0OP5rFOmkujJum5BVZMjPfvYz1L74xS+6B4BGMDQZBBoBIEATKQBCGExhCwI09BEXSjwCmI6hsPCZgdr34QbqMvaM5aor+b3mEnRc10jDDUGNMLrUJZiSTZuZi0UTnZzmy0zJ+yStfhnJGYwi2Nh/jHz3gEwxWsSdAMylMKDIKOu/deuWD+BtcnZHWyPzjrsWUj0+8cQT/rAT3fuxAx3PNt1OpWZPMiMSApufYiqRIg+aWJsmhmIuu/JOIteN+1vg/5zueUN5/vZ41ter5LvbCHfQgtqwW8KnkVoiE0NxEpFMObH6+0k8g9NY1VavLsg7C+L1Qmt9Om1Zokg57zhk6UVEsJDBOcj7Ex5a+J9ed6YOv3otYwaxbDoiGY5UBR2AIRpHAI0r260LdsYqeCl5tlXk3YIu4tXC753v/Hze0jKcdsj6obQszw2mKCNtcQaUneEFwUDU4LhrE1hpp8vKEX/R8eG3QIOLhFH8dYnpbb6fTvluiQrOlUb539JFVYu8OwTCY0pkt3WooZ9qWPtBhOP/gw8+yAKxRgRAEi2GQMYCLAWjCC6EEQGJpxemmTIEmrnD3UDFo+DrZxHiO5gw8FkbZgWOFmQNyeZaUBM17G3axXehSoSyGRRK4qULwY1CEjpC2Gi/s0d0VjosEsChQ3gwdiaC0Uje1YRHEVY7IxjYrPGBdghHBBZwk0PIsVuegwKC4GEH5jbQtOfYAKmAnN0nyQrAZYi5kMt7dal4B8DD27ScRTgAKxHJQKRiMdOkURmOg1D7RepmgY45//aMQJg52oAhVwbhIpIsx2JEHrXGgDH1oOnFfVi/5Utf+lIDNFWGCkAxUjtClSF0cSB2TU/wOME2cWjhJI+ZNs1eFnuXIiK4ntOehPyJhuDwN+qU18i/1UbRETLWWtRWqUYhwPWib4CEALyMUgt2IqyAxedwibKx4IoWaLWr1/ZbGRCAsikRTVbhc10kVgqn9KQLCwCH1uLRYdyJ1eUmqWKhy9pgB3HcnSlAdiNgSSvg40sGoURMEUAT28qxWkQ9rztEQCdlAVSIwZeaRLJWLR4/SxW82BNg85ChGCVpFax9DODmDjX4CqbeLxOVYGIcwbTQTp0KWlKfMAQzxN2rLJgAIrIYx3TURBA7Q4SPAFa6ceOGrQIOFQzMpJk6mCmoOUUjWCMc+PRSALR2r8p6DIUaOUnYvOMyhZzbjdN7WQAd2SRPIC3FGZxlBDLe6wWdxJC+cMw74eGYHbsdQGLOsWlnQqlGYGjak43NwVkvK1E2u5k+vuFOmUlNn3gtHcYUEQ7jkQyYmhHWQwdHn3B4oYoRND5AYL4KPyBb5Wa4jwwXt1LekmrBTRZeiNcSF+1E1dKs1QXWrrDMxYVBgT3RzM5qXNQKFuAli5GkxlVOGsbgBTCW8SFN15LQBWFGIZya3ApqaoyG6U76cEpt9Jp+HwBZNv6SG4dAjcyigwUGB6aW7RKv0Yj7DlOseSSREJfKcfGHH34YvnY4inZpqQWgC5fpwreihSTw9cL3qM4n1IRRk00BYK2YOcWjIlaS3yiw6IO7l7+YZhOLRK8XwXJSa8BKsEjEVimMhYE4XggWVggA2af4FoY01lhr2FiSly0WYrBGR2Lib174ab8lhBR7Sp3go0lZO4ocijzExlGQQlBuuxZ/tfiJl/pEJXk21+hQKTd0eLTbQXY1ARkRChIvTOYyVi0Fk+8zr8BXFqxdRoaO3im0C9arS6F13MEAi59SWL/22mt+vqWYULz0Nh2EnLLdMl2XCJBQYRY0AVRgZDPLe80IwViJ5Pw5pmCAmbKvcG+Y5iIVmmW9AHoxI2QGAWuBpsv+JwNV62VzxLVzBhTCBFCcGEzt2GEzAxvuXsX1t3TVDqSgzEkmgpNcywiQqBevEdyYBY/I4oXjkn4CqJVpBzOgMi0XBJgIazKwUh4OICQWG3JitGx5y9e+9rWVaOuZng6PCbTu+Y/cF5RyOZxk5EtusDwFd49LnCWcJGqKUVUXR+Rqrp8eeOABiwcRJfeCBqeW7VovtJCHqZYoA2zp9me3ityIO2qJO4+USjgliQ4GkkF73qxGkEbJph0CgpHVDtAijpgesJpzq0mugB3xAIZDlvxyYlcWlgEuRR8eL+rhbsnJJS0DCaackajkIRsBiCHNgWmUtFqm6YbUusVRwJVQS3U7a5MQLwaXYzr9WVEuml0meCuCiz9WYi0J2X27Km4SCWWhWWC18BAkBgCdxKPd0uZ0ERDpAoe0lqiTu+sIEmIqd9YusEIgNsFcdmPR2kZQIy1gQlMrkE1HsFp77DI1OhWN+EqrJeDScFk2mrwL3+ZLPcXYge8SwAfoEnESArSYd/I4WNjnTCjj0E7QJzwcXQQ2C6ZAQLSdMCAiuvIiMCJIwU8F9kQB7HLDfZeZMpbiYearyCqsapSxGuEr9UpUJcKI2DI5ufZ5pQnGWm2UmvCGjFIaL1IoglqWGZHihWx81Uszxk5j+BfhftrYBGAobsZoALwgj2ANXD6u7q0yito8KUaCm+yx16CdxvsO2uOInbExOoPLdNENLNBYmYKI6Rf4rNt0Do0WI/mGYNjBEbm4FB1hCjEONQ899JBUS5fLRMci+SBP4qDcMfGyjJXpUskStQasZ/jaFaRwJANJPGoHa1kWjQpMBQ4ZKmCMDAxZsOPNftHkRAZfI5kNUWNq53jppZe8NxdkdXntTtqbN2+Sv7BrSRSnZHk+igrNWLzERxmlXnEzM0p5rOQSN+wgO7aLrXRXKI6jAnB/KnWF/8gjjxSUnT3FPoscRwMVmIIdZGIXzSmFL2mxI48wTU7DM1GGJcAf//hHUhmrGMuwcMhsLtCkpuEes48ajkc14hlzZdO1VTUK8WrnYu7hTxz5C/+E0YLdPSlYj+QEWEriCwp5AMOyjO9wj46OKE4pAvNJvcxifqnPhhFJhYFZkuImFKYd0SEdMqdlQ3bQ6NFRIzeGnCkACkkUpBgTEZTNJlJm2Yx4j+cvXWlEIWSzE3f4ARevIzWSJA+yADXZhkVd0z5d0zKYFwEYn0jK0E93LWeTfcuXv/zlGQMo+grARi4j7hI+m+KevdmFlOZ7Jfg68IN5wE4KBDCEYAqE5OQftm7L1bKHALCqC3BmvS1lo6ZjuzePiakW6RsLOkZBlnZJD3tt2nEp+3BKAwVuJ0enXV044mXICDzi6QLbSKVXzYQswyMFFbASjFftMJESm/r15xNPPPHggw/CwQI1ouKClEOfE71VJ6Z7ZIG3ve1tnF4Khqb8BSbXl42++uqrzulWZpLTAnJfeqKMlxtMmaCXyDji4gepMJ39ZZ0sKQpbXdCEs5aQUEgeL6+kqBJbGWtnfI3k8dGSPUZ6ZZvphCgzwrHM1LzIkhxmIdO3/Iv8dkQGF0rMIMkTnqgWvMLg5lfN2tNCOy0K2YhtCKBiIJqkJb8W3G23hKEjpk2KeubrCgAi4UiqHD6OWjwSXq/CMvzKDurbA8ITm7564TCLDNEdi40ql0bBcIVGxhZ2TVyvlQwx43pZACBMC45MQQB11yZGsSFqCjNiBMCRALzRKEvDvIinTjwOJSwfBQN5NRYeL9d0BI44slh45MwEG3Pp1Yj1NnftDbkUkbgTXs0XgglG39f1n5XvGqYYz74GA5KJ0NaSGk5d4Om9oNzRQVZBlitoMWdnkG3bTFWjhBKbtlHaPRrIe6Jwhpx1zRCjtPAemREj8B6XBl408S2PCdMQLLTg7ggs9IhTejliUumCtizw0zGBdcWL60NWDARTHAJAr0aUjfJ3euQgcZ86RnplCv4iusglvzOEyp3KhTO9rsawlqczjvUZU9x1icIadUkwPcpPcdFooX7sYx+DSWvCSHuFNmjJoFGXR8aRtvcoMmpsrQKIYYMhvCivdloXH71lgiapjAtk/9GFV/OmCVNdlistRAq3E/gSEnHqoAamBTTEdYEVgJIlw1EzSwXZekUi2lHKhqHLl/zsw1uQuleFPMQmbQJ4JK0WAtOXaoKXmr6O85yBCuYIMpzj42NRkqG0mNBI6QowHL4Tvctoo9zkFIMEUDh2QWisyvgxgqwlMcjjEQtWIon5mhb4Zsde67qAACaLeHGE3/BLqXFEVkGtGv0ao09Cj4RfY62qEBKD2EoDL0UeRKIcu2jWcjb91Rsnk+ooIRsyoH3SGC0yHcvDNqWRHYVn5Wxy5+o1zVmB03MFR1oplW3zNCLEE7loSIwcIgvaMbiCRkIyuoLsaUTavmRGkBFcqfRf/+UYaM/xDcAf/vAHRyH/wZEuCCxDdy+C8EVT1APwKkK+vP4tfPIYq6BDHkMIYDiR+HQ1QMoJxleBo4VhwQAiYUFgAxnBGnjsscfkCKhRDVl8CQOt2cEUwGIyDmvPHJFZtEKNVHxObNJ4dHSkHU0txEPEKLnkjRs3tHi949bST1G9nbAChUiSoIwIsn2mwyBjB/GIwL5mZQeNCFKHzGA1ORGRQAlejtXWvHTVAjZNNLIahebXXnvNRLthIJ59CwIikmI5I5WRpaCabApqJbNgupeTAqhQIapHfD3mEiNJ/iwu4O6jH1m2PUY4YEmiVgOuprA/RiSsgJtTwlMBzDHyHMFLqi73dCawT5svjwyinQrO+MyrQDYEteT36PtiQ8RiVvKoZhOUsSi2oqARO6OgZUC97VvVZtMQU0BggKOAIQAehbutLiHVqRP3i9fiDHWiGXG1qYydGbQ3C03sQM7YcVGjuI1VQ2zq6L24JFHIqxEkAO5yAnubxeItwoi3k9cqkhrmf1vzR38dLvg3wxljXfmPJD//+c/b68yoJH/GY8DcRjnKmRu+XldOY2znQTKBFb32NxM5QJimSovl5MbNmZHJvB5p8Wtv4JKIedVeSdXbT/+5eifPEm0QBsAOTsVM4AJf4GhKJKTCB32pQDy9MJMchQGYyDq30wgNGsVWGplgOPCx4Bxqw/kEyixmeUNgVS1wNFoqzEIGXXydc7jk8hbiQx/6kOWEFLeu5itg1NTJLzcRmBQ5Jg9DEKZ8xF2nRSXIehGPFL4WTNZudeElSfz2t7/tN/iuYmkBWfhzlkc8HMJ7l+XmzvEcfZQd2+VEH/jAB8hJcsbXSJ4AGmHhUSGJRkwJY/kh6wN+kmDKzuK7s79ahmuJFlJtBkYpLWn2rLC/UoAgp8YWv1qBP0sIjLiaVCShCJ8kJ2uLCDYAp1TB2jVI1oMTMvy7XTBiluGyhDV6JHmNzKiFEaTPFOQM3JLBWZL65PcZr0fBlF4Q1CxgDdrkjE1lFkMQbBaQUrRABjAgWG1UFgZgHXcwUZVEzWeM4rS+L7YoOHk7Ohx+1dRDBqs3GiOyT/3rX//adzL8jZrwKUIeNEmYDH7x9a1vfYvukgAehZEPSJzJfvzjH7vMZRa3TOaa1okXU8GE5IggmMeqzT40wFrpk0mBwOG1W/IMZYGwEiIBbrS8ebax+XO92mmtHTKnAmc6Laz3lq985Ssgvs7nXnzxRUmZ+zKRAlHTxullKwKcXjAGpGFfVGD6dMYiZGLSaKF5JsYplwUIN2qugAvdLAxokMEKUqKJwCEo+ALGnz5qmnkJUmQYUhno4jXuaGZchsACTSvNqpaZylw4Tb2EDNjJ1CGakLas0skiHa0NwYJB1KlMTbroUgDwbae05hM8ngUgOzizgGzuE5/4xAMPPOCAzGI7+Zp1ghku3Lv09Ch6IguZ38hBNJLKfMlStXAvLPBSoCHLd0Xtd77zndi5uGR2UdVAlk/flqjZF+y4OKexJ0MWFuHQFCm6qPNIAJOCqayEgFQ20W7SSWuW3UTzFurLUt3KMQUJjS2YktNjNa8FKAQ2RwB1yGRgAcVA9XDBiCUJk/GZnXHIqWYEfC05VoIGBwBNFyI77Xy3G3En+bLUknZ2SuaydkyQ/cwqE0Dl147b3EPQYWdaqGU/NidKmcG1Vf4f01GKawFYTx08NmTJCl4wjTUws5CB4oxGMLACR4jxyBNQMK2GYA0HZmPHnroMWSo1MPw1vc3KK4qbN286jHbvD42+0ilTRirc+YxzjKxOwHVY5Ja8RfEmwM/8Pv3pT8OkY9kbAUjl/zD/4Q9/yFAib/YUu3SRHzIvSmCLCIwjhycWA3J1C4eOGiGjye2FUY2u2k2BLou6jUov9YVswlhZq6+gmNWUEFGGBe/Pf/6zTMQwpG13zoBeEBPF+eKll17ywTaikhQ/K7RZZVk7xu9//3uYMuFf/OIXQhJbMOIHP/hBisl9/Lrx+9//vlnHksmctmBqZEe1NW+f0Qhf+3PPPSexIgAiZKM2/QFIXbxka2IzMQkRB3NQ93es5kWTdguMHRk399rJ1CjBlMcLgqIw8ZjblJgbo5oeOEgZjqau1dbxP//D1BA0mjbRhMGZS69vniSSZkUvUmTbyZf8aFohcIx1YmBe0hqlWHjWGw9DWYiUCZpWNqcmkQjpJEivsjPym2sr1vt6vXAikrROx4K74wJeJPTnnMsaSAWNFhw9E4FpWotGdODEjqjiJvG0mGviybOsfNHfpoU+fQ2EQDZjLQlwIYC/MuYykoZDPJhk8JiJEpswjKbGVAGQIUyPNg8HNASbdAMBenGHefWFzGRgq5noAPJwBjDnN0HWoFVpJ4Nvw7NuzbgAYS7YnCXNYAZhLgbhHhxDi+GZEQWAkmEBjAABsho+I6hJosa3wnQAZjHKhufFnRsb8Y4l4Y9hyZDx+RgAhR63a/R3FvHEFFv+/I27WiA8tmklHgFYAxf+LAj4T3Fs58SghexHwid0YC2l80GkjV/aZy0/++yztmoyELWET8yhwtNPPy3TZ1VB0BFciwt0P2F4/vnnxWVq2i2sKVf8DmQOYf6bOI7qJsoRSsgWqb7xjW9IUwhm1Vi//isXeaDHBc0AAEAASURBVLGlgdFqA29GbYDJKltxwHRq0G56TC1aX/3qVwkhVhLaG2E6+8OUrOzdiN1elyWKBwb0EVgBEivrkPnk4d/73vekvUIVUb75zW9S3jcD9hkJlBjNy1lK+IYs2goB3ma6Z+AEMImBUca9rJrmkaK+eaImjWTE2tvctFN80Hby1WvmZJFc3Cjhhi7udBTzgWyFVSmo1kgdZJfU2Jmmft3vPY+4jC+0JcIGzETIakTn6OjI6YYreIyXaIWCGRSXGc0tpLXXELXdgoT2RXcpjMxdmJ0zGaIXQTVSHmOKiLXqPyBBkH00ki2cLGNIwuCl1KXFbm+hAtR2RC7705/+1GsT6ssUOAymfJQMaEpX42i4gvIAhnvcWU/jAGFGQWMiaSxYUJzw2ke7dIRwT0o6kiEgsYOLiWxFWvHLGdHScN1sNi0rsGxDLwXFC64lqsI0FxRBwfAoZIGpNQ48QI2rAeve6npRQxZB88V7vZ/EQheZcW/e1RC0hAyAs7Mw+85ioMt6WztvNJAA0cfamgLjKLBwv1/96ld2X8tNjBNtOY8uIeI73/mOVIYXSfUef/xxByChCT6yYGPZTboDWTgSuAH808U9Y/p/J/25CWmv4b6W84NpQVNoEnPRtCcZSCROS2VpJWvzZ2QJRnELNmnVJ29CYYukZgsbiadvBknjMkKQxg9jelrwSCAkeUTFSqCP9c/QKWYZP/XUU0I+KRGk6kc+8hGbBuVlSbqMkoZIvL19/tSnPiWcC6w4IiulNUqM9ofaZLtEbKr05jRkvcRi/lAjj2IyeKetwlZPU7rosg2QwdSGuc3aTBPMcGhuUmjNv22tbGgI9SllJnJxunRw8GjrE91MCcfy6OaEfzDy6JvDJR4Yi426DYZl4NgPHQL4hyV348YNHi9Q0sKkAPiWa1Bx0CxYdfLB973vfURF0Dza8GSjaU1ajFITEY9gRGx+6JvB6U2YMNWUrUt7XZRSwFYCH+C+oph80FEGMrfGEUxmCamxLEN3FlvShDkFDrgaDkCJlzq0AO05TPgalYQURtmc09aCowLZkOF7lQDXWrJOKjXJEwNMYI+sZJXZjWxFRrEtWOndHQRaSBJTU2+6r+bgdoEA1F4XzAyIBSN4VIOV6Ku1GKIFJkBgkijYWblEw0PgiuFA02Lgch5hvm7hq4qt/YUXXnDMpymt45IAasS5segmdPgLNf5WmfLe974Xax6uCE3dePA3+AKfBSXmcGOkBFPxUaJKfosUgvQFRwvEX9Xwn+t89rOfJafFKyhLaZ2MLY0nn3zSGqGgq1KppIUDWdiFSVOFVAja51iVCivj6mMCXM1NK9yVBEICPI+XTqKlV9RjJvpYIcKNaE0moqNgGZNbZHSUcxsFgTSGCJd6xWgxpfUpNFtLppZPi1YIkpUAapIRgz4lZYmrHTIYL2gXL1ggktZDTTSMS36AXSmYqRqcDYDtyAaBXgBJlvzUbmnrdtEjdiiGUEqNKfnVKKtZhpXYlgdgPQgABKmPIFhp+LKG4DHBUBOV7L1iqPXGP8gvaOpt+xFnuQ43skuZFEcNaMiSwZSZZTPuMUWQbW8gnkZi0JEWR0dHL7/8MqeBhr6xCaBmRrUWhYJZlUEMFECtdr0YKWhyaHSgUVxNKjbH0VjxmuNFMJoDe5yisUI8jdWGg6msRpZNtGcfyBpx4a6ckAV0eVTDVAD3qpzGneQ0IhVTK4Bm0/5nwZtiDuaIbV+0Z8PMhs6blAUjC3/glZLroospKhknyjABaqQgVrMhWA1fryIeWa25uscEA5g18nAVCGrDh/hq2KKc1u4W0i2w5cYrJH1cBZz34mIUmgAzCCCP2wyZFk/m2/5fYdkbl/7c5z7Hkz/84Q9zUZ7mlEZ+TmiUc73bVaPcEjjAaRHZWMMpkD/AcbdAciy8VBeaqGlNERwF1ACWM1NA9sk2LyKe4dozXSYy/CQnJSUS5oYOqBNOQoqWbdACeOihhwRjctsTTCHp3Rokq17aej8rbXHR+7vf/c4Vp5jiwOsmghqsT0kpJxhZh3fIRIFGFIFYu0UlLjMiGwnfSAnE9griNql4gS+l0LxJVQ+gkQXiInYwt5am8zSmhRsqZG7Ihgs6CgMKIlRDyiRRIUbMbRrslvZMQOzyj9hpQRBaWu9kHWY4wcfHx/ZM26n/M5JtcScbC0eEgzrUyyttgVwE/fyGwKbDSuAi9E1CBAOw1i5thGZGvKQSGe0W2hMYHbAavlFKXbS22nkFszCFfSJhMDLLDPLoo49adbyCGACphBsGd17uc6IZ2YF73GjUG0LAwMmwRMZFzou7RpMiHpGfcZruM+wM/64WAmzQz/J04QZgsoFbtGZBC5jbyNpsnK4FvavQwoZihEwlI5gIlNkcgM6UHuE0U1gjqCQD+jHKLHBgVuCINeaIJYUIPoNmo7SYUPe2XM52joiuobmtHYJ6N2qXfsILZK7L36SlFj7KWgjDi9hBcKCR6ZN+aefJukQbaam80mlS8b6HACg470LmrrIHvHigH7l4l/71r3/dmcz57OGHH4ZsIMoeXVdaj3IacVy6YI2IdTjyYUsV4AgOzSrARfwVtU0BTcmAi/RRqGSxk81cMiVDYRGxUrFQZbaCN7mZGBuXFNg7faPuQGqgEzHFyCHvZQUSe2EiuQDo/fjHP+5oz3BYYkZ5w9lFuPQROAmk6+yFrOhJXDsbxbSj9qMf/Ugjuzg1G65dTZLLKuyLlDogeIjzFTCm417TtQTYMevBRGccEQ41HWaV8CFAhjDstI/DTWMUcrWz9WU3yHCS0BAz7TKe8csx0cc0FnZRYYtVOT0jC6wm10QztZkSgrXAJwayuhqLOJktElsa3zK//JIbME5k4Scq/IYIoGKlmMVDrA2pMYfWhQ453Q5Zh76TFbU1kp/z/OMf/wB7b4BUxeNtcPXv9mN8a59eLGaURoX8LEAj97y8y3UKmBi2B7cr8BXvZMQgQEOuuG7eq9OUAICmFcxEHskMR6AktkeuRWC5lXaZlxUnk5I0cUVDqNwMqqOcUuAeA2JXyxIBESWc6WU3wbqTIhciHhyMALjwN6FQiw+Na4zguWoaUYdqzrXiiYWDrEYWUL/yyiteAcneZAOCkr1QkWw1xXxY4PKZlBYUBCgt3BWOdoLxXn4oDqqR5cACq4hJQvT9mFh8VKPGaaE5wzk5ISX5g8/tRXDLxNFeGIWJF4/iyfxZDCWeUzs5V2+Z/cNeVhd98ObruAK0K+yOJca8kCmZ2FJRQ5DDaiccBC1WbFOIToKqK+hjrDYWccsbKcjosw7KpoEArEAlw8F6WQF3XQlwm9ib/V/2YRDGZCK2AJj+n/zkJ04xvj1gXjY0HexmRlw/2XItOXusXIa1+att1jp0xaPF3mZ/NhFINelqLH7wgx9ARpA/mCCvKSHwQjVkLEwNLriLoXZiU8bzxGWzBkcZf+jK382UrhFeWOeU9gB0ulCmDg+uBFNTIY86pXI8xPNMtULTfEaNKUnQ5O4e4Ts/9uhyjUZRE/HRNBDZtbA7KmPTcaPegbpuujP8qDUWnLcTEkA1gC4AOdVJYhf0Wln6ZvF7lw3TQPPOdJTKgB6D1YrhSFVGndgZrpjHrMeAU7Qo3qCq+YzXJ5/85CeNikLi8SvhT6A5Pj6uHcK5CuIkrJZpilw+zUSBVMS2Cwod/AFxuy/MjtgQTOLo1bW7WATTQDjE88gaVAsNC0TiBY2aYOYVxwo+8A1ElqHa8lemWU8ETAWMGsDugj5kMFMrq3mKDdL6yJe5A5pgtUekYZIMjKLawjBEYy1xMhxAYizBelPAekYHvnYSO6cYBU0LOjQpddeo4GUsINbrtuvqxAIsw/7mi2E1CXPl8hyiHDOj6fUJiETSZQs0QcRezU3d2PAAU+BUwWlEYYBeOLyWi6AvhVRbGyYCL5NurNhn9Qq7yWEJ2bEtML24QIDc/JLNzKJAEi8E7JputXI+vmE4r4AMJrxzvQM4ZGPzBxwheKwFvnYFkAupaxmcMDXqskJQwA5xRc7rcMrf7NM2cjiIe4SZIvdhnTrkTDZakNZylZqZa29FZIJeOdgkmE5XHwxRLRNpASvoaAnuMa3By/a4DNoSQAHxlrApaxQiSejR4nVe5kXSQOaN1P41XtwAfQ5g1uysfNI2bwv3qNGsKRHEFGahQ4sprt0Qmaxe+FoEE10T0ABIKRgF5J+FMgIgKDoZqBdsaWj0qG4KhCxDtCgE0JgZsYNT14nFdejWpDQYUUgNGBhvQqcPf9Wb6Fqiro46lpHCmAJggEa9YAPR1GJgLKIT8dB0EUBJHo3XJQuwFeOAM6Nwxko8jxe6Puska+35/K0IKEq2kbqSFjQla75PtG+hI4v0BZ8932yaDi5bdBMfdeWy/BImT/Uo/RQWxVAX4kIksg5KEt5iLpFgjr8CRF6khHKe2rzDMfXQSIVdpxzy00jRpQzQ49TaCTmPwTXOEAAWuhhHTTt87RyEXyUO65WGHRxlgB7vk5pU5OT2dGlFtEU5Fsi89DrdO1iYTbApCJ/w8MEKE6l7nMZ1z44qO+gIyAjziBRhIlhEqwsaCyOu1ybKtjZaBm/4/vWSGpif0IubuXDnvVrMHbLURJMYnArAvePFPsVNmIThTlqEQpPu0Si1UYypGKhGAbJRurTQggowI6hRr1IvBAWCFoDGtAZkE0Jq0bX6Mr8Dvtq3uLWuSa3CqBbtHgF9beubWO0+7iUTWniQIFnd11AAUYAhEHQNgs/6NPZpul3OIzpawOzifGcg4lq0Kx4xhZYAtWh8k5fmklmcubwK8FVZP/aQeZkUGYqERRB0DS04inE2ZyZtgpjOV80iqcxUKmG4JAId7y6czvhW0ydEmkEtXgcxu0YUzAJSkiB5rmk1a3IiOCj0uoMvllqSzctl/irEe6/oQyu/HdBrCBciQ193k9YlpndN7iu5Y3NtrLKa/tu/m4Kf75GB7sRQUFAoRRIFwK8AaveJKOilF5j7kcqPgCXFlqiuZEAK7J4UI/Tvn0IkhqIssdnQijAvgpQ7axPB2oIFi7E87ZiXfeAUX2hhbMNbp2AWyKQpTl8GRF9Z2/LEmPgyozp7ZtKMjILtGcyGDhCZbjVD6/ULEy++4RxjdxTlibR/IQYK5CdMBLkor7C7c2nyU5YAADQpYloBHMYoj2yi1sLb+bNHfkVT/saHkULTkBpL7eGzrdCva1YT+nEHoEwYSsEEU7zhREWZMGqNrC3EGYW7rlUyrM8AQK0ABZLuAHWwmohWiE1S7KeP7ahZJFMAZGZVK/CTlYYecTEkQK2r9vjSE1n0yZOItXs0u2pDrksTwTJtVNYYa7vrZBn25+ves7sblYJ5w8hdmoLMbk1CY2HHMV0SRjhHR0ciqTRTlsrOgqyMQI7pEbI5Ynl5Ac92deAnGFaykCT/bS7QJIx5rCCeJAiKyF73uzlFhLRmP6dS1yLP9asnxK0WciaqLphNOlKI12UUWJlGmCGrSa4YaEXlKm0MxtpsJFN4odBYdfB4rJb7pBApQzVlzCgPdW/j7Oxe27GXhc0OO9gLTSI1KV7cpMLaJCd5Ezv0qB67LdVkHLwqgzmzAIBsIPqsip1cbzk8OMrg8LcR9mwZOvDBTU21UMO7SNiFJsvYUeiuhfCQFY8sAx9MYPPbhRVqoopG4uVCWlAIh4lQABuoV9EbU4BiIC4DDwBTl8fpPQlPkQgvU9YCbkA1BEvXBbPXW17O+kqWg2okUKV57VRIPvrrJetQjmDEE8LLiuxCAZgsAhmaOm2xXuoWqTdtzc7Zh21dmcm2vF7Xwtf5R+HDa0dfcjgo5WdZGwyBtS1OH5rwMzuiYCcm+lMDJlQLBKcq0yGM8kssJLBWstqPUP2ezYtOTF2KuRjloNjNfDWzhhgo2nrLJEb3YYCuxE5ycPOLi+8NfJsiaygWcAmTXm/IavJr0WXg+KF2LZSqBhio1m5LBhgCmdge7RwCAcwa0QEr/Gp4GXiV5TS+ZG6+iO29sF2NlcyXKObRPal7aroQlfB+c2groqxcUt6kEVl6UZA1PAIUNLUHqEdNjcZW4E/RsjbPqoIjg1N7tdVcN1yL3qSF7yrJVwTC/RDfE1jJt5a2uUCQv9lc7fHCCMocW65AcS7NGuwgsELz/tCOQmZOixd52A0+OgoPbKCuxNZVOGJYQ+CM/HD0Npx7u4wiEjfGBRrKekcdXbHTvhL9tjOv/oKJNLXMP2yPkGS2ZbAlz1pCM68yCL8g9KbYpwBOdpYTflQy3HqQYw9yXSiQPp0RsWzgQ5ZI+42pHIoOfi5mLIfogKaLiHCk2QmQbNe1mTKvjMOfbqzfxQsTzMtLTLyc0c+0+TQcWx1rs54hkA0BOyQCHnroIdb2RbQTIu80HWKlw5Q5kvX4mZkudND3oZJJsV/6jopn4yLgcmtHJ3+bx1wbgqBpst7MGl5+ZmcgXjZaNdYcFxHiKWYQToB5R8EXNuIdQGOeg1oAX4fPDz2CKYWdGjWNYN7C4wMI4BEar9OCOCFpYUdxiUxs9MkT66kJc08KAXYWumt3MnBYNq1O8eaXcWyBXhX62EhEEyNop0AWdyiliKRqhjLcjLBbNqTd2JPRwOoKSyqMpmZGQIV5GVAdYMEahTUPgYk+4mpEyAAWze3oAsJ5j/bGVpAlJ/n54a1bt7ifG6GVVuv/Q1CY9hsfvHzs4eMBJzC7r6+k+RXPNJZ46BAph2cfn1f36TqR8iL0KRXB3InDGEJlgLQAHbf/IhtX8eNRBNuc1lKc/J0XMBZGVRI+//nPJo960kDKQNVhN0Ng/BzuCOcvDgj2QqG/YyKzaG/0rah96be//S1lCORjV6vUV1c8o0/H/badT/j40ZdfXJxpuAKOchx2YTJL11nMrNh7RwDsco6EeZPXpoBlZJRilp9LsEY7k885hTB3o+KdD3XZWb7ZtLKtIWbB7zT8aAKCdnMkbTRNFq2IA58/icLa/QBZPBI6XReYJvStNHUOJEbLj7y8khzF2uxwBoI5f3nFxGV5PAoaJRR4QdMIDYXkJzaR7P8cwJDOMc1sMsMMgJYDaIEwtUak1AriikfCG6WFjiIRwEfjvAtgoAIn1md7VKyTZ1mjsHwc+LLwiSdi2qvILOfKqpSSK/ldnBtwHM0mdQDiiI+1lzIYXjKlkUh0ZJZgQzwu5QTDr2S9208nVh0E0xdrRHKDYeraR+xz+JBjwT/NPoO/DdCORsQmnuOO30n62M6k124nFjqI5zs/CSmnEn/EDSckX77zHBHD1/KSAz/C1OuI5tTl7zzQhcXcL7EnM+LrRasAbVt1T2Wsj9yNksmJXb4kJbkjlxthroiRk5kh9CWY4ammzoypGaz2+B+3WD0sHjcUpmS9NMRML+VJ7FPV7373u5SxebKCBWwtiev+HAA0Tizl8Yk+4Qjh1JkhNPp1v1XUQrW2xV8fuArKNh8WtOYxwgWsxn1DnvvtkTUpOFKBNx5P69Ie8rIe5HrNJbcAtypMBPcVgHzfJw5q59wCqzDKnjzeVuQ9jz1ZKGnWEobbOUPweEMILNYAPDo8OhOYO0NQRsrkavR7JOt5ViZSxDDQCufNPv0bkQiWBQRlru/TURwRSSloABOaGGazFatdsWX6Iw9kM9e60JEph6CFw6gDwIShlNOf45tHfBW92gHGAhBhEGmLdv/9Afq4jB2Ioaw5n1XB31lOG7MTWSN8uhBVvTG2IWQOILl1URZitZtKC1ijXlclNDo6OkKBUsxIx0b5o7EUl8pRCgswAA4YmkfTYU7VZKgGsKECgKmEFoAjQE0w7AxByq+Jmpp8JuJaIJhxG6rDeJOrZWfRW6n39tNqyfATNXXcLNlCHImogLt2dXf08lAWgBZTbu+jEUtAvNPuzyvD7JfobGiPN+nCi5tlzuynooImRfyNUT92EpGlAgQQjqmDMhUEWQuHY+sSytAnA7Nghz7i8SWkdnVa1KjWcu4IxYgyF6TZ2iK0BqhKRBMvDkqLMPYo6mux3qxqiarwKs2kkuGCph3MKJgWMHtJnajkEzm/bhJzTVtJO6H1YgRzpE+H+6FmhJla1jQ3HquX0uY0vJM6G4rogqk0yvCB66ol99XSzAHkj0h53ceeyPK/7nfYtlnnH2KN04pDgKwQspXDqziKGUE2yuo8Q6N90eZnt+NGRVstNmeFSyUD5ETFyAz+9a9/NcsWJMGUvt4Xf5ENDbBRCEzH6CSqxYA41k6Iwh/WvhloMXMGs28IIggaBZMueBmrXS9Al1KLXmjoEM+PUvx20FjUDBzbboh0Vx+ZLpHikpxEJSR5NAI8ktacupxxljd3llj4xLZjGSW3MhEajWog9VEWNax8X785VTgmRsoMmn1jFStIRI4LcyEVZTVkJQsjRQaGQpx5ie1oD0cUdktjhcYaPgqoeSSAWeMkskiMdIWj3i5GoVxd70gi5PEBTF9eX9bzaqQ88qtMhzhkhQ/TxXCkhBSjREw/UmAZFiMkfJKL7AoKGnmjGy3trjEFU4WHC6zsaTnAsSIUl12GCEHI2rFwxCULUxbrbY02Ws4dSZtFkmGDh4nE1cyxeJqnlVoYhUNWLJPGPGkHQ7ZI9BpLcwVZx1JDBFN/bU+WWoavC6+Yboh+bx/XM3sSOkc8HgCex5GQEfIALQZSHMAOYS7naQmHPNRyL2O5vk2LiSwSlGVzXJAf8Ei2iqnoyZguPRmQtbmUaKvXfEEwEcaqZQFch3sJPbpwdxpo2RgovBIygmp88zAwZNN98+ZNfm/2tdjYZUYCd1M2ozYAAqeRGkH0FV7hGk5O7XCDiNso5iKe64turCAbSDyNpG3RGqgRfTbBFAAN4Nsg6rv3sFoMgUxZgLIhzBU8kpAAWKuJt1Z3VWEtLpgRCGLorVu3zKAVXoteQ+CzsGglt2pvS029WQCAFDXFTUdUpART1vB5mfvBWDNXjMydFpjIVpIKPmrcgNHgYCeGiix4mQvHSt+u4gJNbeCYEUxaSQ8WLNwsTC/ZlmXaB9AL9nc1ATbmV155xTd2UuwZhSYWmHIPjsoz8WqUjI3Athy+l/xqwpNHnfNQikba+Qzb4qVdHb5G1kBfo+IuGGVX9rTGkW9rhKARnYARbCdw7kjK+8VytOyB3uNzAqaXZlPSkialRzj2N04AzZnRZYS7No+kN8SqZhQAc1CMMggylutUl3TuL9yAuGD1o3vDmzzqsdFOBe5hI/uSnwDqgG2Ydk0DFYLV6dIoj8oMHxiQak3kILMwSzqks6ouC0MA4nOWk5qF1QbqsmNrlJZ6MYgjI7O807pe3mbieKcpc6jhZ9aMCxnr2YK0ydmlTRnMXMpwAqCpjGBwDHdR7krU8ZNn2wuRivugeVyWFKw3O0QWU0daw10NkYE/OK94xUEAw3ulIMLyh1yCVSnLGkhRR7EYhAzuR0dHpVYdBPhq+LFeCnMFML64Y0RCNTdgyVQwHczeh01iZQLDaYMBOKjKpxzm2v8YKnV0ZcCQRRMnA2R9zab2JhAax8AFU3Uy6AIgYpQSBY3ZP2G8RPINJiEFNbXpsDWaGrMAEyl1A5NEl1O2RgVNQ3DMztv1MF2xX68atUBhrFgskvqGxIYxPswOnJkMri/dY9pmXP3hSIz+LofNkkbQBBOuKzvmkH6kz5KUYluNlgl8yYRsAyP3AA7ElgYupLV2OMw///lPa8Hfl5KTGuJtDQRE6IIOTMZZi3xWtfp/nM7q3+ozW3zdz+84t5TBiYx8FKaD7cVrLLcVPN5xw1zyA/PqDtgLR2vD9PjshoYWIaFtKZarL8mJzpPMor+r3y/hLM5SJGp4g8ZeW4Lc4wbq97YRoHij580171kWdiClXiYynR6hedQI0AjWCBhltINRrgUwvTA9ujaxzYgUXIpx+A3KsgZTAIGhhh27ySwkmy0Vy9KxxTrhUu5D0ZHuORxJOnwIzaHdTwnQXqMbpUbWlo4mLqnWq0wKEokkGsnAfRGUxYjaptUCMwQORXbW9DLRhitjqwjiKKXiMCIs5/EdaMdGQ7RwaxzBVo5ibWNEVGOhcSoyE5U6/nqOl79gyGiqiccyG7bVfgWFeFgTFS8wgEgUJ621YDXJHsRBAjMdCellFiBDsC78EWKzZgazlSkAZD3UzDVqaFrq4qlvFSxJdHw/r5GdvZhWw1QYwaN2CEpmVPfNAzRc2FnN8sTwusZBQSDDjmDt0JBxhNNcoIMgBPSpqQumQv7tmuRLg0PQIsahYJs3lS610aGjGk3UiGFyRQ/bCeFdIttl/fFQW6x3SmIINKaTFnBv1AQZgVJg4S2Co+jkkTocnj1dRvFS8Zdjc35MxVDx1Atz0cbLKOogJazrdcVERxZmkw3Jl1oMvLLRPOwJkIDEJDANJJYGg6ltOi0ABnVf5pWic7ppILQWpjcTajuA5cdShCOigZgaC1AMZ1lZEvq0am4ghL+neFeDlnjJRjyiZm4LGOBxWvRS3OMosj0xcBJb1ygboFYazj6cScCSCIDtn2owOxvOgEwKIBuTRlCq6HsRMAr2LYEPYNWJoeYOzOBoisV6UZNjggHOGVa4HCGyZFjKNrwQN9G+9eOL+YOxJn1bx+RZa3OizhLWi6ZRSY676wLbKrfWkpsBRgZjWZW17QEAwrsudL/BeeqKzrAAzNgkuZq6uaCaYgkwOJnNgrmzcKTPlr1GwoSZq4ggclUt3vsZZWy6Q4OgjCm0pJdGo5xXvDzBwhRzhr4tM1xEEKGQCpk1DJwa4C2fWCavJxtre5nZF50jWABRUUAwTzPjAMNr0aXA3L/wH1c6QofP7Jo71DLIcEGNRhjxVTryLoUFINAaRwA3sApInnGYTqgRRqgsk5M3cFGZpoGRMlzyhxfPARvOYhjxN7AlBtarRt8QdMBnlHPnegS1ZrIjThmuJaSLoISWtHoBIuC6qoM5jkIgJtMCs7sbOhiLCM2NZQjWZBcSg9Uw9aphnqHG1XelFAsouRch6WJ5AKRIiikRVmjKTW1xFDTZNhJGMDHsQCljURj5lzCbwEl9CB5ZlXG4uPm2nXIsARFNHMfIaBoCLTvzHl2+lLBiOZY7UNOXw2k3IwIWgOuoCUZ+UcyLGsOd2Z1xjo+PcU8wjNBXY6GFL7qo8VcWTTqPpBS+uOQPo9QSMHAeadQjgmCU0SQSSXiOwnQOfZaEqyS1ElrWg0xaqQQhyU/4KI/fJwYWI/CwvjIgBRlTITxzyZ5EK0FfGOUSJMkOMBOYMQsZ9kijqNlYWrAMfC3gJjqDRIHlTRzj+AExFgDRwdffDTfK7MBEIamyTNko/3R84VfM7nTCpOhHPHY4AjQarvYIaJGig5degFr7donjdjuODOLYbuGbbpOIaWqG7BEv9D2abggpLqR61JgkHABAwURCoVt+P252ZtLoIO+wQowZheOwKIziZUaYK7KoxbeWkE+rzx1JiYIuZ0UxNoJFi0c7Kenj8y7fdrERyejAuGmY3+TohgD0NgehzeTNlGTT5u80He5Je56R9wRbBkxh5tSdjwhGL2aBIApkB7VGBxPvaky/+R5l4S9h1msKmZQF+JkYZxQf8vqI/1k2eQMrhQwT/fBRg2aIe3Rz4XzkHlOj+E4A+EaBHe19LBEjvRJSfwhStBVzoYndzkTiNWRk07Sx5HE+hSZYi9R80dEJGiJDDXxGGTQEKdjYfAAvj3xDNNHLfxQWxtQjmrq4Ey+CRmWNDQFwwoxAfoBR+djStmdIdbldxCOSmnhyC4dHMncjrBGvrBqcec0vs1Pc5pQwKDALXSDAVIxqoHaT28oCCDRmkJO4OvRaEh1j7bVmx1hnc4mn/BTZTGQNso8idhvla4d23CRBPAFi2ihTEDsCaEFfDdMjNLCxibpR16Wu6AWYVq+b+BuY8IiryYNU3NUK4jDNrC6PkOOlEWCiiyqJrZdUvEvNht5g48Xs3GBkNgQaagCNaMZUo5baB3/I6j2t3Mnp/jRad7U9u++j0p5iIKg0Hwwn0vEPJSNGJNh84KsA4CuNrREmNDFLkuj/ujG1ZsVkmEgAZNdAMN3yqA1EBL5i/jx6veYQjW+ugFqbrd4YBWj3gbGrHzfIt9aX67IGeY12BDGq9qigIM5KbSwtbmqRCKZe5mLEn8iW/5HHHyGVGYmApPVIKr1uq9Uf/ehHkRKIrUnuKBEmiRY4HJq5ZKzaXXCTU0i1aP33GIgUH0dsOmpciXXbcYMPt6ZR2tErm7AAdbSrU3bZrlEqKidiOi9AhCrzpXFj4gqIJo5h7U92rxiFDP+8xTbJBxB0eQo26UmoJrASIMi6nj5a/0ajgIuRrpm18/I9Fz7npCCfUYbjlXE/l6hnIx9MJE0NJh4rszv4NPVmVrYRGrUidPu0IvRIog3xawr4BRqu1lgeD46dIeBlmHCKF2u8bZtQCEFxXQ15uC/lcfePJiIQrC5h1B0fV+ZM4ReOddkVC6wita8gfCNioG8ehLDj42MU9NrDEVeM8ij2WT8ow5FlaJRj+ovihOS1vi2DSTy1ZBOyEGltw9eCO0BMFKzJI1hrRM1Y0VMm5VGROLjeIq2k2DJAzVnSGcrYPiYd+yAIVjcw7Q69ptFSnTFdytY74Y+tGFMktaUJo3ay1G9aTXEGrJEvCaMwTS7zmmvtTVYI+9fjtOTBSyRVCIMF4e2UJOF4nMd1E4CfjPvRCCNoS9X2Z30uTHwxWuo43M9F554jnwSLey7HPgIwsbJ0YvA+A7dxNgbyNnGwkOFln8e8KnbL4Q2s1muIXMMBmWvmjgBJaJ4xXACQh47Fg4UWV1T4yu+8gufo0hCHfWjwFWhwWlFCnte4Hh0PneitNAjWYSuTO7pSIInaKAi0sEiQ8uLCFVi3pX4YJ941Fl8R2fWCnBQaedTGImu40CmXcWWmBQJ1hAOL3P2A1eiNIr4yWcqml6it3Y+A3Zwajkjt6QJGf7latB9ooQvtlOQfNac9G+o1F8IWgwtVTtzZWXsxzs5k1thEMRdmGWAGmVRC6nEZZLPeuSxGjPCJyhM4p7keCkOQ2Ir2HB6ga63fSsFRcwZeOjB8UU6SS2dxNQTP/RXU1Yi1zWX2Z9891Mvu3fj4/OBcZSbMcFEPZa6scD7vLn1Uwcv5EJcKQbyDhq9HjHQlg08rnLh5PDcNwZppCFIWhpqjKIXXHBRmyInhsyRHKl+VeU9dZOwPMupFATW5rZ+++L28VEVmCt+FgC6RC2WAkOdwbcXqctbup7e6WEmM9l7enzjofRdkVxC+IIFp0fpoxuVpf9HOqnaDxhRkS01krT3thIfftybuf72XIJtMlrJMBL+1x2hybfksTKl07zEYCkIWMwqwPbOH1UIjZTyQ7sFUa0LTUfrPFC5GfeTkM0k7jV4vHlmjb2ugZXPD+Qn3404O+GbEPYxHxvTmfYgH7F8TDEeFxxJ4FojJxXfcWFcCw9RllBZCxkjjKLs/6zvAjHuiGp5Id0DnHg45mEi6nGDzrWRxRtd1rjJD8hg13+L3sgbRxPdrYoGgI655jJFH7MCQ8QLI0QyxYHxcAk3g0M71wRWxTJdFolg8YAWgoIYOMXIda0Yw1eiKQEj1QaUkAjXLCRFHM18dCvF+uCLd817VKLIJcLh71SM4aveTPnkoXgYawjUxQlCq61ROMDILmui7NRNYfSsj5fSlHnxLSAwlHkBBxAeJXpoTEg4xUPORo6TY+zS/IPJrYAECQe1w1Irhrtt8QexG2F97w33szHS4qGepgA+9pDX1lbSjuEkEcwzfPLJPL8EZ33yxMMcYRxJV7T2IAJjOTNkLfQXBhggyjt1IbSr13oGtcCcJdjMLjK/RvCjJiTu/VWqHibU6dnoBqXYHAuw5BBeCQU7rRh2inxxSJM3KTL90EQ7a+t+oTQbMnSUng28svxHIBAunZutfMPIlrAxCKDE2v6/GHV/4kL358UdaubiQJAqjI0ETa6wK0Uq7ItIJScGWUB6sRcm/kdJITiuQGzkvE8xFASIO45YZTEy1OKGj4I+SEE+L1SUx9EcMRHMvPf2ESUA0Fq8sI/6iLGl1EyrkwdEOwZJG1kWBgX5B5JtBkqQmIxhOGAMhq0uTfehOQQMxlRfDl5/Sl2yWepkvkciPDgpqGTQcBkFHwVcB0FcN+Q1QqKmwxmjU3ma3c4PMUOzmfMA9tMNhGRZjgdwVbDgjc0IzK/23P/mcy702ZI1qyNmtORpGe1qvmIidmVWMQkej2YwCgooW7cqSLNmEVwIoy/a7ASeGGvHgVu4VsL5cdf6PBS+X9KVTWznv7eiGOC9R2rrvgJepyoGEAwVlRKx/h185hbgGXjM8OZNy6/C9XXE0BrsIw13MNVyv4d1yWida1Epc1CEgCODNWhSPcEQ3p2a6+DRKLT3BvRf6sk6piigmjHpT796NbO4ihemjo6Pe3eMLAREAgi1pMDTnd+tZI46GJCHiPviVLhmSVNpTgUgRUbsGdZlw8+ZNjDzKbW0e/qyXb8UFaOdW6rvR05UiSNFFrHelQEhZtkuPlZK3v3mA+QYojEmjDUWyuZ8k+fDID2a8iOuSGlpmB9iAe2x47bzIFDtVcDa35GyYjwHMqUlRjNrmqHGfsnLB9X4MGU3CR9AjWMsQwbfHBMDxjpkOzTsD7hXfO5N2Rh1SJCX0WFnC5dc7Fq3QM8rsA6DQYlAr/Eztfko2gRRn8lLF3aJXSZx76WrQ0FcLZ47b8lZOKa3QYqCF4RFx4QlNsJpTJvDUIc8jguKRscIxGRQ/UzPQn7fpWxktYFefYpb3PJAtUX+RQD2yTRhtPWOhCwsRH1l3nRNbA0jrA0MGhJlG4iyBG6X2aIcQcN/61rd69XR8fOykL6D7rQitDbHmZbUScxS8j9aCMgoANfxf/vKX3la7c5hgqktBvIXa4yHWzV2mS34hkjF9T8Y4fsVLazPIyHAA8MHqtnyNHhlBzVZq25JeGx5qtRvVwGxl0s3FeW21lNBYLDYsrwWXJdmNx8TeGLXEvyx4KSqpkvayiF8ZnYM53bOItF/dQcDStcj9gSxBgSv75Fj+Ze618zznI2dkjdsl5GrI0MDwRS4HYWfzsglZp4XBgzFtdp13TLnw5GdnxTtO5tQmmKqd0SwVBcAjLRJAZzp1AEykyG8gBAcr6tQixHQEg6kRL4I5lT///PPa3ZwKW4ZIVB0bBevowyRSvo6sUVhotLBpJPEU8qTJGouSAJcYcl7voKSNeFHEcBZAEA5lo4YUgAXkpARwYPedVq/yMSKzbUby7rIVL7CbDcZXsCCSvUGode/MIGga4gajhQom4WnF2PAHQUtDiKd08tWCl1qBuT1qht8xEF+1icA0wxJAi53GY9NnW+WHvMVrQNmovYfd4OCbJROyWmPuFAIK/qCG34O7HmVDvdobBc7rAGWvgHOVJd+sdN7hxBsZzjX2vMhLUc879v7BP6SclJ/N1Ip3vNbVknDjdqmuya3GHfc3tNMrb0ZHETJku2KBMG39C7ilnACXjGSwolwd4gJWw5kCM1hsGoQRw8DwBQKNhmOn0aOBAI0QBCB/qUHI86GSU7ZTPGXldygvSRkLWakx43i0AfgNqF2BRig3SsiD5sBOOzTB0szIMmZo6pQFQCCPG1ifo/pjPMIiOjjWRUKPMinpqsOpzFfYbQgxnPH7osAdrkYisQbABJ0dF1IBpoKXelpGzXXn6n13wNRjvWm5CNC84NK1CclRS4skYSg60h2Cr2jVo5qxiR0wjyjUTlSU3QYwpt2OMQFaRtmLSH499p5Y4JByUh5p+ypnAYhlPFu48X4GrCUEeym/DBPynoU3mwC5mLEyLI/+sIJa1iYp4+KK1/p/+tOfcFklmeu/UMX7S0KtIoU8hqiD4YDhhFxNMGU2/MRDM4AAYL1+laSW9xmFpsdXX33VdSrK5Eye6vzG4jTQggeg772ZFKk3GB5h0out7ATveMc7kBU93WDYP4RICLgbLtVSXBfEBeAX3PJ6kVduizKRJGhCSUO8WRK1fb+FDkNRFhc1NPRtBiQXzT2KO+wAMHCno+O+7PKokApTHAFGjYlYyWM4agPHIDuJ30EjgqRFvNlnFlpL3mnByFJRXylQ3B9Msp3o4oGJRDZyZiItZEMEKbCB2gEQ3E3Z7RjfrqNRC0xF73U5RAscUiRlX/5tXXFNgBWr+MNZvhDy2l0vj3QWE3p4M9fnndD2rKEZK4Kgb/UKEOKmX3+69hIUEOfl3pi71ZJ9eCeLskWlYKeIp0X2AqsWXauwtF6BBINfQQevVilFwKJPyw9ri01trEXr9bp7NxRQ1uKA7G7BFa1oKKoSz6goZBA4CnyZrNdN3hSJdOgjiLVaEiR57A0SkQRHeTeVARCwNpbuhMcLvrOnLiFSoHz729+ud7XW12GLQYiNuExZYuvyAVPXsh6NhQmggjcwpkY8hUw2Yw3cWZCaXurA8chKFeJ5rGhZ2rOu7LAkspPLduMMNHZZqM8UiNOFnSmFKcs4rHA5YVSXN0tuhNDkh5CVJKdpjCJCbMhaWLgu9vQzB5axq3EYvZSCHNq2kNct978FDimScnROyaY8m8+BeTnvdOUnyRLguKMuzsqnc0pD4O9TQzMqR7ceLBsBVCSVkgim8XXJ6EWK0KMrHPiKxaBYTmA1qQDVBQJ1y0ltwagNV8BkE2XAAUVSY4V1i9ZLHrHMwhOY/E5GHPQLTimzS2H5qaO6qOozKSkSOSWPtCa5b7wffPBB6RI4vrJLZ3kEJVAMRVNdjv+4SL3dkJAfU+0KACn/6QVq/riJawHHWIm/uExOCEQlpyHkV4rF7vsIAzYXjAkzA8LU0kWqgc0LhI1CzloMBECrhXGwACtgagL0SnIDIBMJjkZlg+zrPibSdo2XuIkF+dsXBVMxVCKvuPRwuUlZaMyVwDPXMaWI4epmHwBTi9n0zRP5fYTPpChoVAhPkTtQ4XV1vEa4AgscXiTlc7PY+Ki4IFOz2sU7Xsjpx2XX/rlvZS0Zy+LFCP4tk9LiROx8KihA8G4BI0yFS5iCEYQCKEBkEUCtLu0ALYBZXQHNKFLEsvgBautnCr71qn1O4D2GECYO+kTRJuHetvOyu053xAIrwVCwLKWEvkwSXgVWibOrVWITiTrEEOa8FTk+PpZDaVGIh5cAjbJewZRsWqhjqdNadPb30i1+GbEMVxwxFi+SIwhQEwkd+CICYQwRa+iOLARTA/BWCgUfnGsZ1QAbBVkTNzges1V26xFsFJwxbDjmXdcMqXHPOjEgA5b1EEwq5x4btl2HSR0U+l4NR5IwGuQlu4ZEQY1yGwBYnu71nVjslxTOPcYyII20AxC5My2W3K/he2KBQ4qkHK4dO6cPttQ5qIv/jpa6oHFHNYfev8BHR0hCtkjh0UeRnF5Ec+eo3dsVnyWJNWB+D63oqUXRQpiJpK32aqQMUcwxRuoEE0CtJS3qihaPair4Nt724IwvDCErVkr6Hlj/GVC9Co4kFMKI5zMpMde1g9yTwCSRUBMYawFOkKWaSIoOMUiLhS7iCXbO4AYqHmWjHjHy6agIKOYK1sKoxn58ZRT5ESEALdSCuw3GWKGWfQiAlCRUSBUsJML/+te/+rwUsoHmaLvWlWUQjwWD4IsIyeXg0mfERW2FZVDQDicZjGrqtYP3L/nSNj46NjBSEcB9qN8sYedzNFfGbKudkMIrrT0yJgr2FSroAqdjZLVAgEkdYdRuZ1r91xIaoWkPDdDYHq/rw7LAgb27H+NOiOR/PmDi6M7dMjXeLxWCdt4VFWUhpiXUERgXTu9/+2ipWEtyB13ahwV8pUdAXVGrPVj7oNXSkGlf0rQmazcEU4u59NO1ptcU3lGIp4aLIwQGEA+mq0wAHP+ZK5sIgl5r2AnkifIpIcDP8w0U1BCUsYqqAC3ee/gDAl/4wheQcoMhjLpJQBkFOBpRZgSfl0HWyOYKweot2mKtxZtoFnvxxRd9aAVZkHWZ+Nxzz9kGBHqkUnO71lUvysG0Y23yOHP4S89g9PHSTlmzAFMuTDby41VLYy9eY4SgbYA9xW72lOZTJyHJwHT2GFrDbBa0NGsjf4B2hczosC2ytrSxHr2QRSHg4pJfU7gnFjiYnJSfSQDZiBOXEfBaa8kj7/TG4+GHH7auZApcNhwb/nYx1kDts/97lEq0BuptYfB1qZCvMt2IScd0OQVb0ohbDB7xUiwStfRQCSaAFrLFwiN2lly1KKngGCAH1I4mdnAM1KXRlgDhkUceoRTKEGR5xJBvOr+zg79zEWVcYELAXW7uJN7vlyTp8OU+bjmFUb+ax4gK3paIrSwGEyPsxDh64VhCap077EszqYmRSCFvxcuPVv3hEnqBtWMqHdNbi0aP2nFx+LW3ibOyWmGCCs7F3lwViegIB2byo0ByuqOjizrmgoR+kuCXl3JhSZxsDr55cbcr4UXQWC5BHVrQ2sWLyUJfb9ENC9SMqjTpGpuU282r03SFHRRkFWh0cR/iagJHsyBYmwWY6KijHLXUCQ4BHcDSATwKyu6vBV8/EoNcL2rIRlNLREa2a+CALHAwOWmL0CLJ16sZ2o/tpGkihTfIglFBkFNC4KDb9czN9GqJWmkCWBCxtnH0XbqrSXGkdQ7T6tUCMFwB6AKoK+vmVXtAAnisZep1wwqHqPgCYGpEX2SxZ4hr2skAQTt51GKTbNFrXymeMJck2o0NTQanUb6pBSnWcMD36HMoqWKMnJEN8bZKMAVDs7x9DOA/MRRS/T8QmNKF1qIzwRAhEvMKzU7uTJ20hMliqMEvpEJGTfE/PfhvTSGIy9JGOfVvfvObZ555hiIzCmuP6BhrILJa5NHCoqsJaJHKMtV4QVPE6Gyiha3ky7JmHzbYOfx+Qd4dplFkUyszdmAtShPHgBEkg6jnOwdECG9TCZ81FMbBXctGHSm1LmUekTVKLdwbgqBeAISNetpn7DVwQBY4mJyUTS0t+z+ntOd7tIFLQ6w6fv+e97xHuyxJbf9XIJxRr1FOcAb2WqC1lOuLNc688jsZlsWGtWOmVzFyw8Tg+jIXHHsEIxUFLWAIRLVgiBqgRhw1NXbBMkFFl8zLbSB8wcUOAc3/tiiqwsSFRgiqrW2ZqaghXRLdmAWOUd4d+YRT2igEGAtTUPAbU+/xHU5LmdXCkyjsExzvrHQprmJFIn8Sxf0jySV6IjVFRChKIY67UawtwCGFeNqpBUE1BPgJSRICG4gseVySim4SUqYjEr66yKxOI0ohYjgL+M7MFYRDBjndsaLMFBGHYIgCUHSBySakUkeA80gw7BjHKJahixbDIeOlmIhsCNaoaIFgLGTTwQLklLaT2Qt6+wd8gqkh4Eu76GzUEHShhqYuxaPSQPm1fUtu6xZCV2Js1B51zXDwdTkgCxxMJLUkOLQFxrg8nuvzPPmLtNFfjfOdDQS9BR0rE1quvFFDa/2gBh73RRNsuNWCjtXlaClH8+tMcDHaEKFEHifLg6xdsVRah1Yayh6bfvCwxggFj7gouHhUC51EFVYU7aGhDNMRXsxy7YialoIC4mCUhT/DBVOjxCY4EIRCAcUth0e9oomvbbwVoUI5Gl7wSatXlBSG4Mg9hW+PfkEvfCAuUvdnNSx+t8+iqr3KWNI6SttXBKnUJGe6A2ikJAmzkEeMEzhQkCm7wjZKlPRRlxAZctkuTAZ3DnB7AIFsLi40ksRRncBg7NBcRdDb8ZTkGtGBjztSWkIQTG0qJOkuGKCQH74C2TxqYUkA4qXGWrxZcpmDoz8b6DIEd73Rxx2CLgDBtksEEQ9AHGC42iW1mfI3aHzBZorJgK8aEb1TR1PLdTlECxxMJOV5/JK3tWgtYOmDE5O8zKdCHFQ7hDzeTAAM2S4RQUeXukf4ADRbCbrckQkfYrR8B1rr2dJyn2i9uX+0VDaID2X4CgTUqq0cElaQUgoBhScwQDCFgAiYai4H3//+94tEegUIQxIPUy8u5MV1EUaAk/FBcDwX5rxAh2mIbcaf4j86OhLFSFL4yDJqYQ4jVoJmzxBV5fXCGRm8WhF8fQ9g5QtP2EmZXbaSykYCMJaCGomB1Frdk6vDVMMLcTIAxGV7D3sKJcI6gQlpoFGkol3D/SgLcQFd8oup4QkJFiUVEgq4VGMiYmtB3yODaIFMclHPfInU0mrpLXxbDmRdEABqIhESoBiLOzpOG84fQrA83QG8TB9xOEY1cHxjPXRHhZRWaIAoe+RF/jqEl4Qmoi4qR3kHieumg7XAyrcOouTHROWjVpe14cseGcSTTz5pGQhDlpbaOuyWE5oh23UU1K0uqwiadWu4DFStS3BB2f+z2JsWmNaSGrK44OWJ3xdZsYhrVAwHK0i16hABw9er3WMtGi1jpVEGKhp7BEATGakgUHrLsR53MjZYAiXVMgpZWSRTsAPYinVD6jJ0BPBVqRRVi4EsAydlPcYIU5HLRao80V/AgiCG+iBf8SUpLjCpqRHg+J95/V7273//u5O7FvYhJxzICvrD3RCidqvowoFhpZxiOjkJLNeGGYLaFYQDNVLOFhJkMVpaaoguCia5OuIJr9aSJ1DEI5tgpxav5emCKVGZ2hsemAqRKks5KeXyV67NeoLdJO8oGwu/sejjviRym9jJv2QIIUCrIbYQu5To7HgRKeJtDLx+fGNY4GAiKQfNj6stAJ4q9jl7uoSSLWpvZbYATpueloQ6j7eoOLfVK88SmKwlRBzHZHbyiJYuUgN4eeKvIjk1t8JnaQEGFgIQR1mZdhzRURNPgYAvLcBqJZFqBDtgilOGRHaIk0RvLIgqbRQC/vKXv7iR9LWjYGQImswi0nk9FZGk3aCGqaRe7SUSspY9ZEYQWXw7pRE+XmpSSfQAAi7JURMa4AvEbKWFeBoNhyYYVRMjjgC7gk0OO1HbYR+OPckQ9DXKpg0pI3bIIAyaRmlE2WPGzJ5oRjYcsiECWQ0ZDjqICKb//ve/vS7H0Qs37UaFkzEJL93uzZK5diWK3Zr2idaGYIH7kh2ZwzmtxqIue4YLX4J5A0ZIUrHAEDxt+HX7gVrgYCLprASuCRZKfIuucE2Ff5e/cFkpErgFsD0rkC0k7g5ARxFKBIWXXnrJWPgyXFHJJ5ke5Tha4oggTLFbhiWSRse5EjUIaghDWS8Ja9eohK/WWI2+4tGSBoQjHdNCHVlbyx5ZCKiRJLIe6TjsxC92cJC3dOG0kq1hEVb8MkQLNXXh0ii86CIbFTGfffZZj5jqginAiS99AyAuN7DAjRTBBEEmwrSUWbBmPTELdwOd/cVWBKWoMNUREaSMZU/32i4xvc2zJyEr4nvnrt2HTSQ0MPkpGOs0hUk8ZRDA1IFjLMGyobEClv83CQuZqStjBwgftxK1KBlxjKAxkeKjAqUdCB1dKKvZh8BgjQpGYEXX2WVYsIns+7HHHiuGGosmaXOAfUidzei6976ywMHck2Y1N1BdiqmtLqX16UbM1ZtHnuoSSoLpWu2MAi38KCBuUcliXID+/Oc/93clvHsxnNO7VoNTrAHAdBnn9s2XhoTBV1f3Yq5ERXCPcCwnh3TFcOtQfOx6zuI33KNFBdAItqhgGuIGzYsmsj366KPWdlEDWcsYDGj5YVpMLI6j75cz7CBeCI4CKJpu/d797nd330cRIol3VEZHyBOe3EuiJhdzjs6q6GdbP6nyFSeySOGVOuGohSQbiSzeRSocBOEImiKjl93ZEAXauSQRVZHycSiYjubFJamxvjYlrbO8w6+oBz9STQeBAWr4RFVPO1PUi69Gc01sBUA2ABXMGpmZCEw2gcwNL03NjiEGuqt19cEg8m6bkFQRvqJLASA1V5laGErLGuWsqimGCd91gSsLvytlEEwjHs1m7SxC130HaIHX32MPUKl9RRa8WjnlEWBnPdmWI/O0BFRH12nR2vBu11+6sxpFFivHclWDLWDojeZLAAA1dElEQVTI4oJHyx5gYSuAhuNSo4UNGY4XHW4nhAyAR9/KdDW5ZGrUUpIWJ7IAuY8UT1BwhvVNmNhEMB9vOa5CEJcNBNCLtOiQX5zVQk0ZKKmIoY4mgHjvete7XGsKjuKdXl0aaaS3kI2pDFTKic7IlgXK/lDWrheasOIzAMVw3CPoPYxzvSBrzxDvRF7DK4ygYFqtEaxGsJKQU2vEiIRZ3i7FmHpjhIidhsA2htJtewkxuhiBdikFd2KQkyRydtaTEXdJfSn0r4nc5xZ400VS7r4MSabHo0ZBQd7k6x9RzDIT5nRpVwaYaCIqPfXUUy+88IL3JBaqLKmk0kKCPGu+uGCU1dVRETWwpa4GQ/DySppmhXuNg+zjjz8uJiJSgbMhrZYCBASU1cKok6xFq8stp/O1D4/8gYzWNkYoEExNBtI6UBd5hdq41AWGXPBCzT2Gk7iakLoSA4AUEwmObgYYDX69pDJcLzEARjWEMRGJuP1GPBXQPQZAlikzgr3E2LgDiJq01VoQhKwYq8YCkI66phfgpK9GygewyOLuwCFqS5xZRvvR0ZHwDTAcJjoXL6glEq2FURuYW6Am6OLErync/xY4sNP9pRjUKcxSdArj6GpHQgnRrVu3HFrlET4AsiQcxJzCdBUOoK0W8XoBG96jw6l1KJEUB52j5WKO1boMqRjuEQ5Sgl2xxhGeFohgKv5q9GrIi2ZfMvmtOu64aDTKcCWVNYJR89j6x0ILTCHYpYQbCQTFaEdXwQvgEO0WAuuCBV4ivtsD95KyV98koUZTdMSpuCCIUVwQYRDSukbUqyulIMj4fA3mA3hJq0csDGExpbG0w1RX0kaTAESSHsJx1lYorrFrloZ3cldXnOsVQaogK3UFw8ykgFijr5BQQZzuHslAO0OIzbw+sRJSKWWzcZkAkxkv8YMk1MhDI8cCX7A517MSATJ+5r2u38AWuJwN+UANZL2RXG19CohyJWdSi3ZClUUIoceQYWoEC2GWpS9snBm9ehahZE+CqcVpeUMzEKaxsZAAoq9Y4aKDBaZXHJEFK167+/DI2ovjLD+MaqlGStGbSET1TkNC57tX7R4d28UR16yyTgXa8fGxLkuaeFIz94PCqMvBFaHbugOokx2CkZIgy6p8Ki8/lcHFNCPAkZa6RsBCQMRFe13pC1n6SR1AsAxUssxKbkUIIAR35O+OEo7hUwMYkAzq4Oo1k5MpC24nII+CteIwgWZXolQQQx01mB2C43y7AjR5q15k10MvoWJAeSilbD+PP/64/JcMWi6B9DWJQ7DApXnSISi7W0Zr0op1O+msKixaEtaweNQyNkYUWwYy+BrhqC1FR0XJjgglGXQBJ2BpVAuXrfZqL15Elhrlp5IXsQYvkcVJ3IlerxXe2h52AyASLHYQDGbKCE+++On4bBkLbX35JMAh+PLLL1MELMQ72Mq7hTBJGS7aqRC71EE/4tqTROhBXzAV5YWnFIFjlPAqEhVJPRprSBKGVoiUrcvRRHA4qPkgwfaDHSIuB4QzG4ytxfZDC+2NhTylWeix3kEDKPHFeoaQH+XkFM4AZlaj4fApDpPwYL2stKJy4SJoUpOFnSryIj5wYarXBA7GAm/G071V16IySwFq2ajoACiIWN4tTjgOjNpb8GDtirVqcQKcWCUgvr6W72gUTNVeFqsd9sVKxbkbWUtaAJX8vvrqqwj6TF0UdqIXYhxC9ToeQpNAOfDi6wQKTR2cJMSQ8wZ7i/LKK6/46MfpXotfEzgU+6v4uFvGXsr7tMhpmpDIiqriqagNU+RSY6fGdwgSGIwpmfVSVsRxLkZBBNSlxdgMohZnsWAH8hsFQQGIUML6jXWB786Emt5iQ/OIoyHeNUnJtZChb0gFOPILnRorZACgqVENAdMVj/XFC5hxyNZk0VFBTTsbYhQvxAnJVqwkcEcQpoFgyIZcvJhZ1ywI+uSW9SiIMjuQ/OLErync/xa4zklXc2Txt/6tVWuglaDWJYUpudAVWpNazgUuqYHsCPyZz3zGipL9CTEuy6xn8dRysm6hWVRqMVdiaEnLXDwia0krANTU4p1HvDwCYucxODSPBBMdxGgHbV2O+XgdHx+DpWCroPK//4uLPw/qgwRfy0q6BVm9aREdxD0KbWot5IGgUFnKTEeRVL7sY1U7Dbi4ANlAO8Hf/vY3aalRMjLsouMgTxg7ikzZtYP9yShdSsPRN1yoNSTz1hJZ9RIAE6yy7lmxrtGoWpY1mtoxUli+a1YXIKYVL2OVJIlpLRevvWVC8IknnkCKtGrcr0/3FzfsoVB4M0bSHN0MWYHLeRq/t+q0Vy/PaBv4SwohaxEHFVeB69Bx8pre8oZgbauVEaDFXCBYShKjJbsw1Yp2q1QtIfUJJwnRd1hGuV8lCut4aUwLARHHhhhFMLWCVJiQYcKvHawrxdlExPd1gT/l5w/lFV4hGIidwO0HZt26Osi7kXTCtZeInr5Ih2A4mvBHZbAWMkhyfUkq6At2iVGXGnf1FI+VSGn3iEKNHrWDya9OUxrZV5D16NAQgp3AY2pGZCnVsNsHQBkaBWPqAkSY9lsmjLREVu8+pK5x3hgWeDNG0rs6cxYz+laUhaRMlqddY2UE8Djw6wKQixRClWDtSk40EcusamHUayuf4pd2CYIwcYfgAlfX008/bZQ/GApfmMMrIoXLiUFYGCIQJKfgiwhe7jd98oWUrBYyjtoRcQMrdMp5hUWpqFHyUCwk3UUxLdAIo4AD0BfpxDXBV5jW6HEw4QcDpsABV9e7jQNBo0JCdkAzC7gicDjQmMzhQCYGgh6Hyz6AIbYTwkPOhvYzp5D/394d81aWFH8fl553wRMxAQExIhkhYdBCiogQLLDAIoFAEPMukJCAAO0mLCAECCESBMOuWEYQbkRMwOtA+n98v7M1h2v7zrXHnh3b3UG7TnV1dXXdW79Tp7vvsd05DyWYBkoPD3DvZfXXd9W3zgMLSa/5IzsbnBO6jRQcRF8qzKZjCwsgDAwJackXjPMgH0QK4HmutJXvKdsjNoAjQNLzuEEt7MJHl4CeJQU/viEAUGAKaAYIZI6ybCNaC4YXJe8ARQFSdqv9m0xn+BkAUimkIdiaKeeWhsB0yQDdo12yIWhDKHGiyeiobLGPQDLVdUEbOg4DMJuLWnd+0zQm4URfqtYrp9FpCnxiJcfSR6cCqDJEmll7tSEuZc8Sfkk8cJUv00ti+stshnCqFMyFN84EPPpS9heTahqEqOi19udZHhgJZjtF0sZ0QpAGchZdnihDbGcfU0ZpURW8WqM0+uTLuig4aTgb/9BZ+gklPcY2F4NKRR2EoiQQPzk5IdB8wfF2dhQOrCA0wXpoDqABscvZkaO8YsQ9wmXMadoKjJ9lo4ZTtBrFplZ0w41V5Ic+l+CKi4opsEGr2p3JzYxjjUKPQZupy2Z6rvLFvHseuI979zf6KQowG8rtCAsnZfaajYuOqb7UrjG1utOsoD3aC2MHnjxgQjQoJiXUBF4tO9pBfvvtt72HRYT7dXwDwRQAJ4116fCAIwRWP9GOZAWjPcsbJdtCouxvD51mCG6tQBJqT8lPCcC3fXmt3jPvib5VUbCIE1QxyRCVrdvttjuf4FeVNqwyKbfoGAGG+EpHBCWYTTz3otuXZySCKyouIaleasUl2sQNZDHXjxFm01+vNBPYGjb0DNrQU+tIieEk7G4kDHaqrKcEk9Kru0jI3hRG5yLusAdWTnrNH674VIKDreqzHK3h41bsAE2DVrUwllQ6OwUBndYU0jJNOKgpTPTeECunnsd7x7NeHuTBnPA2ouxSFikZlJyCxVAA7vTMDn0CQYigKVygnADUA8FerSQP/f73v29ZVrZLIRA3hGUEdGVmkc0u49NMj0t2KnJqc3FmixgB/CxUMyNwVEerK/G39JZDCWu1YjaKmVJuLJ+L1soY9j7jnL+ZtFfnEJptwVnndS9peTSF1exX+hqco3ex7qIHnn637uLsPuA5CcLikB3bSHM5/ONNrIva4SfpD2jw8O5Upv/1NBgB48CohNGSpUQ1NGk9VGzrS9KCAOS1xudRHUfemmaWkIcUatZmMGEQCXCpBayvvvqqF+7B3GCXJBzH94SLb9CaZgWW5vSoZ5SmzB7Li737mRJ5NPhjnjqBuqhxWKXMNNNJg6YKSxS0ms00aFXbuGeMn9Jax8ShQV8EbVrHvEY8vnZTkYbzfPeS7Nlqoz/m8TqX5K32wHq6v+aPTzh5xKtQ7flORCmeIpVao6uPHJ5CStR6/eIXv3DI3PknJ99194xvFI+ZUiTA4Wf1nrv9/LTRyfc02il0j97ADuL0ag+5rYP3fp7v+LpskRLCYBrBVL/a8n5PZ5VgEzDydOx0vSZP957NvWqATqgkQXP0XXYcjLokY1wa2JDNCBxT0IT2jKzQwBIYTdupj3ZeSl5NTKGkYiCFfITu5uJSrTDeUzwYVbOWDTiKX4vi+FEvy10GoDSYJuW6DzrvRntajQFPWTuKczhNOu+3TLJ7PIvULKQnvyVvLgj6Gyjmqu+wBxaSXvOHK5yCDLVCuzDboknMs6NuxbatRaNeAYH1TYuVElIo9u6773q1PtQI0Qxt5Q5EOo1Pg6daK5sIUR1+MUNgU6WGLyS9hEXKSSEQ9JuohiAv4fKLKQkvjPNTAmANnSlhjNd/eMeStFeWZ2jaFDgCx/2sHuCicYy7azmtttOJZkDG2AhiNvSHxXXBh3RqZiAw1WTUZZ1sUNwz1DA0SA1GXZIh6QGfbez0mhUrpN4nwr3hO4WDbhfBaJbQVhfKQbCJGMu4Xu3qn694byExCS8XUU7nqJ0pD4fkKnfbAwtJr/nzFf8TSKl2qQQKAAJ97pD421bBiQMsSqN0CQ2hp20ly3O/+93vQKFfLpGECELakU9ZnuVLHMN50gco0Y0usNMpjQKddIIbEAZAAbRLmz82o72i2Bl777r26yaZF4Slp8dV2igB3FYYvAXV4zmbFRw7V1ZRGaCAs4tAiiVcRI/hECYVYNEmLwb9tOHrbu4tceqCqQsgCz3pNxEdzZqMAuBckoGeYNdygTuE1Q/IDkaBneEUvSKeWRvIpIjN3cVYDHODsTDibQkWNBjGfsym8EydS+AOe2Ah6TV/uKJLPE+hvegVb4johiQj5vFdooEFQp1MxIRoACTv84+JABzscBpcQgp6YJxLaR0ZyaNVS738gJ1OqBcCprOxgkIAAU+BBZSByJ6Cbfc7ug8grKJCapv+PfLDr3LbYN0oZPT1nlOJKppAA4FjT9aWHbLWFJpF862mJDNOfbErEB+CW2aFxVQBd93dLei0iGGg/IOpLwwt/VQbSyvMdVcwTUhnFkw1d5v1/GMR1nP9gwcPjMMSehBbYw7QRtfKS0DZuEan+U9/+pO7Bf9bEe4jMzqCZPIHFK6mu+2BhaRX/HwLpB1W/E8loiDFlL3Q3fZKpuEn1F3WJQwCtcWqS309dANTe0T+tb180HO3UFesZgIR785wQhOggBVmSNNgCggYk2gAsjgIgKUYyy6/PBT0EMMBo471BB84ci42wC86pXv4zKZB4gn4wJ91BjL06Eu5c6ZWDJjBYHMh3JSbVBzMWmNCc3kxRDY18EdGFmwg83LGq9EZoEC03KIjJFVTJV/2igPTZ5W7glk7DKCjO4FXWDmblQHUKmNGl4drmsmXdSIsj1qY9t8ELLnyzHw09JM5rGq13nkPLCS94kcspEOEvTp1Ra9gQ2wLDgF9heIMTCBkiRNYVONoFcbkJZ4O20vfENKxj33sY+DM6HY/4IgIB2HhJtTTC7SBHkGOicAh7BI004YDf/WFoTagPcVbT4TOTqFCTKNQAo/gF3hKIZMiZIJlspAUojlTRbNRpMOQVBfnosyU2c1L60wWEx1frcSx/CrDhcWSPtNxDwCmLs0i/zQLQwM4II6JhpsmYjoMo4oxnugJ+O3ma6+9xiFazTdjjNtYY8xhwohsoA3WWyt46623bDHxkuGMrtadZvoP61mt98EDC0mv+CnvQODJ8zgVLqsFvzBDC1pFvMGRKXM5oyY8lxFp013HCVoY0Tl2YOeEk3VMQe6IPr6HccmXvjiCHwFTgCY9M7SApxDMgU56HIf0BP3hD38YhgJlWaGOHpP1otDekcTQgiBEoxOmBKmMQUA3askr8lkn/K0DtAggH/Q6fdAMagkzwKDqiJmmSxo0KYnxmxFBMBfJMS3UNhBJAjpmP8JACj6UZFhKzNdRLUP799qf+cxnIKlFAx2VfE5eX8Jjw2HC6OauOxiVLHsI8AsuyynM1sRLuhu9WYTmhxWu1rvtgYWkV/x8i8yzncVYoVuEC8UiX9QV1dMFRxGKcbTSOaFexIIPfLRHXY/28EIXTPAHzmygY6I9YnuoF/OKONeFjF51zB7RDqEcOQLEljgdk3KqyfF+iSS15VaUSwzhoy1v8AEQ6cHEYRvaXFgrAaQNAVzgshxWdkzGQNDH2SmzgNHNqxmxpMstc2ijG4Xr2O+pXKHKphZAN6LEUzGv/EOVVoMSpryzBzasLCnYCPrc5z7nha2apO2MIRnM9XmNe7fGnEv3YRmXVR7qpcmvv/462gehnulEsN9A5+pZzHvigfVgcv0fNFBQhBx0U+R0UABgwRqJEqKcLpCa4cWk6J1LBA1Joj3RS9PkjAACblICEyWkklO/ZSJJMxmrjboYDtixQUeDuoR30FOyqaPnUwCafjLM0MWlglZLb3HagPKmOAeVzKIUj0DYMfot2r755ptQzOqqvsBXk+G6AeBEzCVOxdBUpU3NTjJQT225QDE1Nju7anZmLeWsi+71SifDbNDziRVepmo1X3aaKQGX7MmTjXtkrRc9lFsAsXpr5yrnsJMGmhlDBs3miCM1L7E76YEnK1l3cm4XTWpieIhiUrwVzwWqVkECU2qNOTqnbxwyCtqDM8izOyGto1CvmiLUItyWtMOYAAsA6SJEyTSWS5qrDT2j/Pa3vwVP+FYwLYmCFY/nlu3sI0PqjjRRQn7ALj2PHz/WUYIpfyTfIgCMGPSkc1soYTaF7HE6lXJPynANXwlN0mwugYiDWU6kOn1lahwol/zpT3/qQdhwDUSsjrpsxzqGBuLBKK9at22pQUeuc9swKcUqxEXTOWaIZJrLVt58QbnZufHws6bcu5VZ9PJAHrinSFpgCxVeEN4TIYJ2cpm9sBdpODrqhZ7QrS/08aztdz6eoLWGNWQgi4RFLwI6QhbQoAZVIMCWSEkfGV3wyeiSeQORciJQZTOHmDco40sYYaI00Fjk9c0kFtKgGEUXQIAPtaVshtvO9KIAaDq6E2CktNfoBurH9ZiU08mS8Q9hR1nB2Ve/+lXdCThNRfJLX/pStjVWk4p+/tooY0DaWIU5n8vxQ7CZcOZlP5pytx+7TO4iXkuYzIgdr3xJ3hMP3Md10gnCWd4SJzYrLKuJfEtpLUfaA4EX4rMlsIS1Kn05cApmP7h0Tt7Guj1lTfSAYw+GCDGpu2LlTpDDJns7mojZnLFP7SEdMtpsaYucmCa70oZGNJx0zDFSymWjclJHR/ElSs6BWrNjoVrJMGrloV5lj4Ch1g39IMeOEBsoZLDJ6nIRrjUjq4qOT1JoCGuFfjAK5Q2dbSZCbDzDZjP1L//wbcFzi+GkcpZcZY68rZc6A9CXKkbZLnHS07ozbfjGSj9TcS6a1OER8wYNKedJs5P/+kxNxG8ffCtwGij/HFa4Wu+hB+41koqNAgN0/uQnP7EV88lPflLyCMVCNMEJT0UsQgmqfEv0gi/gA77ANbDlcRuO6AgQOxyOJia2RaYmwsUqPQSEqEKYhn/+858gVX4KZNvSIQ9edTE6JZDaap0NIqnlz3/+c3zLdoTZT6cuRkE7GO+/CSmw0quXndK37UM4aNh+ubdz2fKjJeYQHy3ZZKTkF6xYtQBbdpaaCPQJWYxFmwVKBruX2Md3nzBB6xt6OVaVbbmOJ8eHZ8c9l0M5D0wvBA6d87ngEDi37zFMs2gIM/LRmx1taLcutyLZqJuBqRnRQJVj1C6Z++aBhaSnuQYktRDpWdjehViSg/geCBuRDxDVZASYWrYIO2ATqPXYC7acqQQxoAR8EBBy4YXuaNoUyAgxg1R60IoA1gRAdbc1TBvlsC8YLTumQTz/+Mc/hpui2k69VkStMFQXeiS2v/zlL+102/BxPv/Tn/40jGaGEcGiEcmYEfOMhWbbgS+6QcNHc0ToBUyNJeuEXyzEdMl4iGMU8ja7yNjRgubgXhd9paWSYlhsLIPqy54D457bZAg2V4xlLokZtInMXFilNNNzVZ3L7D6kqecAFsJN9zZfhq9//etScgp9B9w4uzWeq2QxlwfuI5L61As/AS8yxaco6ueJ4hYiwEThJKjgnZqYUhe1iFJbRPP0B0aladAQlAg2eApfwJyaEpkdQKGBvMgHgvgKAXw6hbFk1ogSHzBkhQECeihmIflGFNJe/iQhhSa6fOpTnyKsiW1uAJ67//a3v1lCdQ9w+kcOmHlqENCyL4KwqYU+lAA19LnffpJpMB1G8k9JumVQySa476hp+Kg1/zQ7E7SuqteDBw+4xbY7jjUBMo01OHju0OcyGT9Fd8bzA8T0qaGH0KSQPFfJASZtelGl+GhIWu/2sdpichvQJDE3I8WHtYXyAzpX0z30wL1DUgHjY4ZEiAJDLMFN7z2ytwBioKrFPtCgBBPCiSQxHDQC/NljIQlcBDCsUcNNGJROgbfDzNNsFK1uxdBAEI1aOEuAPBpmYdqJprBfDfkZqLgtjCWbzk5a62SwNTvA5KkZRL6zKxAcLtvb8VjNAF0MxxiAaJqaykkxDRQ0q03kou+6USgho0BqFipGYa37hLn/61//Mh0TZy399LAfAdTcBkgS8NN78rpbtQCppkaMVRcNeoDPM1v8YhU9LFRviQMaDjelnLdNiqR7knUMM3W8v1kT6O7iu9G4hxWu1vvpgXuHpALDJ70DilMwFY1qAOfRFX5Jpqx7ej4FDWKYpBiDO8QicJzysUfv/DkBoSUCCQOO1gdBJEABajhhcQKiEcfTomwOX1gqgIkkk6gCWPCOJXATSAEjTMfOLeDKBz22e1cewo68Z/y//OUvhB1Edyyf2aZDFaxkJwuBmiFiso2R5khA3dzVFxXCxmUSbUyiik6Wq90w3GNYYj3UySpnuUyWHpZI3MjoYnb8o0B2GCpFtZmml+kziQYyFw19Lj/wYgbjt/bH0cU066jVHPPAuaouYuYoA7nr/PWvf3UDsAzNYB+ous/FBNmPvkjJ4t9zD9waJC2k59NyKeB9ubccdHElqGDBuUWTmCGZQvJFICSViXhG9kYPT9kek3UXOYYQYNAQAeZwSNqOgIBBJD6F+AoarCBqCmHRmIAGQdJwon0nfvoAzgwDZTa+LlI8W0wsAbsSUqDppJTtIzv4HuQlrVI8z/hOJnUM3lyMSwM9weWgScPhx2mU6vHbWUKv0TAEMR0ZD1+sPzgt60mftYzkFl0UAzm0YLLemQRA3ZbcFezjPXz40DRh6GVhdGxjRmWM37vMPMzpcoDwzaFHAZRsznjytvXkoX7LxFpTw8mxCJNCH9C5mu65B27Nl2PveyxmrFTKfXzpg1RffSGNFuqYRVqwta01papeEA0h44CefiyEBltvvPGGxTIHy/tyQMAhJIkd0qSfnmoEGYU2CBuSukyAzHzJGt0oTBLGGZkAJrFRKO9jD0iFTfh2bzzUe5nbd77zHTOlPJ2jXHfDKduxMM9KGrqBRvIYIpfW10rFye4HSKySZlrnNQoBMKTJpZ97st/dSLF7Yx/fyolRxvnHjHjtMk0htfkt5/giMdv/YmGnI7F7brx2M5bCO+mBp4H38k+vMFYDCNgH7P7whz94+wbLcSCOqAamogJI4Vw0I1FESVEN9RA6ygHlpJokenR6frfhAJRJFm8IMQZGbfLg6yjDKurQCoCroHVRtFKoZonuamNpZVujJ1ArSWbTSQlhqweSXyfw4SkYcjDevDTpolX3FOqro9pwW75RSCqazhaS9TrbdICji1JfebE1EJfOrqp7XyemVsXdyKIEMJU4e6UIwDUFfJIH9N90EwMMwSczizgc67vkWcTtwafPtzdtydJ/9zxwfqS9hPP0pQdA8KIwsGJo7wV6vvLKKyAPsOJrJSMrdAlKLpqFWAqJdAlr9IJiAYEmvyUHBOLfeaOCrZqYZUqSFv4o11cJN5+A6C5bZIYSlhmiQgOCcrVeE65ZQjNCF2JJWmGk0w6yvSapt0mZbEY2r70JjuaZdaqMFZEZWhE4I3YkQQ8j1bq78Ridu0APIz3Ls9CPSqlyJysrZ7kpyE8584c//KF1VSBF+MjhbkIsz9OMyF38YEaSfVPoxaxNTf3BmnoT0186b9QDt2adtM0EMcAd1rYEgM0NTE9kNmdsfdjA8e0PXyyBSe5a/9qr8SmpUKIVjWkhTC9KaEDgQ1Lv9DUKBBFyxKwMegbUZHGQjO6EK4ZuOz4MpW0IYltj+jh1p9NETGEKDlpNBuHk0w9+8IMWWJ09slcvb5IRWzC1JcUMQ6vJ2w0zBJ3b74pLNuPET60Rh78VPoY2KCUGUhCU8wx8pJNnYKj1U7PGxLFIah/c2TKpq9VSZsv0WXvMQDcnkyv4liWKS5D6s5/9zK3Ry7HwWd43IdfdnCVL8x3zwK1BUt/svty++lIGwSwMQInEx9OZB3MB0GdDQKuQEO1k9moymtQ1dYlDuUwWGpaVOCIqz3rvvfc8nEKH3eD/zwF4+ydyMfoNJxQjCCggDxOkquMwb2A02G0KxfBYyAYxrMAgxito6ed//vMfPw+1deO/aPhtKFh3Kh7Ws9BJHesPHv+dhGe2Lh3FN9kKDnhVG7fJGroRu1RfqlBL1TiZNhyWcCOrNLHHrrf9ejINylGYBnXG4I9//KPjrjNxzL1CzzPtMeL0OkZ+q1Bfl3rxieKDc8mZfp/Ggd634u5oa9GNE59wn9RWw6KXBw544NYgKWQxDd9vRawKCWHplz9+AgRNEB5+IRFmYUCA5Lk1ZiWBaMrFFc2T3wFTaSB8lF6RIQBY5YYAomQQXmhF6wVAoSdCLUqrCbBHQdCAMOJgwQ48TzNQhEEZr1bEOQ7N0m2PzG4SmnDMEVMC7oARVGWVsO/MJsOsV8pYeYMkM9wSDKpIFQ2qsL+hZ744xxcDUUuewfSkBMdwclWZKQyVxUMl5oWwVmC8K8CCr7uRH3Fhmosp6M6evToPH7Cnj1WvZJ4pv6eq4TC5V1+fBVNt6Lk7+lVYv4bwIRIwULPb07AulwcOeODWIClQEH59y80HuAhg4SFuHV6RUEAWUAjFEtN0oEwciis6KaStg+V2k8Q8VXRqtfVsBQ1eoC2SerImxhihWEIKTaaEquGs1sHQgCzDjEWbQSlUDFS9hVHmWbyjwRKwnJRCI5oyGNKdWgTkkgzaibJR7v35YIsZDic5bcpm2OpHU7LactXckkOuBhM0GNr9jBLGsJ/Hmqlx8dlj30nOrtglI0Oe8dJSU3MDkP05/aoLPiV79Xwi+OeWjJ+mZ8qPZITudVFnmwUHDzRM5T0ybjnZxtoE9jSsy+WBAx64NTtO4Mb3GxgBFDVa3uer79K/4RUSUkW44zKxA3PeNk3MUAUdKJGqAFPQ4NK2iWNP/mvxN77xDWdlPP2V4kle2ENASVsmqV0OMzqmuoL5Pnn617iAmzb8reWQ0S+pDJeF7DFfMhUdh7DDo5DHMTRtTIX4LAemdqV1NC/5oBfrKeXUTxTt/nCajgZSEAo2emQyz2VYg2CAQREjTIZm+Z0s70c/+tHXvvY1lxzllPtbb73licEz/qNHj/y+QK+mw9TSwNGT5p0Jp8/XCg+Yi4m4tZBnajI6MsZ0wLeatQwgry+Z1I7TKMHB14UMDXxryduyiY9YF8ymo2nmiF5leeBIDzyNliM7fOBiYqZgKGzUAgn8OcwIMgQPTkF1KVMDEX1FFMQU+cW5RVhJlmCjnEyAZSNFxkq4Ic4lYqojDhhDYCY1Ck1H5Buu7gw4oEFTUybMfqVTR3oBIAUS2T13hIsATFHcdSDdFlhpCHrOHTFmteForgzuuMQ3tP160/GbAicfnK9wW3K+oh8UcCx8N+hWj3HJG1qdEq4mAJHls9JqH67PAkdJIDpgJcxLHk1goklpoodO6OlDJI9gAyJTG8irZ7io/x1w2LGrdXngGA/cGiSdMBMqJlZEqfFhhCCBDtsJJ7blHKYnnkNMwggxbFdaMkWbsaAqDtoSqsu9ogtOo9RUrxk3poGUbd9tl9FARndYUGsooBVzFG4JfuhSxwiSmDQw2wl5TJgiF4NlYBqqZoNpErDQqYAk8K1jZfS7HBqRGTHJx1HjGJEeGM0Mqy4nJyfWHwCWbLRlE4u/ISkBQ+tiahTOx0ch2yy5evqGevh0MgzRCgNhY1kVyX4yANrbUrw5wecCtQ2nSx4byxGZbVAoD4UBvTw9bRSusjzwPB64NUhqkkUCIrAoNqCDw4B+jyRiNQmhqRGXLTSLZImV+BRyjx8/tlXyzW9+kx6XUAkMwR2jECPMpLqodWHSGEAggzGV6OmCqKRnS6dTF9DDklLj1Kbk3Elpit9YaDozWxPb6gvm5Iz4OPDUdBxRQMgZTZYMAbAllzRNo6eNKnayATypMdOPzy3obaGEGAwlCRMNAd0848Mvwm57htZETF1HdJkjTPTQ7SHAcEbPAMORtDpMbAay/usySwj7iS0NwNcelwRcfsr+hEtIG47Bjj24OzoUAUZZEuCO2kUsD1zNA0++ylfr/OJ7TQwLALTwePvtt5lhwWsCJqu2UXeMncW2UC+66Jc9ORHpnUAx1dIi2ZYm/8nS0z21RqkI0SkME9uZmtpMVZPRpEvCCJfoOOp02vSAKXI3UBJntF00F33JJFY9ki4ZP5ckFRz6FftpbLACUK5qjRUSQUBMo4e8xCY7rjttqc1daHwTie8S/YlPfMIeXQDtEMLDhw9///vfgzxganEzz+heNqrmbamoV0lRIrvEcRchRpuS/Yg49Gt1ogDH/puDDT4RNvz73/+2tWUusHKWOKY7e2TKslHrAISpSu2qlwee0wO36Zvkq99sBUaxIWDkL/7BBoDThJmMMLtCkIhM2AEoSwNBAHSW3dCGST9Ysc9rRPlvBmAakUAF+jTuqX3vg8vQwwk9dRmi7s2OQvgiT/SaklBGq77qA5OaJmI0KLpQGD9Ol9lDrOFcmt0OVP8/jqEV+R1sla7yMPSxTe/EFSfzgAMDsjmeqftgND0z95qshLjD6eWf95mpHztJBp0r4Fg5bzeJMRJ2e7bwhG4ImOg4F8y19a9jFtLZEGrT4RngjjCRDHb7ISwVxXS8yTEGW5HuE+QJsNPKxqNHj8Arq/ISgwln7aqXB57HA7cJSffmKTDsSPh1ioMshZNoKTauEB66AJRqSCohVcuqJoxdQhBB6OVMBiJpUKVQF6tFuBozU9HsUbsknwB5hQyFio4KIiYxK4CAzCO2JYs6pk2XoKrLc2vd8WdQtF6ZMfIjU2sC02pqCpACdn6exKo2fOApgltsBFEIH2EWMc7XF2dKM8WEtrrT42f4Hh3kmx7zpZxuRRzb7pCxyFDu/wKQJ6yjJ3TnYR2r8okQUDcjQyDoz1djMwKw1sqTuuDIrKXA6NaI3RggOPh2eIB78VO1VbLo5YEre+A2IalQaZ5iSfxLl/zI51vf+hYkEhiYnojFdnGCeSmnUCjM0iCk5UcST1BCibgVdQ0howFwzuUU85oIBCJkokki2IMzzAArFAgIBkZPoXRXmhdSk9PsIADHZQpn+pSfLSQxs6TWOBmAc1YAs1ZNo5ydLuOAMAWmY0oV1YzhIisAnN86gNeU8BtUJSCxhbCspc0c624UTfDLY7UuNtm9k5ADCYM/Bli49N8H6mhPyWFbtb6UGNEHSibzUohmBpqReZIYAlMxnGzUSXtJ9N///ndN3/ve93xYcFxG7FVPaaaT8GjWa5XlgefxwK1BUmHje2+qEWLST3okGuLzCvOnSowpxZVsS1Q7CynkMD0DquVNaRa6SnFrgc/Kqf/n7ulbuGL6UbmnUXogOCW66Bvs1hGn7qOEgI7gUhe0kA5VdY8Prb785S9j4ihk9DXEgZkS2Gvd4+xdboW3TegKS5TEcBCcBjQVXnKPYRWmFQCfhaVPGZ+JsBYmuhW5DSBc6sVynJOTEyktVwPHX/3qVwSoMkf/W8V8CdNmIMK6cKC+0epKhhHTpFbYQAMY1aVWtDVTo2g1hMzUN8Sn5tti5dRdoSGIGSLH7jStannguTxwm5BUDDRXYSOjEZlCWjQKeE1H1qfwsANlUaQEeSLZNoVD7AJeEMplvvCFL4jehiOPKFAxpaX+BaltYmt5utvuoAemayJTVAt1sIKzjXA0SfzTgXdpFGGIDFl01Gqg9lv8L7ZgaGsAmgDJmDdU02+UBjpbbwdNUr5p5dQzvnmZi1zVqgt/wkdP6D4dLiXQ+fnyUHN0VMATvUupIiAmZvpSUXVOUyvcWxNCkxEruYJ53IiTS6dJK45L+/uSZQekfDpWGBxaoLMpnM7w5p25ddei77YHbg2SCiSfRAGAECdgVCjiXOoTomdCKEIt0iz/gT9h7xSOtVdRN2g4+g2KhqTeYG9PQ7gW5/hCXZRCEJxMgpL4ShCQzQFokY9O0qNuYt42TYk3fdgn2aZdY8ALIMYn2bZXszMbItQRmAxWfCLm5dINiTdkrJ6ppasQUytXWBuxawdJPdGbbCf2eW9gNE+qeZKAXurKbrRTAxAMU4xFp9ZuYPFxeDg7faBGl7d++9vfpjOfkyeTnsRWvTzwnB64NUjaPIUKQgiFU0IizqW8MF0iRqeg9QwIIq290l/ka02gcRsImH73u9/9zW9+AwQFvOTLJsnsY5AfGN31flLtYv80+ItnMtGaTcTJKgkdGO2oI+FGRBBo3CG6vIm6Ic4OxNQ9ZpdmwQz0FHPBAWEepd2QTk5OTIGj5KoQ7c9//nOLqp70f/3rXwNcK6dwjYyOFZDH+QpCeZ99+lkrDZd/WDWjIzBxmGR0tU8EpLZu4DEfoXsdQ1JdVlkeuBYP3CYkLZh30fQEWbigwLiULwYU9BWlQk6hVg7lkbOX5wtgYhNvJAm4jIn2Qxq4YEvaAUYI6CFX9MKFBEgqmRrBQqM0ND5CkOMYiIC1Atq8ItO5S0DTvJpa415qgjchzIysipghOHDoBEyN5Tmw+eI79sBF+loH0EVSb6PJPx8Edm4hpuw1KM1Ux20p68c5dej7iSRJ3lPTT3kdDeoS/vKqIQjnYQm+1Ngzh3MXWlOSzUlGr3p54Hk8cJuQVMCEaCY88TDMmo6p94LfZYHq/835Yagcik5DCHKBl3Bq4wtXowNNoAAg+k0OMJ2oJqyI0j6YeulCQMlyrYojkHDE8qKBvCITvlgzrS+xOm4/XU1nmVuBm6YvGt28so3ZW4+hpwsBYpDRPcMigPuWRRUYqos9IqhX32qfiL57haqKaSLUFEbrroshdKEZgY/j9mZjUEbs5X744awhFAKE1assDzy/B24ZkoqfgqdIKHoLqiNr+KWX7mqqxFJR500ZnjdfffVVPsXUJAiTIdygmoySfK2eXi3AOS/lSV8+65J+8jT4dWMm9SGlE03AiVFoQg9JiGw3BoxKnYwCVVsfrNdevVW413TTlxcNzWZNJjIGADVMs8BBuCRg+moFE23uvO2JW2oP78I4Sg6Xuu/UPFFFfsY1VsNRiNkH7VAqVzPGrY5vW1jXqw8xhaNhEcsDV/bA0y/ilVW8mI4CQwQay7e/MEAjLhsMhfH0KhTFnmCzI+9wj8inWUIqPWwItSJKt3GbPWr8V155BZiWnArXtEl/EIazl2I4C6np0QV6KrQZ9POf/7xtZbSOFvIUQ+tFbfIzX4QS8+Wptz7JqoAMfiG0KvMxmbsp4JDUCtdc8g8BzNPp7Vqj1QpXRKgTUOvOP4g+lOHHcZND+BzZYK3Wy7llvpOo+lx0J6A1OrNXvTzwPB44/Sfpz9P/zvT1pCm2FRFrUmJbQXR57jSTKYzRQld59OiRVTnRa4MFcNS9gE+JIQS21zPbxZbDlrudq/9OMjmKN+Djm2++6aXUCMBnyw7BM7yxLZBO4UNNBLiaT3I4gh4ervA8ZFS7D7lLqZXQE9NtzBGCr3zlK9202EBJ9Z108prUi/fArclJb9o1AljEKjPQlh7mHlFsYyLIC3jH+4UoGFWkmYJZYAtmrfJNJ7csrcp2A4jpvqf2Dl8GYXkM9nG7ZZCwdWbNgXs0Tsw8Fr3jnUoOEyd6apoJqHH4XD0yQ8xYi1geuLIHngLHlVXcjY5AcCYixoY+TGyjUdIELuEmAlx6dH1mXxF+DF4f1nPrWnMvh7vNuLWwH2db4kzdBAmEgy4DyuHX99zLkSTTU78c1gdEGKcuq14eeH4PLCTd92FhuU1e9iU21xOo8VwK12kfVYl1OZKY8Uf+XhEyRKk6XOMEt5NxRV4aX80l56DVJCPOyuCk0y0KTVKZjtuPZpiIVZYHnt8DC0mf+LDg7KLwQxeNF3mZWL22YmilLluA6AH/HmagZ72XE6x1ANN23vrFLX6uCwfVcDYfniLirmw/lBFDTNm5/3QpdohOSoBRKwm6U6MOwc/atjjLA1fzwELSfb8VaXEHE/eFzlyPZAHf5QSzwC6M9RPDiibPmMp2uDNa7yYjJLUAYsPN7tyckeATjuIcAt14zD94zZP5No+pd448PTsRoYuSZHVNVmPtPtniKyetuyY4fjf9u2b1QXhgIekTrwsw4Xf8R0BYF0WXbUchihNYIAhEC2ZEe9AA9PiB7phkfjMp68h+gO9IKU7oWc1LO7+eVgnnrmjMvKoOKKuDUfXAK74uSoSDq5DU5dafLlO4ZS56eeAKHlhI+j9OO4289yFy6P+ReP9CK3Ib2LVsI1MMj0w5aVEdWNDg8r6hav4xcSmhnJR/+MEDOIJb8EEhGXTFZY4tf9ekxEm4mlhEZ6FAqktihOlBGAuBr97pOFVC5r75P9et+to9sJD0qUsnwGLtXT6V21HF5x5z7/KszJZD/70NY3gnQ/RzW/9hxYufP/7xj/OM/3ECVXvoJgDmMHHUHKUgOI2TMV2qAWjZaACqS7+MIOa9sZZf/T9tJ4W9IxGS1isNHdWgZO8jW5fLA1fzwELSq/lt9bqiBwAfFJtV44cPH/rvrf73ATClEdjBxPJQYqCz9RAQqQkIhoNoqyVq/AHT0lJdDOH9hF6/jXYg35tTvNCAcn11uaLdq9vywEEPLCQ96J7VeN0eAGclmxTDNT/PhYl+g++12bJUj/l+j+Qfh/RDUvtRNqZ0kTzCR4SSRZQg1EpgGi0DBaDe8UzSK6V1f/3118GxsZTrns3StzzwxAPr16Lrq/CiPSDr7BEeAoJISPr48eM33ngDevpnohAwvrxV6yl2bpZN0cyFiRGhJ/kKPsAl4NJ/c1J/8Ytf/OxnP+snAGBal+n4oue8xrvrHlhIetc/4ZdvfgAucIRrihSSjX6G/95774E8b9H2AieEVw56QieZMLFownpV7xQ8ecYPVeGvtVEP9YT90N6/hgbcEFn3euG/fC5ZFt16DywkvfUf4e2aALwLOsfsOGr/z9V/07Jl5JFcckrAw76XmwSg6m1H8mmAj+gKjrcjSks/8pGPOPYkG4Wh/k+UV8YQo6F6hl7E8sB1eWAh6XV5cuk5ygNnsQwH9lnKhHT++4uXE0pOIaCHfZvvWundJqTEcPArMFT2Ks91iZaBPnjwwD+FbrOe5MhnX5fRq14euC4PLCS9Lk8uPcd6YNZJrZBCTEVPUBghhXz33Xffeeed/udorzgBf705GwExQ0O4+d///hcKK3TSoLz22mteV9jvpkat1pB6+h5r65JbHjjOAwtJj/PTkrphD4DF7cO7V9z/4x//cDrKtj7cBLJaqxPrFBToBKP2rz760Y+enJw4CXD2h0wMD3lveAZL/b32wELSe/3xvzyTh6Tlm0waSPV+E3tHVk79IyYnomwlyS4JkOwdrx/60IccF7VJZSnAXlMaztZ1eXkmuyy5ex5YSHr3PtPbPSNppmdwD+Om0cM4kAWmijxUKz6shLbST1tJ8yCPLz9tiWDrggHWLXPRywPX64GFpNfrz6Xtih4AkQOCADQtiMlPt3oTAJExQW2Sw9kKL3p54AV4YCHpC3DyGuLZHgCF4eAeStYTs+KSWAWAwl9QOxD87GGWxPLAzXjg/wCrWlHADFCeBgAAAABJRU5ErkJggg==)"
+      ],
+      "metadata": {
+        "id": "I8RargmGTWN2"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class Model(nn.Module):\n",
+        "    # define nn\n",
+        "    def __init__(self):\n",
+        "        super(Model, self).__init__()\n",
+        "        self.fc1 = nn.Linear(4, 20)\n",
+        "        self.fc2 = nn.Linear(20, 20)\n",
+        "        self.fc3 = nn.Linear(20, 3)\n",
+        "        self.softmax = nn.Softmax(dim=1)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = self.fc1(x)\n",
+        "        x = self.fc2(x)\n",
+        "        x = self.fc3(x)\n",
+        "        x = self.softmax(x)\n",
+        "\n",
+        "        return x\n",
+        "\n",
+        "# Initialize Model\n",
+        "model = Model()"
+      ],
+      "metadata": {
+        "id": "dIdQ9U3yTKtP"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We will now need to split the dataset into a training set and testing set for ML. This is done fairly easily with the `train_test_split` helper function from sklearn."
+      ],
+      "metadata": {
+        "id": "SfC03XLNXDPZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_X, test_X, train_y, test_y = train_test_split(\n",
+        "    dataset[dataset.columns[0:4]].values, # use columns 0-4 as X\n",
+        "    dataset.target, # use target as y\n",
+        "    test_size=0.2 # use 20% of data for testing\n",
+        ")\n",
+        "\n",
+        "# Uncomment for sanity checks\n",
+        "# print(\"train_X: \", train_X)\n",
+        "# print(\"test_X: \", test_X)\n",
+        "print(\"train_y: \", train_y)\n",
+        "print(\"test_y: \", test_y)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "agmbEdmfUO1-",
+        "outputId": "87766edd-50db-48af-aa5d-3f4fc164f8b7"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "train_y:  104    2.0\n",
+            "57     1.0\n",
+            "58     1.0\n",
+            "5      0.0\n",
+            "77     1.0\n",
+            "      ... \n",
+            "35     0.0\n",
+            "84     1.0\n",
+            "59     1.0\n",
+            "109    2.0\n",
+            "78     1.0\n",
+            "Name: target, Length: 120, dtype: float64\n",
+            "test_y:  24     0.0\n",
+            "26     0.0\n",
+            "108    2.0\n",
+            "87     1.0\n",
+            "137    2.0\n",
+            "107    2.0\n",
+            "90     1.0\n",
+            "3      0.0\n",
+            "120    2.0\n",
+            "70     1.0\n",
+            "130    2.0\n",
+            "34     0.0\n",
+            "21     0.0\n",
+            "39     0.0\n",
+            "60     1.0\n",
+            "106    2.0\n",
+            "91     1.0\n",
+            "17     0.0\n",
+            "113    2.0\n",
+            "44     0.0\n",
+            "122    2.0\n",
+            "82     1.0\n",
+            "128    2.0\n",
+            "19     0.0\n",
+            "97     1.0\n",
+            "85     1.0\n",
+            "28     0.0\n",
+            "131    2.0\n",
+            "133    2.0\n",
+            "10     0.0\n",
+            "Name: target, dtype: float64\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can now define the parameters for training, we will use the [Cross Entropy Loss](https://machinelearningmastery.com/cross-entropy-for-machine-learning/) and [Stochastic Gradient Descent Optimizer](https://en.wikipedia.org/wiki/Stochastic_gradient_descent)."
+      ],
+      "metadata": {
+        "id": "_FrQXhAGZGS3"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# our loss function\n",
+        "loss_fn = nn.CrossEntropyLoss()\n",
+        "\n",
+        "# our optimizer\n",
+        "optimizer = torch.optim.SGD(model.parameters(), lr=0.01)\n",
+        "\n",
+        "\n",
+        "# use 800 EPOCHS\n",
+        "EPOCHS = 800\n",
+        "\n",
+        "# Convert training data to pytorch variables\n",
+        "train_X = Variable(torch.Tensor(train_X).float())\n",
+        "test_X = Variable(torch.Tensor(test_X).float())\n",
+        "train_y = Variable(torch.Tensor(train_y.values).long())\n",
+        "test_y = Variable(torch.Tensor(test_y.values).long())\n",
+        "\n",
+        "\n",
+        "loss_list     = np.zeros((EPOCHS,))\n",
+        "accuracy_list = np.zeros((EPOCHS,))\n",
+        "\n",
+        "\n",
+        "# we use tqdm for nice loading bars\n",
+        "for epoch in tqdm.trange(EPOCHS):\n",
+        "\n",
+        "    # To train, we get a prediction from the current network\n",
+        "    predicted_y = model(train_X)\n",
+        "\n",
+        "    # Compute the loss to see how bad or good we are doing\n",
+        "    loss = loss_fn(predicted_y, train_y)\n",
+        "\n",
+        "    # Append the loss to keep track of our performance\n",
+        "    loss_list[epoch] = loss.item()\n",
+        "\n",
+        "    # Afterwards, we will need to zero the gradients to reset\n",
+        "    optimizer.zero_grad()\n",
+        "    loss.backward()\n",
+        "    optimizer.step()\n",
+        "\n",
+        "    # Calculate the accuracy, call torch.no_grad() to prevent updating gradients\n",
+        "    # while calculating accuracy\n",
+        "    with torch.no_grad():\n",
+        "        y_pred = model(test_X)\n",
+        "        correct = (torch.argmax(y_pred, dim=1) == test_y).type(torch.FloatTensor)\n",
+        "        accuracy_list[epoch] = correct.mean()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9PjADXnuXbdk",
+        "outputId": "81602926-c386-4f68-a9ee-ae2d5837fe47"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 800/800 [00:00<00:00, 1687.27it/s]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot the Accuracy and Loss\n",
+        "\n",
+        "# import matplotlib\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "plt.style.use('ggplot')\n",
+        "\n",
+        "\n",
+        "fig, (ax1, ax2) = plt.subplots(2, figsize=(12, 6), sharex=True)\n",
+        "\n",
+        "ax1.plot(accuracy_list)\n",
+        "ax1.set_ylabel(\"Accuracy\")\n",
+        "ax2.plot(loss_list)\n",
+        "ax2.set_ylabel(\"Loss\")\n",
+        "ax2.set_xlabel(\"epochs\");"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 546
+        },
+        "id": "2fHJAgvwboCe",
+        "outputId": "513c73b7-2663-4bb3-f7b4-cae208940070"
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1200x600 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+0AAAIRCAYAAAA/YFzFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB12ElEQVR4nO3deXxU9b3/8fd3MklIgGQIWdkSQlhcUBAFCyggrVLldwVFi2hbpdJW6e3t7XWpO9TSW9SreC96betWWhWRilcWd1FBFEXcAgJiQJYkJCGZhLCETOb8/jjJQEzCkm3Ombyej8c8MmeZyWf4NDbvfL/ne4xlWZYAAAAAAIDjeMJdAAAAAAAAaByhHQAAAAAAhyK0AwAAAADgUIR2AAAAAAAcitAOAAAAAIBDEdoBAAAAAHAoQjsAAAAAAA5FaAcAAAAAwKEI7QAAAAAAOBShHQAAAAAAh/KGuwCnKCsrUyAQCHcZx5WSkqLi4uJwl4FjoEfuQJ/cgT65A31yB/rkDvTJ+eiROzi9T16vV926dTuxc9u4FtcIBAKqrq4OdxnHZIyRZNdqWVaYq0Fj6JE70Cd3oE/uQJ/cgT65A31yPnrkDpHWJ6bHAwAAAADgUIR2AAAAAAAcitAOAAAAAIBDEdoBAAAAAHAoQjsAAAAAAA7F6vEAAAAAgHZhBWtkLZgvq3B3m36fwG1/khTVpt+jvRDaAQAAAADtY9vXst5/q82/TbDqkBTbuc2/T3sgtAMAAAAA2oe/1P6a0Vuey37cRt/EyJuaLpXva6P3b1+EdgAAAABAu7DKj4R2M+TcNvkexhh54rtETGhnIToAAAAAQPuoHWk3id3CXIh7ENoBAAAAAO2jvMz+6ksKbx0uQmgHAAAAALQLq+6a9kRC+4kitAMAAAAA2kftNe2GkfYTRmgHAAAAALSPuunxXNN+wgjtAAAAAIA2ZwWqpcoKe4OR9hPGLd8AAAAcxCotkQ4eaN03NVL14QOyiotlWa371mhF9Mn56FHLVNSOsnu9Uueu4a3FRQjtAAAADmF9/pGC8//QJu9d2CbvitZGn5yPHrWCxCQZY8JdhWsQ2gEAABzC+uYr+0lMjBQb16rv7fF4FAwGW/U90frok/PRoxYyRmbMhHBX4SqEdgAAAKeovRWSmThVnh9OabW3NcYoIyNDBQUFspjT61j0yfnoEcKBhegAAAAcwgqtqswCTQAAG6EdAADAKepG2n3cCgkAYCO0AwAAOEVtaFdi9/DWAQBwDEI7AACAA1jVh6UDlfYGI+0AgFqOXIju1Vdf1dKlS+X3+5WZmanp06crJyen0XMDgYBeeuklvfvuuyotLVWPHj109dVXa8iQIe1bNAAAQEvUjbJ7o6X4LuGtBQDgGI4baV+zZo0WLFigKVOmaO7cucrMzNScOXNUXl7e6PkLFy7UG2+8oeuuu04PPvigfvCDH+j+++/Xtm3b2rlyAACAFqhbhM7H/YsBAEc4LrQvW7ZM48eP17hx49SrVy/NmDFDMTExWrlyZaPnr1q1SpMnT9ZZZ52ltLQ0XXjhhRo6dKiWLl3azpUDAAC0QHnd9exMjQcAHOGo6fGBQEB5eXmaNGlSaJ/H49HgwYO1ZcuWRl9TXV2tmJiYevtiYmK0efPmJs+vrq4ObRtjFBcXF3ruZHX1Ob3OjoweuQN9cgf65A706fiCH74ja/vXxz9x13ZJkvF1b/V/T/rkDvTJ+eiRO0RanxwV2isqKhQMBuXz+ert9/l8ys/Pb/Q1Z555ppYtW6ZTTjlFaWlpys3N1UcffaRgMNjo+UuWLNHixYtD23379tXcuXOVkpLSap+jraWnp4e7BBwHPXIH+uQO9Mkd6FPjasr2Kv+JByXLOuHXdMnqJ19GRpvUQ5/cgT45Hz1yh0jpk6NCe3Ncd911euyxx/Sb3/xGxhilpaVp7NixTU6nnzx5siZOnBjarvvrS3FxsQKBQLvU3FzGGKWnp6uwsFDWSfyfP9oPPXIH+uQO9Mkd6NOxWdu22IE9vrPM2IuPe76J7aQDoy/UwYKCVq2DPrkDfXI+euQObuiT1+s94YFjR4X2hIQEeTwe+f3+evv9fn+D0fejX3PLLbfo8OHDqqysVLdu3fTMM88oLS2t0fOjo6MVHR3d6DGnNvS7LMtyTa0dFT1yB/rkDvTJHehT4yz/XvtJag95Jv/4xF/XRv+W9Mkd6JPz0SN3iJQ+OWohOq/Xq+zsbOXm5ob2BYNB5ebmasCAAcd8bUxMjJKSklRTU6O1a9fq7LPPbutyAQAAjsmqu42bLym8hQAAXMtRI+2SNHHiRD3yyCPKzs5WTk6OVqxYoaqqKo0dO1aSNH/+fCUlJWnatGmSpK+//lqlpaXKyspSaWmpXnjhBVmWpUsvvTSMnwIAAECh27gZVoQHADST40L7yJEjVVFRoUWLFsnv9ysrK0u33357aHp8SUlJvVUAq6urtXDhQhUVFalTp04aOnSofvWrX6lz585h+gQAAAC1GGkHALSQ40K7JE2YMEETJkxo9NisWbPqbZ966ql66KGH2qEqAACAk2PVjrQrkdAOAGgeR13TDgAAEFFqF6IzjLQDAJqJ0A4AANBWGGkHALQQoR0AAKANWDU10r5ye8PHQnQAgOZx5DXtAAAg/Kwv1yn45DzpcNUxz9tlTETcB7f1WZJlSR6P1CUx3MUAAFyK0A4AABplfbxaqqw4/nntUIurDThdxsPkRgBA8xDaAQBAo+pWPjdXXCcz9HuNnmOMUWpqqoqKihhtb0r3lHBXAABwMUI7AABoXLl9j3HTM0smJb3RU4wx8qZnyFgeeyo4AABoVczVAgAAjfPboV3crgwAgLAhtAMAgAas6mpp/z57I5GVzwEACBdCOwAAaKh2ary8Xqlz1/DWAgBAB0ZoBwAADdUuQqfEJBljwlsLAAAdGKEdAAA0xPXsAAA4AqEdAAA0YNVNj08ktAMAEE7c8g0AAJewdnwjq2BX+3yvTV9IkgyL0AEAEFaEdgAAXMCqKFPwjzdLNYH2/cbdurfv9wMAAPUQ2gEAcIM9BXZgj4mV+g1qn+8Z31lmxNj2+V4AAKBRhHYAAFzAqlsYrk8/Rf323vAWAwAA2g0L0QEA4Aa1C8NxjTkAAB0LoR0AADfgFmwAAHRIhHYAANygvMz+yi3YAADoUAjtAAC4QOi+6Yy0AwDQoThyIbpXX31VS5culd/vV2ZmpqZPn66cnJwmz1++fLlef/11lZSUKCEhQSNGjNC0adMUExPTjlUDANCGaqfHG0I7AAAdiuNG2tesWaMFCxZoypQpmjt3rjIzMzVnzhyVl5c3ev7q1av17LPP6oorrtBDDz2kX/7yl/rggw/03HPPtXPlAAC0obqRdhaiAwCgQ3FcaF+2bJnGjx+vcePGqVevXpoxY4ZiYmK0cuXKRs/fvHmzBg4cqNGjRys1NVVnnnmmRo0apa1bt7Zz5QAAtA3rcJV0YL+9wUg7AAAdiqOmxwcCAeXl5WnSpEmhfR6PR4MHD9aWLVsafc3AgQO1atUqbd26VTk5OdqzZ48+/fRTnXfeeY2eX11drerq6tC2MUZxcXGh505WV5/T6+zI6JE70Cd3oE82q7pawYdn2RvRMTLxXRz1b0Kf3IE+uQN9cj565A6R1idHhfaKigoFg0H5fL56+30+n/Lz8xt9zejRo1VRUaG77rpLklRTU6Mf/OAHuuyyyxo9f8mSJVq8eHFou2/fvpo7d65SUlJa50O0g/T09HCXgOOgR+5An9yho/fp4Lr3VbJlgyQpOrOf0nv0CHNFjevofXIL+uQO9Mn56JE7REqfHBXam2PDhg1asmSJrr/+evXv31+FhYV66qmntHjxYk2ZMqXB+ZMnT9bEiRND23V/fSkuLlYgEGi3upvDGKP09HQVFhbKsqxwl4NG0CN3oE/uQJ9swW++PvL8l79TQUFBGKtpiD65A31yB/rkfPTIHdzQJ6/Xe8IDx44K7QkJCfJ4PPL7/fX2+/3+BqPvdZ5//nmdf/75Gj9+vCSpT58+OnTokP7yl7/osssuk8dT/7L96OhoRUdHN/peTm3od1mW5ZpaOyp65A70yR06ep/qbvVmzrtQSuzm2H+Ljt4nt6BP7kCfnI8euUOk9MlRC9F5vV5lZ2crNzc3tC8YDCo3N1cDBgxo9DVVVVUNrlX4blAHAMC1/KwaDwBAR+aokXZJmjhxoh555BFlZ2crJydHK1asUFVVlcaOHStJmj9/vpKSkjRt2jRJ0rBhw7R8+XL17ds3ND3++eef17BhwwjvAADXs8rL7CeJrBoPAEBH5LjQPnLkSFVUVGjRokXy+/3KysrS7bffHpoeX1JSUm9k/fLLL5cxRgsXLlRpaakSEhI0bNgwXXXVVWH6BAAAtKLakXbDrd4AAOiQHBfaJWnChAmaMGFCo8dmzZpVbzsqKkpXXHGFrrjiinaoDACAdsZIOwAAHVqz5o9//fXXxz8JAAC0iBUMShW1oZ2RdgAAOqRmjbTfeeedSk9P13nnnafzzjtPaWlprV0XAACorJBqaiRjpARfuKsBAABh0KzQ/q//+q9atWqV/vnPf+qFF17QgAEDdN5552nkyJHq0qVLa9cIAIBjWMGgtLdIao9byBTusr92TZSJimr77wcAABynWaF99OjRGj16tCoqKrRmzRqtXr1aTzzxhP72t7/pzDPP1Pnnn6+zzz5bXq8jL5kHAKDZrCcelPXRe+37TbndGwAAHVaLUnVCQkJo0bjCwkKtXr1aq1ev1kMPPaT4+Hide+65GjNmjAYNGtRa9QIAEFbW5lz7SUys1B63FvV4ZEZe0PbfBwAAOFKrDYXHxMQoNjZW0dHRkiRjjNatW6e3335b2dnZmjlzpnr16tVa3w4AgHZnBWukCr8kyTPnz9yGDQAAtLkWhfaDBw/qww8/1OrVq7Vx40YZYzRkyBBNmTJFw4YNk8fj0UcffaQFCxbo0Ucf1R//+MfWqhsAgPZXUS5ZQcl4pITEcFcDAAA6gGaF9o8//lirVq3S+vXrVV1drX79+umnP/2pRo0apa5du9Y799xzz1VlZaWeeOKJVikYAICwCd0z3SfjYWE4AADQ9poV2h944AF1795dl1xyicaMGaMePXoc8/ysrCydd955zSoQAADH8JfaXxOZFg8AANpHs0L73XffrdNOO+2Ez8/JyVFOTk5zvhUAAI5hldeGdq5lBwAA7aRZy96eTGAHACBi1I60G27BBgAA2kmzQvvChQt18803N3n8lltu0QsvvNDsogAAcKTQNe2MtAMAgPbRrND+4YcfaujQoU0eHzp0qNasWdPsogAAcKIj0+MZaQcAAO2jWde0l5SUKC0trcnjqampKikpaXZRaDmrcLesD1ZKwZpwl9Lh+Lt0UU1lZbjLwHHQJ3dwXJ++3SpJMondw1wIAADoKJoV2jt16qTi4uImjxcVFSk6OrrZRaHlgouekL5cF+4yOqR94S4AJ4Q+uYNj+5Tc9B+uAQAAWlOzQvupp56qN998UxdeeKGSkupf11dSUqI333yTxerCrWSPJMmccx6rHLcro85dOmt/5X5JVriLQZPokzs4tE/pPWV69gl3FQAAoINoVmifOnWqbrvtNv32t7/VBRdcoF69ekmSdu7cqZUrV8qyLP3oRz9q1UJxkmqvuzT/b6pMRu8wF9NxGGPULSNDhwoKZFkOChmohz65A30CAABoZmjv0aOHfv/73+vJJ5/U8uXL6x075ZRTdN1114WCPNqfdbhKOrDf3uC2RAAAAADgWs0K7ZKUmZmp2bNnq6KiQkVFRZLsBegSEhJarTg0U90tiWJipLjO4a0FAAAAANBszQ7tdRISEgjqTlN3S6LEJBljwlsLAAAAAKDZWhTa9+7dq23btunAgQONXm84ZsyYlrw9mst/JLQDAAAAANyrWaH98OHDeuSRR7R27dpjLg7U3ND+6quvaunSpfL7/crMzNT06dOVk5PT6LmzZs3Sxo0bG+wfOnSobrvttmZ9f7ezaqfHG65nBwAAAABXa1Zof+655/TRRx9p6tSpGjBggGbPnq2ZM2fK5/NpxYoVKisr08yZM5tV0Jo1a7RgwQLNmDFD/fv31/LlyzVnzhzNmzdPiYmJDc6/6aabFAgEQtv79u3TzTffrO9973vN+v4RoW6knVu9AQAAAICreZrzog8//FBjx47VpEmT1Lu3fTuxpKQknXHGGfrd736n+Ph4vfbaa80qaNmyZRo/frzGjRunXr16acaMGYqJidHKlSsbPb9Lly7y+XyhxxdffKHY2Fide+65zfr+EaGc6fEAAAAAEAmaNdJeUVERmq4eExMjSTp06FDo+IgRI/TPf/5TM2bMOKn3DQQCysvL06RJk0L7PB6PBg8erC1btpzQe7z99tsaOXKkOnXq1Ojx6upqVVdXh7aNMYqLiws9d7K6+o5bp792enw3FqJrbyfcI4QVfXIH+uQO9Mkd6JM70Cfno0fuEGl9alZoT0xM1L59+yRJsbGx6ty5s/Lz80PHDx48qMOHD5/0+1ZUVCgYDMrn89Xb7/P56r1/U7Zu3aqdO3fqhhtuaPKcJUuWaPHixaHtvn37au7cuUpJSTnpesMlPT39mMcLDx9StaSk3pmKy8hon6JQz/F6BGegT+5An9yBPrkDfXIH+uR89MgdIqVPzQrtOTk52rRpU2h72LBhWrp0qbp16ybLsrR8+XINGDCg1Yo8UW+//bb69OnT5KJ1kjR58mRNnDgxtF3315fi4uJ618Y7kTFG6enpKiwsPOYCgIGD+yVJpZX75SkoaK/yoBPvEcKLPrkDfXIH+uQO9Mkd6JPz0SN3cEOfvF7vCQ8cNyu0X3zxxfrggw9UXV2t6Oho/ehHP9KWLVs0f/58SVJaWpquu+66k37fhIQEeTwe+f3+evv9fn+D0ffvOnTokN5//3396Ec/OuZ50dHRio6ObvSYUxv6XZZlHbvWulkO3mjXfKZIc9wewRHokzvQJ3egT+5An9yBPjkfPXKHSOlTs0L7oEGDNGjQoNB2cnKyHnroIe3YsUMej0c9e/ZUVFTUyRfj9So7O1u5ubkaPny4JCkYDCo3N1cTJkw45ms//PBDBQIBnXfeeSf9fSNO3TX7MbHhrQMAAAAA0CInvXp8VVWVHnjgAa1atar+G3k8ysrKUp8+fZoV2OtMnDhRb731lt555x3t2rVLjz/+uKqqqjR27FhJ0vz58/Xss882eN3bb7+tc845R127dm32944Y1VX21yZmFAAAAAAA3OGkR9pjY2P15ZdfasiQIW1QjjRy5EhVVFRo0aJF8vv9ysrK0u233x6aHl9SUtJgFcD8/Hxt2rRJd955Z5vU5Dp1I+3RjLQDAAAAgJs1e3r8li1b9P3vf7+165EkTZgwocnp8LNmzWqwr0ePHlq0aFGb1OI2lmVJ1bXXtDPSDgAAAACudtLT4yVp+vTp2rRpkxYuXKi9e/e2dk1oicCRe9ArJiZ8dQAAAAAAWqxZI+0333yzampqtGTJEi1ZskRRUVGNrsj+t7/9rcUF4iTVrRwvSV5COwAAAAC4WbNC+4gRIxpcVw6HqJsa7/HIeJvVXgAAAACAQzQr1c2cObO160BrCV3Pzig7AAAAALhds65ph4MdJrQDAAAAQKRo1kj7u+++e0LnjRkzpjlvj5YIENoBAAAAIFI0K7Q/+uijJ3QeoT0MGGkHAAAAgIjRrNA+f/78BvuCwaCKi4v12muvqaSkhOvew4V7tAMAAABAxGjWNe0pKSkNHmlpaTr99NP1H//xH0pISNCrr77a2rXiRNSF9pjY8NYBAAAAAGixNlmIbtiwYfrggw/a4q1xPIy0AwAAAEDEaJPQXlhYqOrq6rZ4axyHxTXtAAAAABAxmnVN+8aNGxvdf+DAAW3cuFGvvPKKzjnnnBYVhmZi9XgAAAAAiBjNCu2zZ89u8pjH49G5556r6dOnN7sotEDtSLshtAMAAACA6zUrtN9zzz2N7u/SpYuSk5MVHx/foqLQAnWXJRDaAQAAAMD1mhXaTz311NauA62lusr+GkNoBwAAAAC3a9ZCdEVFRVq3bl2Tx9etW6eioqJmF4UWYKQdAAAAACJGs0L7ggUL9MorrzR5/LXXXtOzzz7b7KLQAtUsRAcAAAAAkaJZof3rr7/WGWec0eTxwYMH66uvvmp2UWiBw7XT4wntAAAAAOB6zQrtlZWViouLa/J4p06dVFlZ2eyi0AJMjwcAAACAiNGs0J6cnKxNmzY1efyrr75SUlJSs4tC81ksRAcAAAAAEaNZoX3UqFF6//33tWLFCgWDwdD+YDCoFStWaM2aNRo9enSrFYmTUDfS7o0Obx0AAAAAgBZr1i3fJk+erM2bN+tvf/ublixZoh49ekiS8vPzVVFRoVNPPVWXXXZZs4t69dVXtXTpUvn9fmVmZmr69OnKyclp8vz9+/frueee00cffaTKykqlpKTopz/9qc4666xm1+BadQvRxcSGtw4AAAAAQIs1K7RHR0frjjvu0Lvvvqu1a9dqz549kqR+/frp3HPP1fnnny+Pp1mD+FqzZo0WLFigGTNmqH///lq+fLnmzJmjefPmKTExscH5gUBAf/jDH5SQkKDf/va3SkpKUklJieLj45v1/V2vNrSbaEbaAQAAAMDtmhXaJcnj8WjcuHEaN25ca9ajZcuWafz48aH3nTFjhtavX6+VK1dq0qRJDc5/++23VVlZqXvvvVder/1xUlNTW7UmVzlcd8s3RtoBAAAAwO2aFdorKyu1d+9eZWZmNnp8x44dSkpKUpcuXU7qfQOBgPLy8uqFc4/Ho8GDB2vLli2NvuaTTz5R//799cQTT2jdunVKSEjQqFGjNGnSpEZH+6urq1Vdd923JGNMaCV8Y8xJ1dve6uo7Zp2BuunxMY7/PJHohHqEsKNP7kCf3IE+uQN9cgf65Hz0yB0irU/NCu1PP/20CgoKNGfOnEaP/+Uvf1HPnj11ww03nNT7VlRUKBgMyufz1dvv8/mUn5/f6Gv27Nmj4uJijR49WrfddpsKCwv1+OOPq6amRldccUWD85csWaLFixeHtvv27au5c+cqJSXlpGoNp/T09CaPFUgKSEpOS1dsRka71YT6jtUjOAd9cgf65A70yR3okzvQJ+ejR+4QKX1qVmjfsGGDfvCDHzR5fNiwYXrjjTeaXdTJsCxLCQkJ+sUvfiGPx6Ps7GyVlpbq5ZdfbjS0T548WRMnTgxt1/31pbi4WIFAoF1qbi5jjNLT01VYWCjLsho9J3DYvuXb3jK/TEFBe5YHnViPEH70yR3okzvQJ3egT+5An5yPHrmDG/rk9XpPeOC4WaG9oqJCCQkJTR7v2rWrysvLT/p9ExIS5PF45Pf76+33+/0NRt/r+Hw+eb3eelPhe/bsKb/fr0AgELrOvU50dLSim1ikzakN/S7LspquNVBjn+PxSC75PJHomD2CY9And6BP7kCf3IE+uQN9cj565A6R0qdmLfHu8/m0bdu2Jo/n5eUdM9Q3xev1Kjs7W7m5uaF9wWBQubm5GjBgQKOvGThwoAoLC+vdL76goEDdunVrENg7hKAd2hXVvNX7AQAAAADO0axkd8455+jtt9/WunXrGhz7+OOPtXLlSg0fPrxZBU2cOFFvvfWW3nnnHe3atUuPP/64qqqqNHbsWEnS/Pnz9eyzz4bOv/DCC1VZWamnn35a+fn5Wr9+vZYsWaKLLrqoWd/f9UKhvQP+wQIAAAAAIkyzkt2VV16pL7/8Uvfff7+ysrLUu3dvSdLOnTu1fft29erVS1deeWWzCho5cqQqKiq0aNEi+f1+ZWVl6fbbbw9Njy8pKam3CmBycrLuuOMO/e1vf9PNN9+spKQk/fCHP2z09nAdQk3tjANPVHjrAAAAAAC0WLNCe3x8vObMmaOXX35Za9eu1YcffihJSktL0+WXX65LL7203m3VTtaECRM0YcKERo/NmjWrwb4BAwY0uZJ9h1NTu5heI7e7AwAAAAC4S7PnUHfq1ElXXnllvRH1w4cP65NPPtHDDz+szz//XM8880yrFImTEJoez0g7AAAAALhdiy98tixLX375pVavXq2PPvpIBw8eVEJCgkaNGtUa9eFk1U2P55p2AAAAAHC9Zie7vLw8rVq1SmvWrAndom3UqFGaMGGC+vfvX++6c7QPKxiULK5pBwAAAIBIcVKhfc+ePVq1apVWr16tgoICJSUlafTo0crJydG8efM0YsSIJm/NhnZQNzVe4pZvAAAAABABTji033HHHdq6dasSEhI0YsQI/fKXv9SgQYMkSYWFhW1WIE5CzZF71TPSDgAAAADud8KhfevWrUpNTdVPfvITnXXWWYpioTPnqTfSzjXtAAAAAOB2J5zspk+frtWrV+uBBx5Qly5dNGLECI0cOVKnnXZaW9aHk8H0eAAAAACIKCcc2i+66CJddNFFKioqCl3X/tZbb8nn84WCO4vPhVndPdolyRDaAQAAAMDtTnoOdWpqqi6//HJdfvnl9VaQl6THH39cn376qc4++2wNHjxYMTExrV4wjuGo273xBxQAAAAAcL8WXficnZ2t7Oxs/fjHP1Zubm4owL/99tuKiYnR3//+99aqEyeibno8U+MBAAAAICK0ymplHo9HZ5xxhs444wzNmDFD69at0+rVq1vjrXEyampDOyvHAwAAAEBEaPUlxmNiYjRy5EiNHDmytd8ax0NoBwAAAICIwjzqSBKaHk9oBwAAAIBIQGiPJDWEdgAAAACIJIT2SBJkejwAAAAARBJCeyRhpB0AAAAAIgqhPZIQ2gEAAAAgohDaIwnT4wEAAAAgohDaIwmhHQAAAAAiCqE9kjA9HgAAAAAiCqE9khDaAQAAACCieMNdQGNeffVVLV26VH6/X5mZmZo+fbpycnIaPfedd97Ro48+Wm9fdHS0nnnmmfYo1VmYHg8AAAAAEcVxoX3NmjVasGCBZsyYof79+2v58uWaM2eO5s2bp8TExEZfExcXp4cffridK3UeqyZoP2GkHQAAAAAiguOmxy9btkzjx4/XuHHj1KtXL82YMUMxMTFauXJlk68xxsjn89V7dEihkXbHtRUAAAAA0AyOGmkPBALKy8vTpEmTQvs8Ho8GDx6sLVu2NPm6Q4cO6cYbb5RlWerbt6+uuuoq9e7du9Fzq6urVV1dHdo2xiguLi703Mnq6muqTlNTI0uSifI6/rNEquP1CM5An9yBPrkDfXIH+uQO9Mn56JE7RFqfHBXaKyoqFAwGG4yU+3w+5efnN/qaHj166IYbblBmZqYOHDigl19+WXfeeacefPBBde/evcH5S5Ys0eLFi0Pbffv21dy5c5WSktKqn6UtpaenN7q/smsXlUmKjY9XSkZG+xaFeprqEZyFPrkDfXIH+uQO9Mkd6JPz0SN3iJQ+OSq0N8eAAQM0YMCAetv//u//rjfeeENTp05tcP7kyZM1ceLE0HbdX1+Ki4sVCATavuAWMMYoPT1dhYWFsiyrwfFgWakkqao6oIKCgvYuDzp+j+AM9Mkd6JM70Cd3oE/uQJ+cjx65gxv65PV6T3jg2FGhPSEhQR6PR36/v95+v99/wtepe71e9e3bV4WFhY0ej46OVnR0dKPHnNrQ77Isq9FarZoj17S75bNEqqZ6BGehT+5An9yBPrkDfXIH+uR89MgdIqVPjlqxzOv1Kjs7W7m5uaF9wWBQubm59UbTjyUYDGrHjh3q1q1bW5XpXDW1MwWiHPW3GAAAAABAMzku3U2cOFGPPPKIsrOzlZOToxUrVqiqqkpjx46VJM2fP19JSUmaNm2aJGnx4sXq37+/0tPTtX//fr388ssqLi7W+PHjw/gpwiR0yzdH/S0GAAAAANBMjgvtI0eOVEVFhRYtWiS/36+srCzdfvvtoenxJSUl9VYBrKys1J///Gf5/X517txZ2dnZ+sMf/qBevXqF6ROEUeiWb9ynHQAAAAAigeNCuyRNmDBBEyZMaPTYrFmz6m1fe+21uvbaa9u+KDeou6Y9itAOAAAAAJGAedSRhNAOAAAAABGF0B5JmB4PAAAAABGF0B5JGGkHAAAAgIhCaI8kjLQDAAAAQEQhtEcSRtoBAAAAIKIQ2iMJI+0AAAAAEFEI7ZGEkXYAAAAAiCiE9kjCSDsAAAAARBRCeyRhpB0AAAAAIgqhPZIQ2gEAAAAgohDaI4jF9HgAAAAAiCiE9khSE7S/RtFWAAAAAIgEpLtIUhOwv0Z5w1sHAAAAAKBVENojCdPjAQAAACCiENojSbB2eryHtgIAAABAJCDdRZLa1eONl+nxAAAAABAJCO2RpO6adqbHAwAAAEBEILRHktD0eEI7AAAAAEQCQnskqZ0ezy3fAAAAACAykO4iSd3q8dzyDQAAAAAigiPT3auvvqqlS5fK7/crMzNT06dPV05OznFf9/777+vhhx/W2WefrVtuuaUdKnWYGm75BgAAAACRxHEj7WvWrNGCBQs0ZcoUzZ07V5mZmZozZ47Ky8uP+bqioiL9/e9/1ymnnNJOlToQ0+MBAAAAIKI4Lt0tW7ZM48eP17hx49SrVy/NmDFDMTExWrlyZZOvCQaD+p//+R9deeWVSk1NbcdqHSbISDsAAAAARBJHhfZAIKC8vDwNHjw4tM/j8Wjw4MHasmVLk69bvHixEhISdMEFF7RHmc7FNe0AAAAAEFEcle4qKioUDAbl8/nq7ff5fMrPz2/0NZs2bdLbb7+t++6774S+R3V1taqrq0PbxhjFxcWFnjtZXX1N1llt36fdeL2O/yyR6rg9giPQJ3egT+5An9yBPrkDfXI+euQOkdYnR4X2k3Xw4EH9z//8j37xi18oISHhhF6zZMkSLV68OLTdt29fzZ07VykpKW1VZqtLT09vsM+qCWjX/gpJUlq//opKSm7vsnCUxnoE56FP7kCf3IE+uQN9cgf65Hz0yB0ipU+OCu0JCQnyeDzy+/319vv9/gaj75K0Z88eFRcXa+7cuaF9lmVJkqZOnap58+Y1aNTkyZM1ceLE0HbdX1+Ki4sVCARa6ZO0DWOM0tPTVVhYGPqcdSz/XikYlDwe7Tl4SKagIExVdmzH6hGcgz65A31yB/rkDvTJHeiT89Ejd3BDn7xe7wkPHDsqtHu9XmVnZys3N1fDhw+XZC8yl5ubqwkTJjQ4v0ePHnrggQfq7Vu4cKEOHTqka6+9VsnJDUebo6OjFR0d3ej3d2pDv8uyrEZCe6n9JKGbZDyu+SyRqrEewXnokzvQJ3egT+5An9yBPjkfPXKHSOmTo0K7JE2cOFGPPPKIsrOzlZOToxUrVqiqqkpjx46VJM2fP19JSUmaNm2aYmJi1KdPn3qv79y5syQ12B/x6kJ7Yrfw1gEAAAAAaDWOC+0jR45URUWFFi1aJL/fr6ysLN1+++2h6fElJSURs6BAa7LKa0O7Lym8hQAAAAAAWo3jQrskTZgwodHp8JI0a9asY7525syZbVCRC9SOtJtEQjsAAAAARApH3acdLVBeZn9lpB0AAAAAIgahPUJYXNMOAAAAABGH0B4pakfaDSPtAAAAABAxHHlNOxqy1q9RzeKnlR8VpZqamoYnlBbbX7mmHQAAAAAiBqHdJaxDh6TiQjUS14+Ii5fSMtqrJAAAAABAGyO0u4QZPEye2+5X9+Rk7S0pkWVZDU9KzZDpFN/+xQEAAAAA2gSh3SVM10SZBJ9iMzJkCgqkxkI7AAAAACCisBAdAAAAAAAORWgHAAAAAMChCO0AAAAAADgUoR0AAAAAAIcitAMAAAAA4FCEdgAAAAAAHIpbvtXyet3zT+GmWjsqeuQO9Mkd6JM70Cd3oE/uQJ+cjx65g5P7dDK1Gcviht8AAAAAADgR0+Nd5ODBg7r11lt18ODBcJeCJtAjd6BP7kCf3IE+uQN9cgf65Hz0yB0irU+EdhexLEvbtm0TkyOcix65A31yB/rkDvTJHeiTO9An56NH7hBpfSK0AwAAAADgUIR2AAAAAAAcitDuItHR0ZoyZYqio6PDXQqaQI/cgT65A31yB/rkDvTJHeiT89Ejd4i0PrF6PAAAAAAADsVIOwAAAAAADkVoBwAAAADAoQjtAAAAAAA4FKEdAAAAAACHIrQDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCOwAAAAAADkVoBwAAAADAoQjtAAAAAAA4FKEdAAAAAACHIrQDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCOwAAAAAADkVoBwAAAADAoQjtAAAAAAA4FKEdAAAAAACHIrQDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCOwAAAAAADkVoBwAAAADAoQjtAAAAAAA4FKEdAAAAAACHIrQDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCOwAAAAAADkVoBwAAAADAoQjtAAAAAAA4FKEdAAAAAACH8oa7AKcoKytTIBAIdxnHlZKSouLi4nCXgWOgR+5An9yBPrkDfXIH+uQO9Mn56JE7OL1PXq9X3bp1O7Fz27gW1wgEAqqurg53GcdkjJFk12pZVpirQWPokTvQJ3egT+5An9yBPrkDfXI+euQOkdYnpscDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCu4tYh6siYiEFAAAAAMCJIbS7hLXta9XM/jftX/HPcJcCAAAAAGgnhHaXsL75StqzW/4nHpJVuDvc5QAAAAAA2gGh3SXMBRNlTjlTVlWVap54UFZNTbhLAgAAAAC0MUK7SxiPR57r/k2mcxdp2xZZr7wQ7pIAAAAAAG2M0O4iJilF3W64VZJkLV0oa/vXYa4IAAAAANCWCO0uEz92gszZo6RgUMHHH5R16EC4SwIAAAAAtBFCu8sYY+S55kbJ113as1vW3/+X28ABAAAAQIQitLuQ6ZIgz89vljweWR+9K2v1G+EuCQAAAADQBgjtLmX6nyoz6ceSJOu5v8jatS3MFQEAAAAAWhuh3cXMRZOlwWdL1YcVfOw+WQf2h7skAAAAAEArIrS7mH0buN9IScnSnt0K/vV+WUHu3w4AAAAAkYLQ7nKma4I8N94hxcRIuetl/fNv4S4JAAAAANBKvOEu4GgbN27Uyy+/rG3btqmsrEw33XSThg8f3uT5ZWVlWrBggfLy8lRYWKgf/vCHuvbaa9uvYIcwmf1krv2NrL/cJ+v1lxTskSnPqPHhLgsAAAAA0EKOGmmvqqpSVlaWfvazn53Q+dXV1UpISNBll12mzMzMNq7O2TznjJa55EpJkvWPR2Rt/jLMFQEAAAAAWspRI+1Dhw7V0KFDT/j81NRUXXfddZKklStXtlVZrmH+ZZqsgl3S+jUKPjJHnpv+KNMnO9xlAQAAAACayVGhvT1UV1eruro6tG2MUVxcXOi5k9XV11SdJipKZsZ/qOahcmnLBgUfnqWo390nk5rRnmV2aMfrEZyBPrkDfXIH+uQO9Mkd6JPz0SN3iLQ+dbjQvmTJEi1evDi03bdvX82dO1cpKSlhrOrkpKenH/N48N75Kvrdz1W97WuZ//m9Uu97XFFJye1UHaTj9wjOQJ/cgT65A31yB/rkDvTJ+eiRO0RKnzpcaJ88ebImTpwY2q7760txcbECgUC4yjohxhilp6ersLBQlmUd81xr5p3Sn25RoGCX8m++XlE3zZHxJbVTpR3XyfQI4UOf3IE+uQN9cgf65A70yfnokTu4oU9er/eEB447XGiPjo5WdHR0o8ec2tDvsizr+LUmdpPnt/cq+MDtUuEu1Txwuzz/QXBvLyfUI4QdfXIH+uQO9Mkd6JM70Cfno0fuECl9ctTq8WhdJiVdnpv+KCWlSIW7FXzgDllle8NdFgAAAADgBDkqtB86dEjbt2/X9u3bJUlFRUXavn27SkpKJEnPPvus5s+fX+81decfOnRIFRUV2r59u3bt2tXepTuWHdznSN1TpT27FZx7q6xC/n0AAAAAwA0cNT3+m2++0ezZs0PbCxYskCSNGTNGM2fOVFlZWSjA17nllltCz/Py8rR69WqlpKTokUceaZ+iXaAuuAcfukcqyldw7q3y/OvdMtkDw10aAAAAAOAYHBXaTzvtNC1atKjJ4zNnzmyw71jn4wiTnCbP7+Yq+PBs6dutCv7XnfL84haZM84Jd2kAAAAAgCY4ano82pbpmmhPlT91qHS4SsH5f1DwtRcjYnEGAAAAAIhEhPYOxnSKk+df75Q570LJsmQtflrWkw/JOlwV7tIAAAAAAN9BaO+AjDda5sczZa76ueTxyPrwHQXvv52V5QEAAADAYQjtHZQxRp4LJsrzm9lS567S9q8V/MO/y9r4WbhLAwAAAADUIrR3cOaUM+W547+knplShV/BefcouOQfsmpqwl0aAAAAAHR4hHbYt4S7/QGZ8yfY17mvWKTgA7fLKi0Od2kAAAAA0KER2iFJMjGx8vz4Rpmf3yLFxUtbv1Jw9r8p+NF7rC4PAAAAAGFCaEc9nnNGy3PXPCkzRzpQKeuvDyj457my9pWHuzQAAAAA6HAI7WjApKTL87v7ZP7fVCkqSvpkjYL3/ErWpx+GuzQAAAAA6FAI7WiU8Xrl+Zdp8tx2v9Sjj7SvXMFH/6jgEw/K2r8v3OUBAAAAQIdAaMcxmcwcee58SGbC5ZKpvaf7XTcquPZdrnUHAAAAgDZGaMdxmehoeS7/qTy3/knK6C3tK5f1+H8pOG+WrKKCcJcHAAAAABGL0I4TZvoNkufueTKTrpG80dLGTxWc9a8KrnhBVqA63OUBAAAAQMQhtOOkGG+0PJdcKc+s/5FOOVOqPixryd8V/MNvZW3dGO7yAAAAACCiENrRLCathzz//nuZ6f8udUmQdn+r4Nzf2QvV+UvDXR4AAAAARARCO5rNGCPP98bJc++jMqN/IBljL1R35w0KvvYiU+YBAAAAoIUI7Wgx0yVBnp/+qzy3PSD1HSBVHZS1+GkFZ/9aVu76cJcHAAAAAK5FaEerMX37y/O7+2Su/bXUNVEq3K3gw7NU88gcWcWF4S4PAAAAAFyH0I5WZTweeUZ9X54/PCbz/X+RPB7ps7UK3j1Twf97RlbVoXCXCAAAAACuQWhHmzDxneX50fXy3P3f0qAzpEC1rGXPK3jnLxVc85asYDDcJQIAAACA4xHa0aZMzz7y/PZeeX55q9Q9VfKXynrqYQXn/IesLbnhLg8AAAAAHI3QjjZnjJEZNspeZf7yn0qd4qQd3yh4/+2q+d//lFVUEO4SAQAAAMCRCO1oNyY6Rp4Jl8sz588yYyZIxiOt/8C+3v2FJ2UdqAx3iQAAAADgKIR2tDuT4JPnmhvluee/pdOGSjUBWa+/pOAdv1Bw5XJZNTXhLhEAAAAAHIHQjrAxPfso6jez5fm3e6SM3lLlPlnP/tm+v/uX62RZVrhLBAAAAICw8oa7AMCcPkyeU4bIeu81WS8/KxXsVPC/fy+dOkSeK6bL9MoKd4kAAAAAEBaMtMMRTFSUPOMulmfOYzIXTZa8XmnjZwr+/jcK/u1/ZJXtDXeJAAAAANDuCO1wFBPfRZ4p18kz+xFp2EjJCspa/YaCd/5CwSX/kHXwQLhLBAAAAIB2Q2iHI5nUDEX98nfy/O4+KecU6fBhWSsWHVmsLhAId4kAAAAA0OYI7XA002+QPLf8SZ4bbpPSekr7yu3F6u75laz1a1isDgAAAEBEYyE6OJ4xRjrre/KccY6s1a/Levk5qShfwf/9k9RvkDxTrpPJOSXcZQIAAABAq2OkHa5hvF55xl4szx//LHPJlVJMjPTNJgXn3qqa//2TrD354S4RAAAAAFqVo0baN27cqJdfflnbtm1TWVmZbrrpJg0fPvyYr9mwYYMWLFignTt3qnv37rr88ss1duzY9ikYYWE6xctMukbW2B/Kevk5WavflNavUfDztTLnXyQzcapMgi/cZQIAAABAizlqpL2qqkpZWVn62c9+dkLnFxUV6U9/+pNOO+003Xfffbrkkkv02GOP6bPPPmvbQuEIxtddnp/8Sp57HpYGny3V1MhaucJerG75IllVVeEuEQAAAABaxFEj7UOHDtXQoUNP+PzXX39dqamp+slPfiJJ6tWrlzZt2qTly5dryJAhbVQlnMb0zFTUr++W9dXnCi5+WtrxjayX/iHrnRUyl14tM/ICGU9UuMsEAAAAgJPmqNB+sr7++msNHjy43r4zzzxTTz/9dJOvqa6uVnV1dWjbGKO4uLjQcyerq8/pdYaLOXWIzJ0Pyvr4PQVf/Lu0t0jW3/5H1hv/J89lP5E5c3ib/9vRI3egT+5An9yBPrkDfXIH+uR89MgdIq1Prg7tfr9fiYmJ9fYlJibq4MGDOnz4sGJiYhq8ZsmSJVq8eHFou2/fvpo7d65SUlLavN7Wkp6eHu4SnK3nVbIuvkz7lr2gioVPyMrfoeD8PyjmlDPku/ZfFXv6ic/maC565A70yR3okzvQJ3egT+5An5yPHrlDpPTJ1aG9OSZPnqyJEyeGtuv++lJcXKxAIBCusk6IMUbp6ekqLCzk/uQn4nvj5TljhIKv/lPWWy/r8FdfqOjWGTKDz7ZH3nv3bfVvSY/cgT65A31yB/rkDvTJHeiT89Ejd3BDn7xe7wkPHLs6tPt8PpWXl9fbV15erri4uEZH2SUpOjpa0dHRjR5zakO/y7Is19QadvGd5bnsJ7IuuETWsudlrXpd1pfrVJP7icw558tMulompfX/AkeP3IE+uQN9cgf65A70yR3ok/PRI3eIlD45avX4k9W/f399+eWX9fZ98cUXGjBgQJgqglMZX3d5rrlRnt8/KnPOeZJlyfroXQXvukHBZx+TVV4W7hIBAAAAoAFHhfZDhw5p+/bt2r59uyT7lm7bt29XSUmJJOnZZ5/V/PnzQ+dfeOGFKioq0j/+8Q/t3r1br732mj744ANdcskl4SgfLmDSesjz85vlufMh6bShR24Td/vPFVzyD1kH9oe7RAAAAAAIcdT0+G+++UazZ88ObS9YsECSNGbMGM2cOVNlZWWhAC9Jqamp+t3vfqe//e1vWrFihbp3765f/vKX3O4Nx2Uy+ynqN7NlbfpCwRcXSNu2yFqxSNa7r8hcPEVm3CUy0Y1fYgEAAAAA7cVYkTDJvxUUFxfXuxWcExljlJGRoYKCgoi4NsMpLMuSPv1QwZf+IRXstHd2S5aZ+COZkeNlvCf+ty165A70yR3okzvQJ3egT+5An5yPHrmDG/oUHR3dMRaiA1qDMUY663vynDlc1ocrZb38rFRaIuvvj8h69Z92eB8xViYqKtylAgAAAOhgHHVNOxBOJipKnlHfl+cPj8n86GdS10SpuFDWUw8reM+vFFz7rqxgTbjLBAAAANCBENqB7zDRMfJ8/1J5/vOvMpf/VOrSVdqzW9bj/6Xg7H+T9cn7soLBcJcJAAAAoAMgtANNMLGd5JlwuR3eL71aiu8s5e9Q8LG5Ct7777I+W+vYa2QAAAAARAZCO3AcplO8PBN/ZIf3iVOlTnHSrm0KPjJHwT/eJCv3E8I7AAAAgDZBaAdOkInvIs+l0+zw/sPLpZhYafvXCj48W8G5t8rKXU94BwAAANCqCO3ASTJdEuS57Kd2eL9wkhQdI32zScGHZ6lmzn/o4Nr3CO8AAAAAWgWhHWgmk+CT54rp8vzxLzLfv1SKiZG2f62S3/9WNb9nwToAAAAALUdoB1rI+JLk+dHP5PnPx2V+OEUmLl7auc1esG7Wv3KrOAAAAADNRmgHWolJ8Cnq8p8q46mlMv9vqhTXWSrYad8q7q6ZCr7/pqxAINxlAgAAAHARQjvQyqK6Jirq0qvl+dPjMpOuse/zXpQv6+n/VvDOXyr4zgpZh6vCXSYAAAAAFyC0A23ExHeW55Ir7WnzU66TEnzS3iJZzzym4O+uV3DZ87L27wt3mQAAAAAcjNAOtDHTKU6eiybbq81P/bnUPVXaVy7r/55R8NafKfj847L2Foe7TAAAAAAO5A13AUBHYWJiZcZPlDX2h7LWrZb16ovSrm2y3nxZ1srlMuecL3PRZJleWeEuFQAAAIBDENqBdmaiomRGjJE1/Hxpw6cKvvaitOkLWR+ulPXhSun0YfJMuEwacLqMMeEuFwAAAEAYEdqBMDHGSKefpajTz5K1/WtZr74oa/0HUu4nCuZ+IvXpJzP+/8mcc55MdHS4ywUAAAAQBi0K7SUlJSopKdGgQYNC+7Zv365ly5apurpao0aN0vDhw1tcJBDpTFZ/mV/eKqsoX9brL8la87a04xtZT82T9c+nZcZeLDNmgkyCL9ylAgAAAGhHLVqI7sknn9QLL7wQ2vb7/Zo9e7bWrl2rr776Sv/1X/+ltWvXtrhIoKMwqT3kueZGeeY+KTP5x5IvSarwy3r5WXvRuqcflrVzW7jLBAAAANBOWhTav/nmGw0ePDi0/d577+nw4cO6//779dhjj2nw4MFaunRpi4sEOhrTNUGei6+wbxd3/X9IWf2lQLWs999S8Pf/ppoH7pD12VpZwZpwlwoAAACgDbVoenxlZaUSExND25988olOPfVUpaenS5KGDx+u5557rmUVAh2Y8XqPLFqXt1nWW0tlffK+tPlLBTd/KSWnyZw/QWb092W6Jh7/DQEAAAC4SotCe0JCgoqL7ftL79+/X19//bWmTZsWOh4MBhUMBltWIQB70bp+g2T6DZJVeq2slStkvfeaVLJH1ot/k/XyMzLDRsmM/aHU7xRWnQcAAAAiRItC++DBg/XKK68oPj5eGzZskGVZ9Rae27Vrl7p3797iIgEcYZJSZC7/qayJU2V9/J6sd16Rvt0qa+27sta+K/XMlBn7Q5lzx8p0ig93uQAAAABaoEWhfdq0aSooKNDf//53eb1e/fjHP1Zqaqokqbq6Wh988IFGjRrVKoUCqM/ExsqM/oE0+gf2LePeeUXWx+9Ju7+V9cxjshb/TebcMTJjfyjTq2+4ywUAAADQDC0K7T6fT/fee68OHDigmJgYeb1H3s6yLN11111KTk5ucZEAjs1k9Ze5tr+sK6bL+uBtWe++IhXulvXuq7LefVXqO8C+7v2c82XiGH0HAAAA3KJFob1OfHzDEBATE6OsrKzWeHsAJ8h07iLz/X+RNf7/SZu+UPDdV6TP1krbtsjatkXW84/b176P/oHU/zSufQcAAAAcrkWh/csvv9S2bdv0L//yL6F9b7/9tl544QUFAgGNGjVKP/nJT+TxtOjOcgBOkjFGOuVMRZ1ypqyKMlkfvCNr9RtS4S5ZH6yU9cFKKTVDZtT3ZUZeIONj7QkAAADAiVoU2l944YV609937Nihv/71r+rTp4/S09P1yiuvyOfzadKkSS2tE0AzmYRuMhdNlnXhJPu2ce+/KeujVVJRgawlf5f10jPS6WfJM+r70hnnyERHh7tkAAAAALVaFNp3796tESNGhLbfe+89xcXF6fe//71iY2P1l7/8Re+99x6hHXCAereN+9H1sta9b4++b90ofblOwS/XSfGd7enz546Tck6RYZYMAAAAEFYtCu2HDh1SXFxcaPuzzz7TkCFDFBsbK0nKycnRqlWrWlYhgFZnYjvJjBovjRovq3C3rDVvyvrwXamsRNaq12Wtel3qniozYox967iM3uEuGQAAAOiQWhTak5OT9c033+iCCy5QYWGhdu7cqYkTJ4aOV1ZWKpqptoCjmfSeMpf9VNakH0tbcmV9+I6s9WukvUWyVrwga8ULUp9+dng/5zwZX1K4SwYAAAA6jBaF9tGjR2vx4sUqLS3Vrl271LlzZ51zzjmh43l5ecrIyGhxkQDanvF4pEFnyAw6Q9a0X0hffKzgh+9IuZ9IO76RteMbWS88JQ08Xebs0TJnfU+ma2K4ywYAAAAiWotC+2WXXaZAIKBPP/1UycnJuvHGG9W5c2dJ9ij7hg0bdPHFF7dKoQDaj4mJlc4eraizR8vaVyFr3WpZa9+RvtkkbfpC1qYvZD37mDRwsB3gh35PpmtCuMsGAAAAIk6LQntUVJSuuuoqXXXVVQ2OdenSRX/9619b8vYAHMB0TZAZd7E07mJZxYWyPnlf1rr3pW+3Sl99Luurz2U987/SoDNlzh4lM/RcmS4EeAAAAKA1tCi0H+3QoUMqKSmRZF/r3qlTp2a/16uvvqqlS5fK7/crMzNT06dPV05OTqPnBgIBvfTSS3r33XdVWlqqHj166Oqrr9aQIUOa/f0BNM6kpMtMuFyacLmsooLaAL9a2pEnbfxU1sZP7QA/8Aw7vA8Zzj3gAQAAgBZocWjfunWrnnnmGW3atEnBYFCS5PF4NGjQIF1zzTXq16/fSb3fmjVrtGDBAs2YMUP9+/fX8uXLNWfOHM2bN0+JiQ2vn124cKFWrVqlX/ziF+rZs6c+//xz3X///frDH/6gvn37tvTjAWiCSc2Q+eEU6YdTZO3Jt6fQr3tf2rWtfoDvO8AO8EPPlUnvFe6yAQAAAFdpUWj/+uuvNWvWLHm9Xl1wwQXq2bOnJPv+7e+//77uuecezZo1q8lR8sYsW7ZM48eP17hx4yRJM2bM0Pr167Vy5cpG7/e+atUqTZ48WWeddZYk6cILL9QXX3yhpUuX6te//nVLPh6AE2TSeshccqV0yZWyCnfJ+nStrE8/kLZtkbZtkbVti6wXF0jpvWSGjpAZcq6U1Z/7wAMAAADH0aLQvnDhQiUlJenee++Vz+erd+yKK67QXXfdpeeee0533XXXCb1fIBBQXl5evXDu8Xg0ePBgbdmypdHXVFdXKyYmpt6+mJgYbd68ucnzq6urQ9vGmNC95o0xJ1RnuNTV5/Q6OzJ6JPue7hm9pYunyPLvlfXZR7I+/VDWpi+kwl2yXtkl65V/SolJMkNGyJw5XGbg6TKxzb+k5qRrpE+uQJ/cgT65A31yB/rkfPTIHSKtTy0eaZ8yZUqDwC5JPp9P3//+9/XPf/7zhN+voqJCwWCwwfv5fD7l5+c3+pozzzxTy5Yt0ymnnKK0tDTl5ubqo48+Ck3V/64lS5Zo8eLFoe2+fftq7ty5SklJOeE6wy09PT3cJeA46FGtjAzplNOlq6YruL9Sh9a9rwMfvqNDH6+RVV4q691XZL37ikxMrGLPOFudzhmluLNHyZves13Ko0/uQJ/cgT65A31yB/rkfPTIHSKlTy0K7cYY1dTUNHk8GAy2+V83rrvuOj322GP6zW9+I2OM0tLSNHbsWK1cubLR8ydPnqyJEyeGtuvqKy4uViAQaNNaW8oYo/T0dBUWFsqyrHCXg0bQo+MYcIY04Ax5rrpB1uYv7Gn0X34sq7REh9a9r0Pr3pdfkjJ6ywweJnPGOTI5p8h4o1u1DPrkDvTJHeiTO9And6BPzkeP3MENffJ6vSc8cNyi0D5w4EC99tprGj16dINvWFJSotdff12DBg064fdLSEiQx+OR3++vt9/v9zc6ml/3mltuuUWHDx9WZWWlunXrpmeeeUZpaWmNnh8dHa3o6MYDgFMb+l2WZbmm1o6KHh2H1ytz2lkyp50ly/qllL9D1pfrZH25Ttr6lVSwU1bBTlmvvyR1ipNOHSpz+lkypw6V6d56s2LokzvQJ3egT+5An9yBPjkfPXKHSOlTi0L7VVddpXvuuUe/+c1vNHz4cGVkZEiS8vPztW7dOnk8nkbv4d5kMV6vsrOzlZubq+HDh0uyR+tzc3M1YcKEY742JiZGSUlJCgQCWrt2rb73ve81/4MBaDfGGKlnpkzPTPtWcgcqpY2fyfpinazcT6R95dL6NbLWr5ElSWk9ZU4dInPqEGngYJm4+DB/AgAAAKDttCi09+3bV3/84x/13HPPad26dTp8+LAkO0APGTJEV1xxhbp27XpS7zlx4kQ98sgjys7OVk5OjlasWKGqqiqNHTtWkjR//nwlJSVp2rRpkuzr6ktLS5WVlaXS0lK98MILsixLl156aUs+GoAwMfFdpLNHy5w9WlYwKO34xg7wGz+1V6Pfs1vWnt2yVi6XPB4pe6DMKbUhvu8AmaiocH8EAAAAoNW0+D7tvXr10s0336xgMKiKigpJR6a5v/jii3r++ef1/PPPn/D7jRw5UhUVFVq0aJH8fr+ysrJ0++23h6bHl5SU1LtOvrq6WgsXLlRRUZE6deqkoUOH6le/+pU6d+7c0o8GIMyMx2PfGi6rv/QvV8k6sF/a/KWsjZ/J2viZVJQvbf1K1tavZC19ToqLt0ffTx0iM+hMKb1nxKwaCgAAgI6pxaG9jsfjafK685M1YcKEJqfDz5o1q972qaeeqoceeqhVvi8AZzPxnaWh58oMPVeSZJXsscP7xs/sW8rt3yd9tlbWZ2vtqfQJPpmBg6UBp8sMGmxPrSfEAwAAwEVaLbQDQHszyWky518knX+RrGCNtCPvyCj8N5ukCr+sj1dJH6+yQ3xiN5naAF89+gJZnpgwfwIAAADg2AjtACKC8UQdmUp/8RWyqg9L27bI2pwra/OXdogvL5P18SpZH69S4d8fDYV4DRws0/9UKb2XPSUfAAAAcAhCO4CIZKJj7GnxA06X/t9UO8TnbbED/JZcWXmbQyE+NBLfuavUb5BMzqky/U+RMnPs9wEAAADC5KRDe15e3gmfW1paerJvDwBtwkTHSANPlxl4uowxSu+epII17yq46UtZW3KlbZvta+K/+FjWFx/bId7rtUfvc06VyTlVyhkk0/nk7ogBAAAAtMRJh/bbbrutLeoAgHZlYmJlBg6WZ8DpkiQrEJB25sn6eqOsb76Svt5o3yO+bnV6/dN+YUZveyp9v1NksgdIqT2YUg8AAIA2c9Kh/YYbbmiLOgAgrIzXa9/nve8ASZNkWZZUXCDr66+krRtlbf1KKtwlFeyUVbBTeu81ezQ+vovUt79M9kCZvgPt510SwvxpAAAAEClOOrSPHTu2DcoAAGcxxtij6Kk9pFHjJUnWvgrpm69kbd0o65vN0rdbpQOV0oZPZW341A7xkv267AFS9kD7jwC9smS80WH7LAAAAHAvFqIDgBNkuiZIQ0bIDBkhqXZK/e5v7UXttm2WlbdF2rNbKsqXVZQvffiOHeSjY6Q+2fZIfPYAmcx+UkoG94wHAADAcRHaAaCZjNcrZfazQ/i4iyVJ1v599q3m8rbI2rZZyttij8Z/s0nWN5vscyQpvrO9On2ffjJZOVJmjpScRpAHAABAPYR2AGhFpnNX6fRhMqcPkyT72vg9+bK2bZHyNsv6dqu0c5t0YL/01eeyvvr8yLT6+C5SVo5MZj+ZzP5SVo6UlEKQBwAA6MAI7QDQhowxUnpPmfSe0vfGSaqdVp+/ww7w27faX3dtt0fkN34ma+NnR4J8l672iHztqLx697VH5FmxHgAAoEMgtANAOzNer32Ne59s6bwLJUlWdbWU/239IL/7W6lyX8OF7uLi7cXtemdLvfvaX3v0kYlmsTsAAIBIQ2gHAAcw0dGhEXWdb++zqg9Lu76V9e3X0rffyNq5Tdq9XTp4QPp6o6yvN9rnSVJUlJTe66gg39f+w0DnruH6SAAAAGgFhHYAcCgTHWPf971v/9A+KxCQCnfZAX5nXu3XbdL+ffZK9ru/lT5ceWRUPiklNBpveveVemUxvR4AAMBFCO0A4CLG67WnxvfKOnKNvGVJZSXSzm2yjg7yxYVSabFUWizr84+OBPmYWHs6fc9MqVemTM8sqWcfmYRuYfpUAAAAaAqhHQBczhhjj6gnpcicOTy03zqwX9q1vf6ofMFO6XCVtP1rWdu/ts+re0HXRKlnph3m67726CPTKa79PxQAAAAkEdoBIGKZ+M7SgNNkBpwW2mcFa6SiAnsq/a5vZe3eLu3eIRUXSPvKpU1fyNr0hX1u3YtS0u0Q36NuZD5TSu1hj/oDAACgTfEbFwB0IMZjL1in9F4yw0aF9ltVVVLBDvua+Lown79DKi+zp9kXF8r6bK19rmQvfJfaQ+rRWyajT+3X3lJaT1axBwAAaEWEdgCATGyslNVfJqt/vf3WvvIjC9yFvu6Qqg7aU+0LdsrSGvtcSTIeKTVDyuhlh/i6UJ/ey/4eAAAAOCmEdgBAk0zXRGnQGTKDzgjts4JBqWyvPTKfXxvcC3ZK+Tulg/ulPbulPbvrj8wbI3VPlTJ6y/ToLWX0qf3aS6ZTfHg+HAAAgAsQ2gEAJ8V4PFL3FKl7iszpw0L7Lcuyp9MX7KwN8ztqw/wOqXKfVLJHKtkj68t19vl1L+yWLKX3lEnvVfu1pz2Fv1ty+384AAAAhyG0AwBahTFG8iVJviSZU86sd8zaVy7l75RVsMP+WrjLHpkvL7VvV1dWIuurz+1z614UE6vCXpmqSU6X0nrY18un95LSerCiPQAA6DAI7QCANme6JkoDE2UGnl5vv7W/0h6RL9wtFe62w/ye3fbid4erVJ23RcrbcuT8uieh0fmeUlqvo0bnu9szAQAAACIEoR0AEDamcxcp51SZnFPr7bcCAZm9RepWtV+lX+XKKtxlB/rC3VJlxTFG52Ok1J4yGb2ktJ72qHxaD/sWdZ27tO+HAwAAaAWEdgCA4xivVya9p+IyMuTJHGBfL1/L2r/vyKh84W57lH7Pbvv+84cPS7u2ydq17cj5dU+6dLXDe2oPKS2j9nnt1/jO7fsBAQAAThChHQDgKqZzV6nfIJl+g+rtt2pq7MXuCnfL2lMb6PfkS0X5kr/UXgyvcrOsvM1HXlP3pGuilJpRG+hrR+bTMux9rG4PAADCiNAOAIgIJiqqdsG6HjI6p94xq+qQPRJflB8K8tYee1sVfmlfubSvXNY3m468pu5JYrcjgT41IzTdXqkZMrGd2u3zAQCAjonQDgCIeCa2k9S7r9S7r8x3jlkHD0hFBbKK8qU9+UeeFxXYYb68TCovk/X1Rvv8o1/sS7JH5VPSpZR0O8inpEspGVxDDwAAWgWhHQDQoZm4eCmzn0xmvwbHrAOVdoivDfNHRuoLpP377Gn3/lJZW3KPvKbuSXwXKSX9SKBPSbevoU9Jl3yscg8AAE4MoR0AgCaY+C5SVn+ZrP4Njln790l78mUVFdi3qCsukFVcaD8vL5MOVErfbpX17dYjr6l74o2WktPqBfm6EXolp8lER7fPBwQAAI5HaAcAoBlM565S9kCZ7IENjllVh2qDfGEoyFvFteF+b5EUqJYKd0mFu0JBPhTojZG6dben2IdG6TNkUtOl5HSm3QMA0MEQ2gEAaGUmtpPUK0vqldXwGvqaGqm0+KhAXztCX1Q7Sl91UCotkUpLZG3+8sjr6p7UTbtPTrNH65PT7Ocp6VL3FBkvo/QAAEQSR4b2V199VUuXLpXf71dmZqamT5+unJycJs9fvny5Xn/9dZWUlCghIUEjRozQtGnTFBMT045VAwBwfCYq6sg17t85ZlmWvfjdUSP0JzXt3hjJ111KTq0N9elHQn1ymuRL4lp6AABcxnGhfc2aNVqwYIFmzJih/v37a/ny5ZozZ47mzZunxMTEBuevXr1azz77rG644QYNGDBABQUFevTRR2WM0U9/+tMwfAIAAJrHGCMl+KQEX4P70EtHTbsvKZRVskcqKbK/Fhfa96g/XCWVlUhlJaHV7qWjr6X3St3Tjgr1afYU/LpQH9/FrgEAADiG40L7smXLNH78eI0bN06SNGPGDK1fv14rV67UpEmTGpy/efNmDRw4UKNHj5YkpaamatSoUfr666/bs2wAANrcMafd143Sl+w5EuT31ob6kj32lPxAQNqzW9qzu+G19JIUF2+H+pQjo/OhUfruaTKxse3yOQEAwBGOCu2BQEB5eXn1wrnH49HgwYO1ZcuWRl8zcOBArVq1Slu3blVOTo727NmjTz/9VOedd147VQ0AQPjVG6VvbHG8mhp7FL4u1JfskYr3yNpb+7y8TDp4QNq1Tdq1rfFQn9jNDvLd666nT5VJSVdANbICQSnKUb9WAAAQERz1/64VFRUKBoPy+Xz19vt8PuXn5zf6mtGjR6uiokJ33XWXJKmmpkY/+MEPdNlllzV6fnV1taqrq0PbxhjFxcWFnjtZXX1Or7Mjo0fuQJ/cgT61LuP1hq6lb4x1uKp2ur091d4q3nNUwC+0A315mVReJuubTUdeJ6lAqr2ePknqnlob6lNluqfa28lpUlIKt7ILI36e3IE+OR89codI65OjQntzbNiwQUuWLNH111+v/v37q7CwUE899ZQWL16sKVOmNDh/yZIlWrx4cWi7b9++mjt3rlJSUtqz7BZJT2/8Fy44Bz1yB/rkDvSpHWVmNbrbsiwFKytUU5ivwJ7dChTuVmBPvmr2FChQVKCaonxZVVVS2V6pbK+srV/Zr/vO+3iSkuVN7SFvWoai0nrIm5qhqNQMezslXZ7YTm37+cDPk0vQJ+ejR+4QKX1yVGhPSEiQx+OR3++vt9/v9zcYfa/z/PPP6/zzz9f48eMlSX369NGhQ4f0l7/8RZdddpk831kld/LkyZo4cWJou+6vL8XFxQoEAq33YdqAMUbp6ekqLCy0r12E49Ajd6BP7kCfHKiLz370Oy20yxijnmlpKvx6s6ziPbJKi+wR+7176n3V4SoFS0t0uLREhzd90fj7J3arHak/aoQ+OVUmKdW+nR2hvtn4eXIH+uR89Mgd3NAnr9d7wgPHjgrtXq9X2dnZys3N1fDhwyVJwWBQubm5mjBhQqOvqaqqajDt4btB/WjR0dGKbmJ6nlMb+l2WZbmm1o6KHrkDfXIH+uR8xhipa6LUJUGmb39731HHLcuSKvdJe/fYi+PtrQv2RVLtc1UdPDL9Pm+z/brvfqOuibXX1NshXt3TZJLtgK/uqYT6E8DPkzvQJ+ejR+4QKX1yVGiXpIkTJ+qRRx5Rdna2cnJytGLFClVVVWns2LGSpPnz5yspKUnTpk2TJA0bNkzLly9X3759Q9Pjn3/+eQ0bNuyY4R0AALQPO9Qn2I+s/o2vfH+g0g7ve/fIKimSSovt6+nrgv3BA/bq+PvKZW07sjhtvV/FuiTYAT659rr67imhr+qeKhMX3x4fFwCAVuW40D5y5EhVVFRo0aJF8vv9ysrK0u233x6aHl9SUlJvZP3yyy+XMUYLFy5UaWmpEhISNGzYMF111VVh+gQAAOBkGGOkzl3tR2a/BqFekqxQqD966n1xaPReB/ZLlRX249utja9+H99ZSqoN8EkpdphPSpVJSrbDfoJPhj/4AwAcxliRMF+gFRQXF9dbVd6JjDHKyMhQQUFBREzziET0yB3okzvQJ3dwSp+sA/ul0qOm3ZcUha6v194iaf++47+J1yt1S669rj6lYcDv5t4V8J3SJxwbfXI+euQObuhTdHS0O69pBwAAaA4T31mK7yv16tv4SP2hg1JpsbS3WFZpsR3kS4vt0frSIqmsVAoEpOJCqbiw3gh9g3vVJ6XUBvnaBfKOeq64zhFziyEAgDMQ2gEAQMQzneKkHn2kHn0aD/U1NZJ/rz39vjbc26G+KPRch6uOLJbX1HX1neLsAJ+UUjtanyolJYdWxFeiT8YT1dYfFwAQQQjtAACgwzNRUUdWoW/keGgF/NpRequ0SNpbUvu1NtTvK5cOHZR2fyvt/rbx0fqoKHsKfl2obyzgx8S2/QcGALgGoR0AAOA46q2A39RieVVVUlntFPza6ff1puP790o1NVLJHqlkT9NT8LsmHrmevvbaelMb7tU9RerclSn4ANCBENoBAABagYmNldJ7Sem9Gg/1wRrJXyaV1q58Hxq1L6m9tV2xfb/62lvbNbkKfmwnO8AnJdvX0yfVjtx3S65dMC9ZJjqm7T8wAKBdENoBAADagfFE1QbsZJmchsft+9Xvr10kr0jW3hJ7kbyjR+sr/FLVIalgp1Sw8/ij9bXB3nRP1YHs/rI8Xlndkrm9HQC4CKEdAADAAez71XexH32yGx+trz4slZbYi+TVfv3ucx2uajBab0nae/QbRXmlbt2PGq2vHaHvftTz+M7t8rkBAMdGaAcAAHAJEx0jpfWQ0no0vWDegUp7qn1ZyZGV8MtKFF1ZrsOFuyV/qVQTOP619XHxRxbNO3oaft3zbt1lvO68bz0AuAmhHQAAIELYo/Vd7cdRo/XGGKVlZKigoEDBQEAqLz3GaH2JtH+fdPCAdHCHlL+j8WBvjJTQ7ciU/24pUvfakfva5+qSyDR8AGghQjsAAEAHYqKiaq93T2l0tF6SrKpDdngvK65dNK/2eWlJaORe1Yft8F9eKm3b0viied7o2mn4KTK1I/X1nyfLdIpv2w8MAC5HaAcAAEA9JraTlNFLymhiJXzLkiorQiPzVt319KHnJXaYD1RLxYVScWHT0/DjOzcM891qR+y7p0iJSTJefmUF0HHxX0AAAACcFPu+9Yn2IzOn8WAfCNj3pj861JeVHLndXVmJvVp+3WPX9iam4XukxG5HFs7rlmJfT5+UbF9z3y1Z8nWzV+cHgAhEaAcAAECrM16vlJwmJac1PQ3/4IGjpt4XN1wZv6xEqgv//r1NT8P3eCRfkj1C3y35yEJ5tQFfSXW3uSPYA3AfQjsAAADCwsTFSz37SD37ND5aHwzat66rC/Zle2ufl8gqK7Gf+/dKwWBt4C9pehp+VJSUmFQ7Wl87Qv+d5+rKwnkAnIfQDgAAAEcyntqp8YndpL79mwj2NVKFv2GYL9t7VLAvlWpqjqyUf/Trj36zKK89Yt9YsK+bjt810b48AADaCaEdAAAArmU8UZKvu/3QwMaDfU2NVF5mT7cvK7Gn39cL+CX28ZqAtLdI2lvUdLD3ekPX0pu6qffdUo56nix1SSDYA2g1hHYAAABENPs2d7Wj5VLTC+fVBvujw/zRI/eqKLOvsT/eivjRMfa19I1dY1/7XJ27EuwBnBBCOwAAADo84/Xat5jrfoz71weq7an2ZXvthfNCq+OXhEbxVeG372FfVCAVFTQd7GNipLqV8LvZMwVMUrIO9s2RpShZviSusQcgidAOAAAAnBDjjT7+ivjV1XaYD03D39tgET3tK5cOH5b27Jb27K63In7J0W8W5Q3d7s74utdOy69dJd/X3R6x9yXZdQGIWIR2AAAAoJWY6GgpJV1KST9GsD9cG+Zrg71/r73t36vo/RU6vKfQnopfE2h08TzpO6P2XRNrA/2RUfvvBn3TKb5tPjCANkdoBwAAANqRiY6RUjOk1Ix6wd4Yo7SMDBUUFChYXW0H99owb5XtPep57Yr4dfex31duP3Z80/R0/Lj474T52in5R43es4Ae4EyEdgAAAMBhjNcrJaXYDzWxeJ5lSZX7aq+n3yurdlr+d0O+Dh448ijYeeyV8X11Yb422B89Yu/rLiV2s2sD0G74iQMAAABcyBgjdU2wH32ym56Of+iAVFZ6ZJS+kdF7VfjtUfuSPVLJnqaDvTFSgu/IqH3ddPy6oO9LkhKTpLh4Ru2BVkJoBwAAACKY6RQvZcRLGb2OvTJ+6JZ3tWH+u9Px/Xulunvel5dJ325tOtzHdrLDuy9JxpdUG+xrtxOT7FH8xG4yMbFt98GBCEFoBwAAADo4442WuqdK3VObDvbBoFRZHgr0Vt0ofVmJLH9pbbAvlQ7ul6oOSUX5UlH+sRfRi+9SG+Drwr0d8EPPE5PscB8V1TYfHHABQjsAAACA4zIej5TQzX5k5jQd7qsOhQK85d8rlZfW364L99WHpQOV9mP3t8efkh8auT9q1P7oUfzOXbmvPSISoR0AAABAqzGxnaS0HlJaj6aDvWVJB/bb4b18rz1SX2YH/NCofXmpPQ3/6Cn5x1oh/6j72h8Zue9+VLiv3e4Ux/X2cBVCOwAAAIB2ZYyROnexHz37HH9KfiMj9Vbddfb+UvuWd0fd117SCVxv382+vj6xdvZAYjcZX7fQlHx17kq4hyMQ2gEAAAA4Ur0p+X36HXshvQp/aMG8o6+xDwX98lJ7dP9Er7f3ekNhXondZBK7yfiSVNmnr4LyhParq49r7tGmCO0AAAAAXM14o497X3tJsqqqpHI7xFvlZbXX29tT762K2in45aVS5T77FnjfGbm3JJU1+OZG6pJw1Oj9kdF6Uxfs67ZZLR/NQGgHAAAA0CGY2FgptYeU2vT19pJkVdeO3NdeV2+Vl0rlfqmiTLGHDujQngL7WIVfCgbt6fn7yqVd25qeli9JcZ3rjdzruwHfVzs1P64zU/MRQmgHAAAAgKOY6Gipe4r90JGRe2OMUjIyVFBQIMuyZAVrpMoKe7S+oswevffXBf2yI4vplZfZq+Uf3G8/Cncde2p+dIy9Yr4vSUrw2YG+q88O9wk++1iCT0roZv8hAhGN0A4AAAAAzWA8UUeuudcxpuVblnTwQGj6fb1A768dya8b2T+w3w74e4vsh46xqJ4kdYoLBXgl+OxQn+irfd6t9nZ5tceiY1rx06O9ODK0v/rqq1q6dKn8fr8yMzM1ffp05eTkNHrurFmztHHjxgb7hw4dqttuu62tSwUAAACAYzLGSPGd7UdGr2NPzT9cdWR0vrxMVoVfqiiTKvx22K/wH3lUH5YOHbQfRQX2649+r+++eVzn2oCf2DDQ123XPkx0dCt9erSU40L7mjVrtGDBAs2YMUP9+/fX8uXLNWfOHM2bN0+JiYkNzr/pppsUCARC2/v27dPNN9+s733ve+1ZNgAAAAC0mImJlVLS7YeOM3p/6KAd7muDvVXht6+93+evfX7kmAKBI9Pz9+w+9vR8yf4DQ93ofW2wV9fEI1P066bsJyTaCwGizTgutC9btkzjx4/XuHHjJEkzZszQ+vXrtXLlSk2aNKnB+V26dKm3/f777ys2Nlbnnntue5QLAAAAAO3OGCPFxduP9J72vibOtafn769dTM9fb/T+yGj+UY+agD1N/8AJXH8v2QG/q88O9QmJMl0TjwT6o56ra6IU38W+lR9OmKNCeyAQUF5eXr1w7vF4NHjwYG3ZsuWE3uPtt9/WyJEj1alTp0aPV1dXq7q6OrRtjFFcXFzouZPV1ef0OjsyeuQO9Mkd6JM70Cd3oE/uQJ+cz609MsZInbvajx69j3muZVnS/sracN9IsD96yv6+cqmm5kjA37Pbfo+j3++738DjscN710SZo8K8qRvJ7+qTqQv4CT6Z2MZz3XE/r9zXp6Y4KrRXVFQoGAzK5/PV2+/z+ZSfn3/c12/dulU7d+7UDTfc0OQ5S5Ys0eLFi0Pbffv21dy5c5WSktLsuttbenp6uEvAcdAjd6BP7kCf3IE+uQN9cgf65Hz0yGYFgwpWVihY7ldNeamC/lLV+MsULC9Vjb92u7wstN/av8++RV7d9fpHv1cT38PEdpLHl6SoxG6Nf/V1kycxSVG+JHkSfDLeIxE3UvrkqNDeUm+//bb69OnT5KJ1kjR58mRNnDgxtF3315fi4uJ618Y7kTFG6enpKiwstP8CBsehR+5An9yBPrkDfXIH+uQO9Mn56FETvLFS9wz70YQoSVagWtpXUXvNfbm0zy9VlMvaV26P4u8rl1W7T/vKperDsqoOqWZPvmr2HH8QV5I9myAhUWl3PqDSTl0c2yev13vCA8eOCu0JCQnyeDzy+/319vv9/gaj79916NAhvf/++/rRj350zPOio6MV3cRKiE5t6HdZluWaWjsqeuQO9Mkd6JM70Cd3oE/uQJ+cjx41U5TXvve8L6ne9feNTWK3LEuqOngkwIeCfu2jwm+H/brAX7lPsoLS/n3S/n0y0TER0ydHhXav16vs7Gzl5uZq+PDhkqRgMKjc3FxNmDDhmK/98MMPFQgEdN5557VHqQAAAACANmKMkTrF249UewT/mLfKC9bUXotfLlWWy5uaLpXsbZ9i25ijQrskTZw4UY888oiys7OVk5OjFStWqKqqSmPHjpUkzZ8/X0lJSZo2bVq917399ts655xz1LVr1zBUDQAAAAAIF+OJOrLAnTEy0THhLqnVOC60jxw5UhUVFVq0aJH8fr+ysrJ0++23h6bHl5SUNFgFMD8/X5s2bdKdd94ZhooBAAAAAGgbjgvtkjRhwoQmp8PPmjWrwb4ePXpo0aJFbVwVAAAAAADti7vaAwAAAADgUIR2AAAAAAAcitAOAAAAAIBDEdoBAAAAAHAoRy5EFw5er3v+KdxUa0dFj9yBPrkDfXIH+uQO9Mkd6JPz0SN3cHKfTqY2Y1mW1Ya1AAAAAACAZmJ6vIscPHhQt956qw4ePBjuUtAEeuQO9Mkd6JM70Cd3oE/uQJ+cjx65Q6T1idDuIpZladu2bWJyhHPRI3egT+5An9yBPrkDfXIH+uR89MgdIq1PhHYAAAAAAByK0A4AAAAAgEMR2l0kOjpaU6ZMUXR0dLhLQRPokTvQJ3egT+5An9yBPrkDfXI+euQOkdYnVo8HAAAAAMChGGkHAAAAAMChCO0AAAAAADgUoR0AAAAAAIcitAMAAAAA4FDecBeAE/Pqq69q6dKl8vv9yszM1PTp05WTkxPusjqMjRs36uWXX9a2bdtUVlamm266ScOHDw8dtyxLixYt0ltvvaX9+/dr0KBBuv7665WRkRE6p7KyUk8++aQ++eQTGWM0YsQIXXfdderUqVM4PlLEWbJkiT766CPt3r1bMTExGjBggK655hr16NEjdM7hw4e1YMECrVmzRtXV1TrzzDN1/fXXy+fzhc4pKSnRX//6V23YsEGdOnXSmDFjNG3aNEVFRYXhU0We119/Xa+//rqKi4slSb169dKUKVM0dOhQSfTIiV566SU9++yzuvjii3XttddKok9OsWjRIi1evLjevh49emjevHmS6JNTlJaW6h//+Ic+++wzVVVVKT09XTfeeKP69esnid8hnGDmzJmh/1862oUXXqjrr7+enyWHCAaDWrRokVatWiW/36+kpCSNGTNGl19+uYwxkiL354nV411gzZo1mj9/vmbMmKH+/ftr+fLl+vDDDzVv3jwlJiaGu7wO4dNPP9XmzZuVnZ2tBx54oEFof+mll/TSSy9p5syZSk1N1fPPP68dO3bowQcfVExMjCTpj3/8o8rKyvTzn/9cNTU1evTRR9WvXz/927/9W7g+VkSZM2eORo0apX79+qmmpkbPPfecdu7cqQcffDD0H+G//vWvWr9+vWbOnKn4+Hg98cQT8ng8uvfeeyXZ/2dw8803y+fz6cc//rHKyso0f/58jR8/XtOmTQvnx4sY69atk8fjUUZGhizL0rvvvquXX35Z9913n3r37k2PHGbr1q166KGHFB8fr9NOOy0U2umTMyxatEhr167VXXfdFdrn8XiUkJAgiT45QWVlpW699VaddtppuvDCC5WQkKCCggKlpaUpPT1dEr9DOEFFRYWCwWBoe8eOHfrDH/6ge+65R6eddho/Sw7x4osvavny5Zo5c6Z69eqlvLw8Pfroo5o6daouvvhiSRH882TB8W677Tbr8ccfD23X1NRYP//5z60lS5aEr6gO7IorrrDWrl0b2g4Gg9aMGTOs//u//wvt279/vzVt2jRr9erVlmVZ1s6dO60rrrjC2rp1a+icTz/91LryyiutvXv3tl/xHUh5ebl1xRVXWBs2bLAsy+7J1KlTrQ8++CB0zq5du6wrrrjC2rx5s2VZlrV+/XrryiuvtMrKykLnvPbaa9ZPfvITq7q6ul3r70iuvfZa66233qJHDnPw4EHr17/+tfX5559b99xzj/XUU09ZlsXPkpM8//zz1k033dToMfrkDP/4xz+su+66q8nj/A7hTE899ZT1q1/9ygoGg/wsOch//ud/Wo8++mi9fffff7/18MMPW5YV2T9PXNPucIFAQHl5eRo8eHBon8fj0eDBg7Vly5YwVoY6RUVF8vv9OuOMM0L74uPjlZOTE+rRli1b1Llz59BUOEkaPHiwjDHaunVru9fcERw4cECS1KVLF0lSXl6eampq6v0s9ezZU8nJyfX61KdPn3rT3YYMGaKDBw9q586d7Vd8BxEMBvX++++rqqpKAwYMoEcO8/jjj2vo0KH1/tsm8bPkNIWFhfrFL36hX/3qV/rv//5vlZSUSKJPTrFu3TplZ2frwQcf1PXXX69bbrlFb775Zug4v0M4TyAQ0KpVqzRu3DgZY/hZcpABAwYoNzdX+fn5kqTt27dr8+bNoUvsIvnniWvaHa5uus7R/xGQJJ/PF/ofLMLL7/dLUoNLFRITE0PH/H5/aLpinaioKHXp0iV0DlpPMBjU008/rYEDB6pPnz6S7B54vV517ty53rnf7dN3f9bq+kqfWs+OHTt0xx13qLq6Wp06ddJNN92kXr16afv27fTIId5//31t27ZN//mf/9ngGD9LztG/f3/deOON6tGjh8rKyrR48WLdfffd+q//+i/65BBFRUV64403dMkll2jy5Mn65ptv9NRTT8nr9Wrs2LH8DuFAH330kfbv36+xY8dK4r95TjJp0iQdPHhQ//7v/y6Px6NgMKipU6fqvPPOkxTZv5MT2gFEnCeeeEI7d+7U73//+3CXgkb06NFD999/vw4cOKAPP/xQjzzyiGbPnh3uslCrpKRETz/9tO68887Q9X9wprrRJUnKzMwMhfgPPviA3jlEMBhUv379Qtc19+3bVzt27NAbb7wRCoVwlpUrV2rIkCFKSkoKdyn4jg8++ECrV6/Wr3/9a/Xu3Vvbt2/X008/rW7dukX8zxPT4x0uISFBHo+nwV9+GvuLHsKjrg/l5eX19peXl4eO+Xw+VVRU1DteU1OjyspK+tjKnnjiCa1fv1733HOPunfvHtrv8/kUCAS0f//+eud/t0/f/Vmr6yt9aj1er1fp6enKzs7WtGnTlJWVpRUrVtAjh8jLy1N5ebluvfVWTZ06VVOnTtXGjRv1yiuvaOrUqUpMTKRPDtW5c2f16NFDhYWF/Dw5RLdu3dSrV696+3r16hW6jIHfIZyluLhYX3zxhcaPHx/ax8+Sc/zjH//QpZdeqlGjRqlPnz46//zzdckll+ill16SFNk/T4R2h/N6vcrOzlZubm5oXzAYVG5urgYMGBDGylAnNTVVPp9PX375ZWjfgQMHtHXr1lCPBgwYoP379ysvLy90Tm5urizL4tZ9rcSyLD3xxBP66KOPdPfddys1NbXe8ezsbEVFRdXrU35+vkpKSur1aceOHfX+Y//FF18oLi6uwS9daD3BYFDV1dX0yCEGDx6sBx54QPfdd1/o0a9fP40ePTr0nD4506FDh0KBnZ8nZxg4cGCDyxnz8/OVkpIiid8hnGblypVKTEzUWWedFdrHz5JzVFVVyeOpH189Ho+s2puhRfLPE9PjXWDixIl65JFHlJ2drZycHK1YsUJVVVURPw3ESep+EapTVFSk7du3q0uXLkpOTtbFF1+sF198URkZGUpNTdXChQvVrVs3nXPOOZLsv6oPGTJEf/7znzVjxgwFAgE9+eSTGjlyJNOvWskTTzyh1atX65ZbblFcXFzoL97x8fGKiYlRfHy8LrjgAi1YsEBdunRRfHy8nnzySQ0YMCD0H/IzzzxTvXr10vz583X11VfL7/dr4cKFuuiiixQdHR3GTxc5nn32WQ0ZMkTJyck6dOiQVq9erY0bN+qOO+6gRw4RFxcXWguiTmxsrLp27RraT5+cYcGCBTr77LOVnJyssrIyLVq0SB6PR6NHj+bnySEuueQS3XXXXXrxxRc1cuRIbd26VW+99ZZ+/vOfS5KMMfwO4RDBYFDvvPOOxowZU+/e6vwsOcewYcP04osvKjk5ObQWzrJlyzRu3DhJkf3zxH3aXeLVV1/Vyy+/LL/fr6ysLF133XXq379/uMvqMDZs2NDoNbdjxozRzJkzZVmWFi1apDfffFMHDhzQoEGD9LOf/Uw9evQInVtZWaknnnhCn3zyiYwxGjFihKZPnx66hzha5sorr2x0/4033hj6A9fhw4e1YMECvf/++woEAjrzzDN1/fXX15sOVVxcrMcff1wbNmxQbGysxowZo6uvvrre/4Gj+f73f/9Xubm5KisrU3x8vDIzM3XppZeGVnqlR840a9YsZWVlhe7TTp+cYd68efrqq6+0b98+JSQkaNCgQZo6dWro/t/0yRk++eQTPfvssyosLFRqaqouueQSff/73w8d53cIZ/j88881Z84czZs3r96/vcTPklMcPHhQzz//vD766COVl5crKSlJo0aN0pQpU+T12mPRkfrzRGgHAAAAAMChuKYdAAAAAACHIrQDAAAAAOBQhHYAAAAAAByK0A4AAAAAgEMR2gEAAAAAcChCOwAAAAAADkVoBwAAAADAoQjtAACg3SxatEhXXnmlKioqwl0KAACuQGgHAAAAAMChCO0AAAAAADgUoR0AAAAAAIfyhrsAAADQ+kpLS7Vw4UJ9+umn2r9/v9LT0zVx4kRdcMEFkqQNGzZo9uzZ+s1vfqPt27dr5cqVOnTokE4//XT97Gc/U3Jycr33++CDD/TSSy9p165d6tSpk84880xdc801SkpKqnfe7t279fzzz2vDhg06dOiQkpOTde655+qqq66qd96BAwf097//XR9//LEsy9KIESP0s5/9TLGxsaFzvvjiC73wwgvauXOnampqlJSUpBEjRmjatGlt9K8GAIDzENoBAIgwfr9fd9xxhyTpoosuUkJCgj777DM99thjOnjwoC655JLQuS+++KKMMbr00ktVUVGh5cuX695779X999+vmJgYSdI777yjRx99VP369dO0adNUXl6uFStWaPPmzbrvvvvUuXNnSdK3336ru+++W16vV+PHj1dqaqoKCwv1ySefNAjtDz30kFJSUjRt2jTl5eXp7bffVkJCgq655hpJ0s6dO/WnP/1JmZmZuvLKKxUdHa3CwkJt3ry5Pf4JAQBwDEI7AAARZuHChQoGg3rggQfUtWtXSdKFF16oefPm6YUXXtAPfvCD0LmVlZV66KGHFBcXJ0nq27evHnroIb355pu6+OKLFQgE9Mwzz6h3796aPXt2KMgPGjRIf/rTn7R8+XJdeeWVkqQnn3xSkjR37tx6I/VXX311gxqzsrJ0ww031Ktj5cqVodD+xRdfKBAI6LbbblNCQkJr/vMAAOAqXNMOAEAEsSxLa9eu1bBhw2RZlioqKkKPIUOG6MCBA8rLywudf/7554cCuySde+656tatmz799FNJUl5ensrLy3XRRReFArsknXXWWerZs6fWr18vSaqoqNBXX32lcePGNZhab4xpUOfRfziQ7D8C7Nu3TwcOHJCk0Oj9unXrFAwGW/JPAgCAqzHSDgBABKmoqND+/fv15ptv6s0332zynLpQnJGRUe+YMUbp6ekqLi6WpNDXHj16NHifHj16aNOmTZKkPXv2SJJ69+59QnV+N9h36dJFkrR//37Fx8dr5MiReuutt/TYY4/pmWee0eDBgzV8+HCde+658ngYcwAAdByEdgAAIohlWZKk8847T2PGjGn0nMzMTO3atas9y2qgqeBdV39MTIxmz56tDRs2aP369frss8+0Zs0anX766brzzjsJ7gCADoPQDgBABElISFBcXJyCwaDOOOOMJs+rC+0FBQX19luWpcLCQvXp00eSlJKSIknKz8/X6aefXu/c/Pz80PG0tDRJ9gJyrcXj8Wjw4MEaPHiwfvrTn+rFF1/UwoULlZube8zPBgBAJOHP1AAARBCPx6MRI0Zo7dq12rFjR4PjFRUV9bbfe+89HTx4MLT94YcfqqysTEOHDpUkZWdnKzExUW+88Yaqq6tD53366afavXu3zjrrLEn2HwtOOeUUrVy5UiUlJfW+R93o+cmorKxssC8rK0uSFAgETvr9AABwK0baAQCIMNOmTdOGDRt0xx13aPz48erVq5cqKyuVl5enL7/8Uk899VTo3C5duujuu+/W2LFjVV5eruXLlys9PV3jx4+XJHm9Xl199dV69NFHNWvWLI0aNUp+v1+vvPKKUlJS6t0+7rrrrtPdd9+tW2+9NXTLt+LiYq1fv17333//SX2GxYsX66uvvtLQoUOVkpKi8vJyvf766+revbsGDRrUOv9QAAC4AKEdAIAI4/P59Mc//lGLFy/W2rVr9dprr6lr167q3bt3g9uvTZ48Wd9++61eeuklHTx4UIMHD9b111+v2NjY0Dljx45VTEyM/u///k/PPPOMYmNjdc455+iaa64JLWgn2SPhc+bM0fPPP6833nhDhw8fVkpKir73ve+d9Gc4++yzVVRUpJUrV2rfvn3q2rWrTj31VF155ZWKj49v/j8OAAAuY6zmzFkDAACutmHDBs2ePVu//e1vde6554a7HAAA0ASuaQcAAAAAwKEI7QAAAAAAOBShHQAAAAAAh+KadgAAAAAAHIqRdgAAAAAAHIrQDgAAAACAQxHaAQAAAABwKEI7AAAAAAAORWgHAAAAAMChCO0AAAAAADgUoR0AAAAAAIcitAMAAAAA4FCEdgAAAAAAHOr/A9TR24rRDSUYAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Congratulations! You've just trained a neural network\n",
+        "\n",
+        "**Exercise:** The model provided is very simplistic, what are other ways the model can be improved upon?"
+      ],
+      "metadata": {
+        "id": "djB-UtvgYbF2"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Step 2: ZK the Neural Network\n",
+        "\n",
+        "Now that we have the Neural Network trained, we can use ezkl to easily ZK our model.\n",
+        "\n",
+        "To proceed we will now need to install `ezkl`\n",
+        "\n"
+      ],
+      "metadata": {
+        "id": "JgtwrbMZcgla"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# check if notebook is in colab\n",
+        "try:\n",
+        "    import google.colab\n",
+        "    import subprocess\n",
+        "    import sys\n",
+        "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"ezkl\"])\n",
+        "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"onnx\"])\n",
+        "\n",
+        "# rely on local installation of ezkl if the notebook is not in colab\n",
+        "except:\n",
+        "    pass\n",
+        "\n",
+        "import os\n",
+        "import json\n",
+        "import ezkl"
+      ],
+      "metadata": {
+        "id": "C_YiqknhdDwN"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, we will need to export the neural network to a `.onnx` file. ezkl reads this `.onnx` file and converts it into a circuit which then allows you to generate proofs as well as verify proofs"
+      ],
+      "metadata": {
+        "id": "-b_z_d2FdVTB"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Specify all the files we need\n",
+        "\n",
+        "model_path = os.path.join('network.onnx')\n",
+        "compiled_model_path = os.path.join('network.ezkl')\n",
+        "pk_path = os.path.join('test.pk')\n",
+        "vk_path = os.path.join('test.vk')\n",
+        "settings_path = os.path.join('settings.json')\n",
+        "srs_path = os.path.join('kzg.srs')\n",
+        "witness_path = os.path.join('witness.json')\n",
+        "data_path = os.path.join('input.json')"
+      ],
+      "metadata": {
+        "id": "YeKWP0tFeCpq"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# After training, export to onnx (network.onnx) and create a data file (input.json)\n",
+        "\n",
+        "# create a random input\n",
+        "x = 0.1*torch.rand(*[1, 4], requires_grad=True)\n",
+        "\n",
+        "# Flips the neural net into inference mode\n",
+        "model.eval()\n",
+        "\n",
+        "# Export the model\n",
+        "torch.onnx.export(model,                     # model being run\n",
+        "                  x,                         # model input (or a tuple for multiple inputs)\n",
+        "                  model_path,                # where to save the model (can be a file or file-like object)\n",
+        "                  export_params=True,        # store the trained parameter weights inside the model file\n",
+        "                  opset_version=10,          # the ONNX version to export the model to\n",
+        "                  do_constant_folding=True,  # whether to execute constant folding for optimization\n",
+        "                  input_names = ['input'],   # the model's input names\n",
+        "                  output_names = ['output'], # the model's output names\n",
+        "                  dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes\n",
+        "                                'output' : {0 : 'batch_size'}})\n",
+        "\n",
+        "data_array = ((x).detach().numpy()).reshape([-1]).tolist()\n",
+        "\n",
+        "data = dict(input_data = [data_array])\n",
+        "\n",
+        "    # Serialize data into file:\n",
+        "json.dump(data, open(data_path, 'w'))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "cQeNw_qndQ8g",
+        "outputId": "2d40f14e-7fbb-4377-e9ee-0e7678edb2ce"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "============= Diagnostic Run torch.onnx.export version 2.0.1+cu118 =============\n",
+            "verbose: False, log level: Level.ERROR\n",
+            "======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "After which we can proceed to generate the settings file for `ezkl` and run calibrate settings to find the optimal settings for `ezkl`"
+      ],
+      "metadata": {
+        "id": "9P4x79hIeiLO"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!RUST_LOG=trace\n",
+        "# TODO: Dictionary outputs\n",
+        "res = ezkl.gen_settings(model_path, settings_path)\n",
+        "assert res == True\n",
+        "\n",
+        "res = ezkl.calibrate_settings(data_path, model_path, settings_path, \"resources\")  # Optimize for resources"
+      ],
+      "metadata": {
+        "id": "cY25BIyreIX8"
+      },
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Next, we will compile the model. The compilation step allow us to generate proofs faster."
+      ],
+      "metadata": {
+        "id": "MFmPMBQ1jYao"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "res = ezkl.compile_model(model_path, compiled_model_path, settings_path)\n",
+        "assert res == True"
+      ],
+      "metadata": {
+        "id": "De5XtpGUerkZ"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Before we can setup the circuit params, we need a SRS (Structured Reference String). The SRS is used to generate the proofs."
+      ],
+      "metadata": {
+        "id": "UbkuSVKljmhA"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "res = ezkl.get_srs(srs_path, settings_path)"
+      ],
+      "metadata": {
+        "id": "amaTcWG6f2GI"
+      },
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now run setup, this will generate a proving key (pk) and verification key (vk). The proving key is used for proving while the verification key is used for verificaton."
+      ],
+      "metadata": {
+        "id": "Y92p3GhVj1Jd"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "res = ezkl.setup(\n",
+        "        compiled_model_path,\n",
+        "        vk_path,\n",
+        "        pk_path,\n",
+        "        srs_path,\n",
+        "        settings_path,\n",
+        "    )\n",
+        "\n",
+        "assert res == True\n",
+        "assert os.path.isfile(vk_path)\n",
+        "assert os.path.isfile(pk_path)\n",
+        "assert os.path.isfile(settings_path)"
+      ],
+      "metadata": {
+        "id": "fdsteit9jzfK"
+      },
+      "execution_count": 14,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Now, we can generate a proof and verify the proof as a sanity check. We will use the \"evm\" transcript. This will allow us to provide proofs to the EVM."
+      ],
+      "metadata": {
+        "id": "QYlqpP3jkExm"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Generate the Witness for the proof\n",
+        "\n",
+        "# now generate the witness file\n",
+        "witness_path = os.path.join('witness.json')\n",
+        "\n",
+        "res = ezkl.gen_witness(data_path, compiled_model_path, witness_path, settings_path = settings_path)\n",
+        "assert os.path.isfile(witness_path)"
+      ],
+      "metadata": {
+        "id": "yoz5Vks5kaHI"
+      },
+      "execution_count": 15,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Generate the proof\n",
+        "\n",
+        "proof_path = os.path.join('proof.json')\n",
+        "\n",
+        "res = ezkl.prove(\n",
+        "        witness_path,\n",
+        "        compiled_model_path,\n",
+        "        pk_path,\n",
+        "        proof_path,\n",
+        "        srs_path,\n",
+        "        \"evm\",\n",
+        "        \"single\",\n",
+        "        settings_path,\n",
+        "    )\n",
+        "\n",
+        "print(res)\n",
+        "assert os.path.isfile(proof_path)"
+      ],
+      "metadata": {
+        "id": "eKkFBZX1kBdE",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "48c67e19-a491-4515-f09c-a560df8c3834"
+      },
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "{'instances': [[[0, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0]], [[50, 0, 0, 0], [105, 0, 0, 0], [110, 0, 0, 0]]], 'proof': '2c316c4cd64dba12f3f47010faaed17c4ce5a7a33527b22e678a0a1483daf4eb1cee7893eef9a56d471ad59c7d801a6fa164f46e74c2842c3e0266509c93d5fe16c879373700b05356d0b5ba8b169da5ce2267c0990053ac2bd0015ea1a2f3dc2a6e7e5a3dcf82cc49b986b61e739d9e08dd7ad368db62c1c418ae52b58c8b8315cbdc371cdab4556c0bb331048d48dfa821a16d1698a919166263748f23c58828c2b219585fddc09dc86bff6c5ee25104c46925f7350c707d24a79a589fa4622bde8eee1b65ebe9efbed056ea95ce1fe0ee9335d0181b64baf67030759fe8c3197cf5870465884e9b0f1ab7a0ad9c7ee5898120db6fc27c8f97db7cf125c4b903a4665accf44e9852f4f2a4a3e3f131e2d0ae410ce7a0cb090d1f60f106848d0cecbe4b776ba6f21a709a1831a0b7409fb0045ddb4c9e9dbb08b518253536c217161564a1e176e051d78e9950c59003969012d5acad592d42b31e239dbaa3531b5eefc2eae68e96aa924c0600ff27a9aa498aeaaa376cad6c5d1eb5689c2e932b8785f4e98d2e9960f5ec61fd6c3e2a48a640a419d3dba77e05888b8409fc7c18e306e18229e533eea4c86b2b02631683035fcd640908e0845cc74b8d5e43231b9f9983dc3a71462b672a64d21738c0e0306c133c5c95312348d12325e721dc0ac18ce3206f1d41af04f337df75169617e2be039c540551e394eedabe7161860ba8aff85a332635fbc1f725a2b42ddad2a6ccd8c8667aa2096903036b3f18b0126669aed158e7ee478bf6d72df0ae9fe79d1968da12fd40f45d3e70beba395526e291c5abefaab10ec6487c687e1de15de9e2b9ccc0fa76ff5def671cf0d8022bc293e1902db45ac1373ba9865c4fd4618da21c097d2bf0b630f148ceb3dfa81c272d1ad3a94249cc47bab06bdf1d352bc53a4eab5a41f15fc08fc11b79ab5116e3649ab2c3873942485963582fbcafb055fba4a5ddd292171986c9c15c804f2ade91eeeecf8fb769f2ec0831828b97ecada178c4e14379c89cf5a99b8f6cf6274f67a36b82d55d99cd8df0530eb3cdd96decf2516fd64aea1dd5ee0dd93d53263ecc55a800defdd44dc9a7499a1c36dff53cb08c5c8716a22116b3c8b0391f22a5bceaed43546705ecf0056acfc2512ef03e9900322b638ba6893a00621924100022097218adae69de31361a7d38686569c47d97aa1ff8cfa85e0bbece46c01336a550107ed4adccc166ce0d95748a5b6d10e21bc52e5eabd113d4064c29930942a5d01ce0011edcc448414fa18fe169b9a2b671d90637afd7ce90a09661862a00598dbaa96c6b5dd58595eef038798cc7b3556edfe69102955c9164f815a11c8ce9243d9fa8211622833a0a8d1f1c484071786791581c6c46b9b7ccbf2a010338ab4a58b3650bea04b18d5749967c6e955ca8e8fdbb05126005986c81e33f091e3d5c48b9ef229a89a2132765c46bd8788ad6dd0dd946dc81765b508d5b10303a1b8ac64dca488fe9a5c9738b2027a7b1135eaeffea4f940fed518ab02cd22cc2a0a8a7faec2433bd20bb38a1dc149686d548716246eb91cf3510a20d131602592a94ace49c1628b76429c03bbd77743060c67fb725eeaf907b48ffcc6a26082f9e27661453710537b936b443bc76d8591472ea756f8ba154ee15f2c4f46c2105f4b7faa7f9ad565c2a73212bd9e50ba4eb672eadb806c5905a4248c581fb2238dae00cce6505ddd69ca286e104283571d80c38e64b82dcd47cad823e4acb231d711884416867b55ce91d5776fe3bd3621f31cea3a6762f6c3fc26566fa802d57d87e064e3fc2189386cd17ddf4f2faae7bb49ad84876cb40886965e689332c452840430452d33fda6826b122a496099a6cb0538d97f0b03947a5fa1b4a88000000000000000000000000000000000000000000000000000000000000000027c883eab60834f804bf0241375eaddb5ad9d58da74f91791daf34f6c2ee55df0968b9b314e3ff1bd5e5af0ab17284ad55b6f1c61a982d817adf43cefec22ecf1dd4bc037491c48d3703675b07f787f8c017a8a2f1c113fd9a1114c74ae5f0fb19cf2f9c6b1c8ae79223935116de9c528aeb8261d1513175b3d02a45df81fed11b9943ba284db691e84b74c39919c09c43387f64cdf70d3286558047f7243e49143b366ef2572b9a534aba3982a69b2d62a76f1c447220db8f228d1c908712f60202e34ec57ba74c45022d5297ea15714caa91581bc92e2e187386ac2dafb87720694953c60c40ed3892f7c3273bf8a1c43f91546c7bdfdb4c0aa52fd50e333a0b352481d3442ed1e434f9379ea74aa7d4df6590b4909c458357e3a0416dbcca04a4287e94dc3cb38796ea94c403701f7e2d374d8c2e4afcf16d45721e464c2e00000000000000000000000000000000000000000000000000000000000000001cb3695633b8452cb4d6a67395e4659c8a3f2358eedb298e1ac98fa99e720ecb12d7eaed08d222e6a85edfb7141ee0c07d20023720397e9ec211a186d4511e39060c7f2e86654553fc57357116c328615607809caef6c853ae1695520dc6bb962e76093351140df0a27813a3bd52e58d6dc4390c6af4a1f459503f07cd7a07b82085d101be7852516a7e12082885e639f5a753c19177b4fc00d746e4fa17788c1237a3be1f74689c2349ae6dd8243353a1f1a83b98e34e245b00586feb36e3de12b68b42dec3a7e5ba6dbf17bda34eb7ceb1b2e6f6dda807d16b04055e210ef12a50e27afc043caa67102b180f80cf9798a29ec120c08c1f940f653c4ca67eba0e1edc0544dfe437cb5bede974540aeaa99bf4aa78945522deb86bc644d1e42d19d3664bce7a21f38916809211640efbb010a849933b0f480d030423b1ccd0cb2309de770a7c8c39ec8d03d4e7802c2b557b1a5f3919d2df103fbe429f1be7741cdf16d24dfe0dc0e6eda9660d80c3f0e6ea8e65c0c43c37b882b8e764ba318400cceaf1e883a61aec78636cf57970dac10169c61b56215a928d4d95d0c9df20061e5afa27afa6c973fcbff320ed98bb57a4db0b5ef588e05ad6e6a9406fa40b1f39329eb6df27520ef6089b07ddd54d918cb4eb03daf29b614da3c6462f0f77231e6a777d40717f24730ae87267dd5bc946f05f05052bbe49184366ce77ca670e2a0f22c0dbeae6d5e2c45be23f3a0296cef6fb07353d5b8143aceb4e54254c02add959205407abcbd9577af0bcb60bdd4277c508a8ba6f98dbebef92778ed01b2bb0ddd077158ebdf0510315b84423701c5f77ce7299a15729acb245d4478f2f58b102fdd896865f5ced9a65862ae2550bf26f7870222f410027d0d0c9b2f0175d1158cc08a4bdffd4aade2e5fa595d53450c8d6e6fd4482892b9a693661761a14385a5259e78d4ef31a59d16d6955abb72e5355d5c396d88f412db8e3909323e01fe838ffc5e3c00fb6e512a266d5c323b3bcd0fbd788c509d05b062a78d70f6130792aed178ae81a90355524e1401891c0754b65bb888c6e7f1b29fa79870dd01116a80dea9b50b49124f31a4bbde04c973479552e6fb3e71d9464de850216f5ba02e940a255fcb46b7269fec5d2c1308277b416aa059811fea3ac449e1c14473e8054d20dbd8ea2ba4431ed6102a50e478bb2470b8f1978dd8d8acdd9a2286156ad2b683e7e253288e5ac9bf46e3c3a00fa8a62658c8e678e2dc7957a0a0773598d3aba58c6b4436226f5ef2dfd4331a912f03e3fd879994b1e7cd21c451b78a8fef89dec609edc64e77638e70f341b98a90fdf7adb1d438c7496f9b535255e15b4ccd955dd3c5d410c269410d2bbe0c2888f8a9c7d27d6c14028cc665f27abe89e9139e6e8ed943be696b05c857268e68543b5811ef319531e6e6510d92e0d9ea7a8c0d1df7f99c0a051508df1ea89516cf961812bff0b3a09dbf28845124e0f23202bdc1e7b2957c9b71ac86cf50ee662bd4a01cc1f5b2f932e60fa4418138822bd1e812d9cf27e29e6572efc6f113bba6d23e9dd84256039464fc950', 'transcript_type': 'EVM'}\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# verify our proof\n",
+        "\n",
+        "res = ezkl.verify(\n",
+        "        proof_path,\n",
+        "        settings_path,\n",
+        "        vk_path,\n",
+        "        srs_path,\n",
+        "    )\n",
+        "\n",
+        "assert res == True\n",
+        "print(\"verified\")"
+      ],
+      "metadata": {
+        "id": "DuuH-qcOkQf1",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "375fdd63-1c0b-4c3c-eddd-f890a752923c"
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "verified\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Congratulations! You have just turned your Neural Network into a Halo2 Circuit!\n"
+      ],
+      "metadata": {
+        "id": "TOSRigalkwH-"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "\n",
+        "# Part 3: Deploying the Verifier\n",
+        "Now that we have the circuit setup, we can proceed to deploy the verifier onchain.\n",
+        "\n",
+        "We will need to setup `solc=0.8.20` for this."
+      ],
+      "metadata": {
+        "id": "flrg3NOGwsJh"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# check if notebook is in colab\n",
+        "try:\n",
+        "    import google.colab\n",
+        "    import subprocess\n",
+        "    import sys\n",
+        "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"solc-select\"])\n",
+        "    !solc-select install 0.8.20\n",
+        "    !solc-select use 0.8.20\n",
+        "    !solc --version\n",
+        "\n",
+        "# rely on local installation if the notebook is not in colab\n",
+        "except:\n",
+        "    pass"
+      ],
+      "metadata": {
+        "id": "CVqMeMYqktvl",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "60ef81a5-867e-4a27-a0a1-0a492244e7f7"
+      },
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Installing solc '0.8.20'...\n",
+            "Version '0.8.20' installed.\n",
+            "Switched global version to 0.8.20\n",
+            "solc, the solidity compiler commandline interface\n",
+            "Version: 0.8.20+commit.a1b79de6.Linux.g++\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "With solc in our environment we can now create the evm verifier."
+      ],
+      "metadata": {
+        "id": "HRHvkMjVlfWU"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "    sol_code_path = os.path.join('Verifier.sol')\n",
+        "    abi_path = os.path.join('Verifier.abi')\n",
+        "\n",
+        "    res = ezkl.create_evm_verifier(\n",
+        "        vk_path,\n",
+        "        srs_path,\n",
+        "        settings_path,\n",
+        "        sol_code_path,\n",
+        "        abi_path\n",
+        "    )\n",
+        "\n",
+        "    assert res == True\n",
+        "    assert os.path.isfile(sol_code_path)"
+      ],
+      "metadata": {
+        "id": "gYlw20VZkva7"
+      },
+      "execution_count": 19,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Get the sample inputs from the proof file\n",
+        "with open(\"proof.json\", \"r\") as f:\n",
+        "    proof = json.load(f)\n"
+      ],
+      "metadata": {
+        "id": "9iR4t-c-n09p"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "onchain_input_array = []\n",
+        "\n",
+        "for value in proof[\"instances\"]:\n",
+        "    for field_element in value:\n",
+        "        onchain_input_array.append(ezkl.vecu64_to_int(field_element))\n",
+        "# This will be the values you use onchain\n",
+        "# copy them over to remix and see if they verify\n",
+        "# What happens when you change a value?\n",
+        "print(\"pubInputs: \", onchain_input_array)\n",
+        "print(\"proof: \", \"0x\" + proof[\"proof\"])"
+      ],
+      "metadata": {
+        "id": "jQSAVMvxrBQD",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "691484fa-ef21-4b40-e179-9d2d90abd3d0"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "pubInputs:  [0, 1, 1, 1, 50, 105, 110]\n",
+            "proof:  0x2c316c4cd64dba12f3f47010faaed17c4ce5a7a33527b22e678a0a1483daf4eb1cee7893eef9a56d471ad59c7d801a6fa164f46e74c2842c3e0266509c93d5fe16c879373700b05356d0b5ba8b169da5ce2267c0990053ac2bd0015ea1a2f3dc2a6e7e5a3dcf82cc49b986b61e739d9e08dd7ad368db62c1c418ae52b58c8b8315cbdc371cdab4556c0bb331048d48dfa821a16d1698a919166263748f23c58828c2b219585fddc09dc86bff6c5ee25104c46925f7350c707d24a79a589fa4622bde8eee1b65ebe9efbed056ea95ce1fe0ee9335d0181b64baf67030759fe8c3197cf5870465884e9b0f1ab7a0ad9c7ee5898120db6fc27c8f97db7cf125c4b903a4665accf44e9852f4f2a4a3e3f131e2d0ae410ce7a0cb090d1f60f106848d0cecbe4b776ba6f21a709a1831a0b7409fb0045ddb4c9e9dbb08b518253536c217161564a1e176e051d78e9950c59003969012d5acad592d42b31e239dbaa3531b5eefc2eae68e96aa924c0600ff27a9aa498aeaaa376cad6c5d1eb5689c2e932b8785f4e98d2e9960f5ec61fd6c3e2a48a640a419d3dba77e05888b8409fc7c18e306e18229e533eea4c86b2b02631683035fcd640908e0845cc74b8d5e43231b9f9983dc3a71462b672a64d21738c0e0306c133c5c95312348d12325e721dc0ac18ce3206f1d41af04f337df75169617e2be039c540551e394eedabe7161860ba8aff85a332635fbc1f725a2b42ddad2a6ccd8c8667aa2096903036b3f18b0126669aed158e7ee478bf6d72df0ae9fe79d1968da12fd40f45d3e70beba395526e291c5abefaab10ec6487c687e1de15de9e2b9ccc0fa76ff5def671cf0d8022bc293e1902db45ac1373ba9865c4fd4618da21c097d2bf0b630f148ceb3dfa81c272d1ad3a94249cc47bab06bdf1d352bc53a4eab5a41f15fc08fc11b79ab5116e3649ab2c3873942485963582fbcafb055fba4a5ddd292171986c9c15c804f2ade91eeeecf8fb769f2ec0831828b97ecada178c4e14379c89cf5a99b8f6cf6274f67a36b82d55d99cd8df0530eb3cdd96decf2516fd64aea1dd5ee0dd93d53263ecc55a800defdd44dc9a7499a1c36dff53cb08c5c8716a22116b3c8b0391f22a5bceaed43546705ecf0056acfc2512ef03e9900322b638ba6893a00621924100022097218adae69de31361a7d38686569c47d97aa1ff8cfa85e0bbece46c01336a550107ed4adccc166ce0d95748a5b6d10e21bc52e5eabd113d4064c29930942a5d01ce0011edcc448414fa18fe169b9a2b671d90637afd7ce90a09661862a00598dbaa96c6b5dd58595eef038798cc7b3556edfe69102955c9164f815a11c8ce9243d9fa8211622833a0a8d1f1c484071786791581c6c46b9b7ccbf2a010338ab4a58b3650bea04b18d5749967c6e955ca8e8fdbb05126005986c81e33f091e3d5c48b9ef229a89a2132765c46bd8788ad6dd0dd946dc81765b508d5b10303a1b8ac64dca488fe9a5c9738b2027a7b1135eaeffea4f940fed518ab02cd22cc2a0a8a7faec2433bd20bb38a1dc149686d548716246eb91cf3510a20d131602592a94ace49c1628b76429c03bbd77743060c67fb725eeaf907b48ffcc6a26082f9e27661453710537b936b443bc76d8591472ea756f8ba154ee15f2c4f46c2105f4b7faa7f9ad565c2a73212bd9e50ba4eb672eadb806c5905a4248c581fb2238dae00cce6505ddd69ca286e104283571d80c38e64b82dcd47cad823e4acb231d711884416867b55ce91d5776fe3bd3621f31cea3a6762f6c3fc26566fa802d57d87e064e3fc2189386cd17ddf4f2faae7bb49ad84876cb40886965e689332c452840430452d33fda6826b122a496099a6cb0538d97f0b03947a5fa1b4a88000000000000000000000000000000000000000000000000000000000000000027c883eab60834f804bf0241375eaddb5ad9d58da74f91791daf34f6c2ee55df0968b9b314e3ff1bd5e5af0ab17284ad55b6f1c61a982d817adf43cefec22ecf1dd4bc037491c48d3703675b07f787f8c017a8a2f1c113fd9a1114c74ae5f0fb19cf2f9c6b1c8ae79223935116de9c528aeb8261d1513175b3d02a45df81fed11b9943ba284db691e84b74c39919c09c43387f64cdf70d3286558047f7243e49143b366ef2572b9a534aba3982a69b2d62a76f1c447220db8f228d1c908712f60202e34ec57ba74c45022d5297ea15714caa91581bc92e2e187386ac2dafb87720694953c60c40ed3892f7c3273bf8a1c43f91546c7bdfdb4c0aa52fd50e333a0b352481d3442ed1e434f9379ea74aa7d4df6590b4909c458357e3a0416dbcca04a4287e94dc3cb38796ea94c403701f7e2d374d8c2e4afcf16d45721e464c2e00000000000000000000000000000000000000000000000000000000000000001cb3695633b8452cb4d6a67395e4659c8a3f2358eedb298e1ac98fa99e720ecb12d7eaed08d222e6a85edfb7141ee0c07d20023720397e9ec211a186d4511e39060c7f2e86654553fc57357116c328615607809caef6c853ae1695520dc6bb962e76093351140df0a27813a3bd52e58d6dc4390c6af4a1f459503f07cd7a07b82085d101be7852516a7e12082885e639f5a753c19177b4fc00d746e4fa17788c1237a3be1f74689c2349ae6dd8243353a1f1a83b98e34e245b00586feb36e3de12b68b42dec3a7e5ba6dbf17bda34eb7ceb1b2e6f6dda807d16b04055e210ef12a50e27afc043caa67102b180f80cf9798a29ec120c08c1f940f653c4ca67eba0e1edc0544dfe437cb5bede974540aeaa99bf4aa78945522deb86bc644d1e42d19d3664bce7a21f38916809211640efbb010a849933b0f480d030423b1ccd0cb2309de770a7c8c39ec8d03d4e7802c2b557b1a5f3919d2df103fbe429f1be7741cdf16d24dfe0dc0e6eda9660d80c3f0e6ea8e65c0c43c37b882b8e764ba318400cceaf1e883a61aec78636cf57970dac10169c61b56215a928d4d95d0c9df20061e5afa27afa6c973fcbff320ed98bb57a4db0b5ef588e05ad6e6a9406fa40b1f39329eb6df27520ef6089b07ddd54d918cb4eb03daf29b614da3c6462f0f77231e6a777d40717f24730ae87267dd5bc946f05f05052bbe49184366ce77ca670e2a0f22c0dbeae6d5e2c45be23f3a0296cef6fb07353d5b8143aceb4e54254c02add959205407abcbd9577af0bcb60bdd4277c508a8ba6f98dbebef92778ed01b2bb0ddd077158ebdf0510315b84423701c5f77ce7299a15729acb245d4478f2f58b102fdd896865f5ced9a65862ae2550bf26f7870222f410027d0d0c9b2f0175d1158cc08a4bdffd4aade2e5fa595d53450c8d6e6fd4482892b9a693661761a14385a5259e78d4ef31a59d16d6955abb72e5355d5c396d88f412db8e3909323e01fe838ffc5e3c00fb6e512a266d5c323b3bcd0fbd788c509d05b062a78d70f6130792aed178ae81a90355524e1401891c0754b65bb888c6e7f1b29fa79870dd01116a80dea9b50b49124f31a4bbde04c973479552e6fb3e71d9464de850216f5ba02e940a255fcb46b7269fec5d2c1308277b416aa059811fea3ac449e1c14473e8054d20dbd8ea2ba4431ed6102a50e478bb2470b8f1978dd8d8acdd9a2286156ad2b683e7e253288e5ac9bf46e3c3a00fa8a62658c8e678e2dc7957a0a0773598d3aba58c6b4436226f5ef2dfd4331a912f03e3fd879994b1e7cd21c451b78a8fef89dec609edc64e77638e70f341b98a90fdf7adb1d438c7496f9b535255e15b4ccd955dd3c5d410c269410d2bbe0c2888f8a9c7d27d6c14028cc665f27abe89e9139e6e8ed943be696b05c857268e68543b5811ef319531e6e6510d92e0d9ea7a8c0d1df7f99c0a051508df1ea89516cf961812bff0b3a09dbf28845124e0f23202bdc1e7b2957c9b71ac86cf50ee662bd4a01cc1f5b2f932e60fa4418138822bd1e812d9cf27e29e6572efc6f113bba6d23e9dd84256039464fc950\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We will exit colab for the next steps. At the left of colab you can see a folder icon. Click on that.\n",
+        "\n",
+        "\n",
+        "You should see a `Verifier.sol`. Right-click and save it locally.\n",
+        "\n",
+        "Now go to [https://remix.ethereum.org](https://remix.ethereum.org).\n",
+        "\n",
+        "Create a new file within remix and copy the verifier code over.\n",
+        "\n",
+        "Finally, compile the code and deploy. For the demo you can deploy to the test environment within remix.\n",
+        "\n",
+        "If everything works, you would have deployed your verifer onchain! Copy the values in the cell above to the respective fields to test if the verifier is working.\n",
+        "\n",
+        "**Note that right now this setup accepts random values!**\n",
+        "\n",
+        "This might not be great for some applications. For that we will want to use a data attested verifier instead. [See this tutorial.](https://github.com/zkonduit/ezkl/blob/main/examples/notebooks/data_attest.ipynb)\n",
+        "\n",
+        "## Congratulations for making it this far!\n",
+        "\n",
+        "If you have followed the whole tutorial, you would have deployed a neural network inference model onchain! That's no mean feat!"
+      ],
+      "metadata": {
+        "id": "zrzPxPvZmX9b"
+      }
+    }
+  ]
+}

--- a/tests/py_integration_tests.rs
+++ b/tests/py_integration_tests.rs
@@ -105,7 +105,7 @@ mod py_tests {
         }
     }
 
-    const TESTS: [&str; 10] = [
+    const TESTS: [&str; 11] = [
         "mnist_gan.ipynb",
         // "mnist_vae.ipynb",
         "keras_simple_demo.ipynb",
@@ -117,7 +117,8 @@ mod py_tests {
         "mean_postgres.ipynb",
         "little_transformer.ipynb",
         "simple_demo_aggregated_proofs.ipynb",
-        // "lstm.ipynb"
+        // "lstm.ipynb",
+        "ezkl_demo.ipynb",
     ];
 
     macro_rules! test_func {


### PR DESCRIPTION
Changes:
1. Uses the ABCDE EZKL demo which goes through an end to end flow of training a model and deploying the model using remix
2. Updates the readme to use one-liner installation for both CLI and the Python bindings