### PR TITLE
refactor: faster filtering algorithm for null consts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,37 +18,19 @@ halo2_proofs = { git = "https://github.com/zkonduit/halo2", branch= "ac/update-h
 halo2curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", rev = "2f322219b39b67da8979bf2b014b31145e7872b0", package = "halo2curves", features = ["derive_serde"] }
 rand = { version = "0.8", default_features = false }
 itertools = { version = "0.10.3", default_features = false }
-plotters = { version = "0.3.0", default_features = false, optional = true }
 tract-onnx = { git = "https://github.com/sonos/tract/", rev= "8864e56", default_features = false, optional = true }
 clap = { version = "4.3.3", features = ["derive"]}
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 serde_json = { version = "1.0.97", default_features = false, features = ["float_roundtrip", "raw_value"], optional = true }
 log = { version = "0.4.17", default_features = false, optional = true }
-tabled = { version = "0.12.0", optional = true}
 thiserror = { version = "1.0.38", default_features = false }
 hex = { version = "0.4.3", default_features = false }
 halo2_wrong_ecc = { git = "https://github.com/zkonduit/halo2wrong", default_features = false, package = "ecc", branch = "ac/send-sync-region"}
 snark-verifier = { git = "https://github.com/zkonduit/snark-verifier", branch = "ac/send-sync-region", features=["derive_serde"]}
-
-
-regex = { version = "1", default_features = false }
-colored = { version = "2.0.0",  default_features = false, optional = true}
-env_logger = { version = "0.10.0",  default_features = false, optional = true}
-colored_json =  { version = "3.0.1",  default_features = false, optional = true}
-tokio = { version = "1.26.0",  default_features = false, features = ["macros", "rt"] }
+tabled = { version = "0.12.0", optional = true}
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-lazy_static = "1.4.0"
-
-# python binding related deps
-pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37", "macros"],  default_features = false, optional = true }
-pyo3-asyncio = { version = "0.18.0",  features = ["attributes", "tokio-runtime"],  default_features = false, optional = true }
-pyo3-log = { version = "0.8.1", default_features = false, optional = true }
-
-# Omit for the time being as ndarrays are not being used
-# numpy = { version = "0.18.0", optional = true }
-
 
 # evm related deps
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -60,6 +42,17 @@ reqwest = { version = "0.11.14", default-features = false, features = ["default-
 openssl = { version = "0.10.55", features = ["vendored"] }
 postgres = "0.19.5"
 pg_bigdecimal = "0.1.5"
+lazy_static = "1.4.0"
+env_logger = { version = "0.10.0",  default_features = false, optional = true}
+colored = { version = "2.0.0",  default_features = false, optional = true}
+colored_json =  { version = "3.0.1",  default_features = false, optional = true}
+plotters = { version = "0.3.0", default_features = false, optional = true }
+regex = { version = "1", default_features = false }
+tokio = { version = "1.26.0",  default_features = false, features = ["macros", "rt"] }
+pyo3 = { version = "0.18.3", features = ["extension-module", "abi3-py37", "macros"],  default_features = false, optional = true }
+pyo3-asyncio = { version = "0.18.0",  features = ["attributes", "tokio-runtime"],  default_features = false, optional = true }
+pyo3-log = { version = "0.8.1", default_features = false, optional = true }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.8", features = ["js"] }
@@ -71,7 +64,6 @@ wasm-bindgen-test = "0.3.34"
 serde-wasm-bindgen = "0.4"
 wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"]}
 console_error_panic_hook = "0.1.7"
-
 
 
 [dev-dependencies]

--- a/benches/accum_conv.rs
+++ b/benches/accum_conv.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
 use ezkl::pfsys::create_keys;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::srs::gen_srs;
 use ezkl::pfsys::TranscriptType;
 use ezkl::tensor::*;

--- a/benches/accum_dot.rs
+++ b/benches/accum_dot.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/accum_einsum_matmul.rs
+++ b/benches/accum_einsum_matmul.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/accum_matmul_relu.rs
+++ b/benches/accum_matmul_relu.rs
@@ -3,7 +3,7 @@ use ezkl::circuit::*;
 
 use ezkl::circuit::lookup::LookupOp;
 use ezkl::circuit::poly::PolyOp;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/accum_sum.rs
+++ b/benches/accum_sum.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/accum_sumpool.rs
+++ b/benches/accum_sumpool.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
 use ezkl::pfsys::create_keys;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::srs::gen_srs;
 use ezkl::pfsys::TranscriptType;
 use ezkl::tensor::*;

--- a/benches/elgamal.rs
+++ b/benches/elgamal.rs
@@ -5,8 +5,8 @@ use ezkl::circuit::modules::elgamal::{
 };
 use ezkl::circuit::modules::Module;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
 use ezkl::pfsys::create_keys;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::srs::gen_srs;
 use ezkl::pfsys::TranscriptType;
 use ezkl::tensor::*;

--- a/benches/pairwise_add.rs
+++ b/benches/pairwise_add.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/pairwise_pow.rs
+++ b/benches/pairwise_pow.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use ezkl::circuit::poly::PolyOp;
 use ezkl::circuit::region::RegionCtx;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/benches/poseidon.rs
+++ b/benches/poseidon.rs
@@ -3,8 +3,8 @@ use ezkl::circuit::modules::poseidon::spec::{PoseidonSpec, POSEIDON_RATE, POSEID
 use ezkl::circuit::modules::poseidon::{PoseidonChip, PoseidonConfig, NUM_INSTANCE_COLUMNS};
 use ezkl::circuit::modules::Module;
 use ezkl::circuit::*;
-use ezkl::execute::create_proof_circuit_kzg;
 use ezkl::pfsys::create_keys;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::srs::gen_srs;
 use ezkl::pfsys::TranscriptType;
 use ezkl::tensor::*;

--- a/benches/relu.rs
+++ b/benches/relu.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ezkl::circuit::region::RegionCtx;
 use ezkl::circuit::{ops::lookup::LookupOp, BaseConfig as Config, CheckMode};
-use ezkl::execute::create_proof_circuit_kzg;
+use ezkl::pfsys::create_proof_circuit_kzg;
 use ezkl::pfsys::TranscriptType;
 use ezkl::pfsys::{create_keys, srs::gen_srs};
 use ezkl::tensor::*;

--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -239,6 +239,7 @@ where
 }
 
 pub fn runconv() {
+    #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
 
     const KERNEL_HEIGHT: usize = 5;

--- a/examples/mlp_4d_einsum.rs
+++ b/examples/mlp_4d_einsum.rs
@@ -192,6 +192,7 @@ impl<const LEN: usize, const BITS: usize> Circuit<F> for MyCircuit<LEN, BITS> {
 }
 
 pub fn runmlp() {
+    #[cfg(not(target_arch = "wasm32"))]
     env_logger::init();
     // parameters
     let mut l0_kernel: Tensor<F> = Tensor::<i32>::new(

--- a/src/bin/ezkl.rs
+++ b/src/bin/ezkl.rs
@@ -1,13 +1,24 @@
+// ignore file if compiling for wasm
+
+#[cfg(not(target_arch = "wasm32"))]
 use clap::Parser;
+#[cfg(not(target_arch = "wasm32"))]
 use colored_json::ToColoredJson;
+#[cfg(not(target_arch = "wasm32"))]
 use ezkl::commands::Cli;
+#[cfg(not(target_arch = "wasm32"))]
 use ezkl::execute::run;
+#[cfg(not(target_arch = "wasm32"))]
 use ezkl::logger::init_logger;
+#[cfg(not(target_arch = "wasm32"))]
 use log::{error, info};
+#[cfg(not(target_arch = "wasm32"))]
 use rand::prelude::SliceRandom;
+#[cfg(not(target_arch = "wasm32"))]
 use std::error::Error;
 
 #[tokio::main(flavor = "current_thread")]
+#[cfg(not(target_arch = "wasm32"))]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     let args = Cli::parse();
     init_logger();
@@ -21,6 +32,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     res
 }
 
+#[cfg(target_arch = "wasm32")]
+pub fn main() {}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn banner() {
     let ell: Vec<&str> = vec![
         "for Neural Networks",

--- a/src/circuit/modules/elgamal.rs
+++ b/src/circuit/modules/elgamal.rs
@@ -919,6 +919,7 @@ mod tests {
     pub fn test_circuit_range_of_input_sizes() {
         let mut rng = test_rng();
 
+        #[cfg(not(target_arch = "wasm32"))]
         env_logger::init();
 
         //

--- a/src/circuit/modules/poseidon.rs
+++ b/src/circuit/modules/poseidon.rs
@@ -473,6 +473,7 @@ mod tests {
     fn hash_for_a_range_of_input_sizes() {
         let rng = rand::rngs::OsRng;
 
+        #[cfg(not(target_arch = "wasm32"))]
         env_logger::init();
 
         for i in [32].into_iter() {

--- a/src/circuit/ops/layouts.rs
+++ b/src/circuit/ops/layouts.rs
@@ -7,7 +7,8 @@ use std::{
 use halo2_proofs::circuit::Value;
 use halo2curves::ff::PrimeField;
 use itertools::Itertools;
-use log::error;
+use log::{debug, error, trace};
+use rayon::slice::ParallelSliceMut;
 
 use super::{
     chip::{BaseConfig, CheckMode, CircuitError},
@@ -57,14 +58,24 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
     region: &mut RegionCtx<F>,
     values: &[ValTensor<F>; 2],
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
+    // time this entire function run
+    let global_start = std::time::Instant::now();
+
     let mut values = values.clone();
 
-    let mut removal_indices: HashSet<usize> = HashSet::new();
-    removal_indices.extend(values[0].get_const_zero_indices()?);
-    removal_indices.extend(values[1].get_const_zero_indices()?);
-    let removal_indices = removal_indices.into_iter().collect_vec();
-    values[0].remove_indices(&removal_indices)?;
-    values[1].remove_indices(&removal_indices)?;
+    // this section has been optimized to death, don't mess with it
+    let mut removal_indices = values[0].get_const_zero_indices()?;
+    let second_zero_indices = values[1].get_const_zero_indices()?;
+    removal_indices.extend(second_zero_indices);
+    removal_indices.par_sort_unstable();
+    removal_indices.dedup();
+
+    // is already sorted
+    values[0].remove_indices(&mut removal_indices, true)?;
+    values[1].remove_indices(&mut removal_indices, true)?;
+
+    let elapsed = global_start.elapsed();
+    trace!("filtering const zero indices took: {:?}", elapsed);
 
     if values[0].len() != values[1].len() {
         return Err(Box::new(TensorError::DimMismatch("dot".to_string())));
@@ -81,9 +92,12 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
         region.increment(overflowed_len);
         let num_constants = values[0].num_constants() + values[1].num_constants();
         region.increment_constants(num_constants);
+        trace!("dummy dot layout took {:?}", global_start.elapsed());
+
         return Ok(Tensor::from([ValType::<F>::from(Value::<F>::unknown())].into_iter()).into());
     }
 
+    let start = std::time::Instant::now();
     let mut inputs = vec![];
     let mut assigned_len = 0;
     for (i, input) in values.iter().enumerate() {
@@ -95,16 +109,25 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
         };
         inputs.push(inp);
     }
+    let elapsed = start.elapsed();
+    trace!("assigning inputs took: {:?}", elapsed);
 
     // Now we can assign the dot product
+    // time this step
+    let start = std::time::Instant::now();
     let accumulated_dot = accumulated::dot(&[inputs[0].clone(), inputs[1].clone()])
         .expect("accum poly: dot op failed");
+    let elapsed = start.elapsed();
+    trace!("calculating accumulated dot took: {:?}", elapsed);
 
+    let start = std::time::Instant::now();
     let (output, output_assigned_len) = region.assign_with_duplication(
         &config.output,
         &accumulated_dot.into(),
         &config.check_mode,
     )?;
+    let elapsed = start.elapsed();
+    trace!("assigning output took: {:?}", elapsed);
 
     assert_eq!(assigned_len, output_assigned_len);
 
@@ -141,6 +164,10 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
 
     region.increment(assigned_len);
     // last element is the result
+
+    let elapsed = global_start.elapsed();
+    trace!("dot layout took: {:?}", elapsed);
+    trace!("----------------------------");
     Ok(last_elem)
 }
 
@@ -599,6 +626,9 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
     values: &[ValTensor<F>; 2],
     op: BaseOp,
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
+    // time to calculate the value of the output
+    let global_start = std::time::Instant::now();
+
     let (mut lhs, mut rhs) = (values[0].clone(), values[1].clone());
 
     let broadcasted_shape = get_broadcasted_shape(lhs.dims(), rhs.dims())?;
@@ -608,19 +638,16 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
     let orig_lhs = lhs.clone();
     let orig_rhs = rhs.clone();
 
-    let zero_indices_a = lhs.get_const_zero_indices()?;
-    let zero_indices_b = rhs.get_const_zero_indices()?;
-    let zero_indices = zero_indices_a
-        .iter()
-        .chain(zero_indices_b.iter())
-        .cloned()
-        .collect::<HashSet<_>>()
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>();
+    let first_zero_indices = lhs.get_const_zero_indices()?;
+    let second_zero_indices = rhs.get_const_zero_indices()?;
+    let mut removal_indices = first_zero_indices.clone();
+    removal_indices.extend(second_zero_indices.clone());
+    removal_indices.par_sort_unstable();
+    removal_indices.dedup();
 
-    lhs.remove_indices(&zero_indices)?;
-    rhs.remove_indices(&zero_indices)?;
+    // is already sorted
+    lhs.remove_indices(&mut removal_indices, true)?;
+    rhs.remove_indices(&mut removal_indices, true)?;
 
     if lhs.len() != rhs.len() {
         return Err(Box::new(CircuitError::DimMismatch(format!(
@@ -636,20 +663,29 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
         let vals = vec![ValType::Value(Value::<F>::unknown()); broadcasted_shape.iter().product()];
         let mut tensor: Tensor<ValType<F>> = Tensor::from(vals.into_iter());
         tensor.reshape(&broadcasted_shape);
+
+        trace!(
+            "dummy pairwise {} layout took {:?}",
+            op.as_str(),
+            global_start.elapsed()
+        );
+
         return Ok(tensor.into());
     }
 
     let mut inputs = vec![];
-
     for (i, input) in [lhs.clone(), rhs.clone()].iter().enumerate() {
         let inp = {
             let res = region.assign(&config.inputs[i], input)?;
+
             res.get_inner()?
         };
         inputs.push(inp);
     }
 
     // Now we can assign the dot product
+    // time the calc
+    let start = std::time::Instant::now();
     let op_result = match op {
         BaseOp::Add => add(&inputs),
         BaseOp::Sub => sub(&inputs),
@@ -660,6 +696,8 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
         error!("{}", e);
         halo2_proofs::plonk::Error::Synthesis
     })?;
+    let elapsed = start.elapsed();
+    debug!("pairwise {} calc took {:?}", op.as_str(), elapsed);
 
     let output = region.assign(&config.output, &op_result.into())?;
 
@@ -677,11 +715,11 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
     // infill the zero indices with the correct values from values[0] or values[1]
     let mut actual_output: ValTensor<F> =
         Into::<Tensor<ValType<F>>>::into((0..broadcasted_shape.iter().product()).map(|i| {
-            if zero_indices.contains(&i) {
+            if removal_indices.contains(&i) {
                 let a = orig_lhs.get_inner_tensor().unwrap()[i].clone();
                 let b = orig_rhs.get_inner_tensor().unwrap()[i].clone();
-                let a_is_null = zero_indices_a.contains(&i);
-                let b_is_null = zero_indices_b.contains(&i);
+                let a_is_null = first_zero_indices.contains(&i);
+                let b_is_null = second_zero_indices.contains(&i);
                 let both_null = a_is_null && b_is_null;
 
                 match op {
@@ -724,6 +762,9 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
         .into();
 
     actual_output.reshape(&broadcasted_shape)?;
+
+    let end = global_start.elapsed();
+    trace!("pairwise {} layout took {:?}", op.as_str(), end);
 
     Ok(actual_output)
 }
@@ -774,6 +815,7 @@ pub fn neg<F: PrimeField + TensorType + PartialOrd>(
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
     let input = {
         let res = region.assign(&config.inputs[1], &values[0])?;
+
         res.get_inner()?
     };
 
@@ -1101,7 +1143,7 @@ pub fn conv<F: PrimeField + TensorType + PartialOrd + std::marker::Send + std::m
     }
 
     // increment the region
-    region.increment(std::cmp::max(assigned_image_len, assigned_kernel_len));
+    region.increment(std::cmp::max(assigned_kernel_len, assigned_image_len));
 
     let og_dims = image.dims().to_vec();
 
@@ -1470,7 +1512,7 @@ pub fn downsample<F: PrimeField + TensorType + PartialOrd>(
     let processed_output =
         tensor::ops::downsample(&input.get_inner_tensor()?, *axis, *stride, *modulo)?;
     let output = region.assign(&config.output, &processed_output.into())?;
-    region.increment(input.len());
+    region.increment(std::cmp::max(input.len(), output.len()));
     Ok(output)
 }
 
@@ -1504,6 +1546,9 @@ pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
     values: &[ValTensor<F>; 1],
     nl: &LookupOp,
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
+    // time the entire operation
+    let timer = std::time::Instant::now();
+
     let x = &values[0];
 
     if region.is_dummy() {
@@ -1513,6 +1558,13 @@ pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
         let vals = vec![ValType::Value(Value::<F>::unknown()); x.len()];
         let mut x = Tensor::from(vals.into_iter());
         x.reshape(dims);
+        // total time taken
+        trace!(
+            "dummy nonlinearity {} layout took {:?}",
+            <LookupOp as Op<F>>::as_string(nl),
+            timer.elapsed()
+        );
+
         return Ok(x.into());
     }
 
@@ -1534,7 +1586,9 @@ pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
 
     let mut output = region.assign(&config.lookup_output, &output.into())?;
 
-    (0..x.len()).for_each(|i| {
+    assert_eq!(w.len(), output.len());
+
+    (0..output.len()).for_each(|i| {
         let (x, y) = config.lookup_input.cartesian_coord(region.offset() + i);
         let selector = config.lookup_selectors.get(&(nl.clone(), x));
         region.enable(selector, y).unwrap();
@@ -1542,7 +1596,14 @@ pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
 
     output.reshape(x.dims())?;
 
-    region.increment(x.len());
+    region.increment(output.len());
+
+    let elapsed = timer.elapsed();
+    trace!(
+        "nonlinearity {} layout took {:?}",
+        <LookupOp as Op<F>>::as_string(nl),
+        elapsed
+    );
 
     // constrain the calculated output to a column
     Ok(output)
@@ -1610,8 +1671,8 @@ pub fn max<F: PrimeField + TensorType + PartialOrd>(
         Some(i) => Tensor::new(Some(&[Value::known(i128_to_felt::<F>(i))]), &[1])?.into(),
     };
 
-    let assigned_max_val = region.assign(&config.inputs[1], &max_val)?;
-    region.next();
+    let assigned_max_val: ValTensor<F> = region.assign(&config.inputs[1], &max_val)?;
+    region.increment(assigned_max_val.len());
 
     let unit: ValTensor<F> =
         Tensor::from(vec![region.assign_constant(&config.inputs[1], F::from(1))?].into_iter())
@@ -1705,7 +1766,7 @@ pub fn min<F: PrimeField + TensorType + PartialOrd>(
     };
 
     let assigned_min_val = region.assign(&config.inputs[1], &min_val)?;
-    region.next();
+    region.increment(assigned_min_val.len());
 
     let unit: ValTensor<F> =
         Tensor::from(vec![region.assign_constant(&config.inputs[1], F::from(1))?].into_iter())

--- a/src/circuit/ops/layouts.rs
+++ b/src/circuit/ops/layouts.rs
@@ -59,7 +59,7 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
     values: &[ValTensor<F>; 2],
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
     // time this entire function run
-    let global_start = std::time::Instant::now();
+    let global_start = instant::Instant::now();
 
     let mut values = values.clone();
 
@@ -97,7 +97,7 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
         return Ok(Tensor::from([ValType::<F>::from(Value::<F>::unknown())].into_iter()).into());
     }
 
-    let start = std::time::Instant::now();
+    let start = instant::Instant::now();
     let mut inputs = vec![];
     let mut assigned_len = 0;
     for (i, input) in values.iter().enumerate() {
@@ -114,13 +114,13 @@ pub fn dot<F: PrimeField + TensorType + PartialOrd>(
 
     // Now we can assign the dot product
     // time this step
-    let start = std::time::Instant::now();
+    let start = instant::Instant::now();
     let accumulated_dot = accumulated::dot(&[inputs[0].clone(), inputs[1].clone()])
         .expect("accum poly: dot op failed");
     let elapsed = start.elapsed();
     trace!("calculating accumulated dot took: {:?}", elapsed);
 
-    let start = std::time::Instant::now();
+    let start = instant::Instant::now();
     let (output, output_assigned_len) = region.assign_with_duplication(
         &config.output,
         &accumulated_dot.into(),
@@ -627,7 +627,7 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
     op: BaseOp,
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
     // time to calculate the value of the output
-    let global_start = std::time::Instant::now();
+    let global_start = instant::Instant::now();
 
     let (mut lhs, mut rhs) = (values[0].clone(), values[1].clone());
 
@@ -685,7 +685,7 @@ pub fn pairwise<F: PrimeField + TensorType + PartialOrd>(
 
     // Now we can assign the dot product
     // time the calc
-    let start = std::time::Instant::now();
+    let start = instant::Instant::now();
     let op_result = match op {
         BaseOp::Add => add(&inputs),
         BaseOp::Sub => sub(&inputs),
@@ -1547,7 +1547,7 @@ pub fn nonlinearity<F: PrimeField + TensorType + PartialOrd>(
     nl: &LookupOp,
 ) -> Result<ValTensor<F>, Box<dyn Error>> {
     // time the entire operation
-    let timer = std::time::Instant::now();
+    let timer = instant::Instant::now();
 
     let x = &values[0];
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(not(target_arch = "wasm32"))]
 use ethers::types::H160;
 #[cfg(feature = "python-bindings")]
@@ -12,10 +12,11 @@ use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::path::PathBuf;
 
-use crate::circuit::{CheckMode, Tolerance};
+use crate::RunArgs;
+
+use crate::circuit::CheckMode;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::graph::TestDataSource;
-use crate::graph::Visibility;
 use crate::pfsys::TranscriptType;
 
 impl std::fmt::Display for TranscriptType {
@@ -135,34 +136,6 @@ impl<'source> FromPyObject<'source> for CalibrationTarget {
     }
 }
 
-/// Parameters specific to a proving run
-#[derive(Debug, Copy, Args, Deserialize, Serialize, Clone, Default, PartialEq, PartialOrd)]
-pub struct RunArgs {
-    /// The tolerance for error on model outputs
-    #[arg(short = 'T', long, default_value = "0")]
-    pub tolerance: Tolerance,
-    /// The denominator in the fixed point representation used when quantizing
-    #[arg(short = 'S', long, default_value = "7")]
-    pub scale: u32,
-    /// The number of bits used in lookup tables
-    #[arg(short = 'B', long, default_value = "16")]
-    pub bits: usize,
-    /// The log_2 number of rows
-    #[arg(short = 'K', long, default_value = "17")]
-    pub logrows: u32,
-    /// The number of batches to split the input data into
-    #[arg(long, default_value = "1")]
-    pub batch_size: usize,
-    /// Flags whether inputs are public, private, hashed
-    #[arg(long, default_value = "private")]
-    pub input_visibility: Visibility,
-    /// Flags whether outputs are public, private, hashed
-    #[arg(long, default_value = "public")]
-    pub output_visibility: Visibility,
-    /// Flags whether params are public, private, hashed
-    #[arg(long, default_value = "private")]
-    pub param_visibility: Visibility,
-}
 use lazy_static::lazy_static;
 
 // if CARGO VERSION is 0.0.0 replace with "source - no compatibility guaranteed"

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -24,10 +24,10 @@ use self::modules::{
 use crate::circuit::lookup::LookupOp;
 use crate::circuit::modules::ModulePlanner;
 use crate::circuit::CheckMode;
-use crate::commands::RunArgs;
 use crate::graph::modules::ModuleInstanceOffset;
 use crate::pfsys::field_to_vecu64;
 use crate::tensor::{Tensor, ValTensor};
+use crate::RunArgs;
 use halo2_proofs::{
     circuit::Layouter,
     plonk::{Circuit, ConstraintSystem, Error as PlonkError},

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -11,11 +11,12 @@ use crate::circuit::Unknown;
 use crate::fieldutils::felt_to_i128;
 use crate::{
     circuit::{lookup::LookupOp, BaseConfig as PolyConfig, CheckMode, Op},
-    commands::RunArgs,
     tensor::{Tensor, ValTensor},
+    RunArgs,
 };
 use halo2curves::bn256::Fr as Fp;
 
+#[cfg(not(target_arch = "wasm32"))]
 use colored::Colorize;
 use core::panic;
 use halo2_proofs::{
@@ -288,6 +289,7 @@ impl Model {
         check_mode: CheckMode,
     ) -> Result<GraphSettings, Box<dyn Error>> {
         let instance_shapes = self.instance_shapes();
+        #[cfg(not(target_arch = "wasm32"))]
         info!(
             "{} {} {}",
             "model has".blue(),
@@ -301,6 +303,7 @@ impl Model {
             .unwrap();
 
         // Then number of columns in the circuits
+        #[cfg(not(target_arch = "wasm32"))]
         info!(
             "{} {} {}",
             "model generates".blue(),

--- a/src/graph/vars.rs
+++ b/src/graph/vars.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
-use crate::commands::RunArgs;
 use crate::tensor::TensorType;
 use crate::tensor::{ValTensor, VarTensor};
+use crate::RunArgs;
 use halo2_proofs::plonk::ConstraintSystem;
 use halo2curves::ff::PrimeField;
 use itertools::Itertools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,15 @@
 //! A library for turning computational graphs, such as neural networks, into ZK-circuits.
 //!
 
+use circuit::Tolerance;
+use clap::Args;
+use graph::Visibility;
+use serde::{Deserialize, Serialize};
+
 /// Methods for configuring tensor operations and assigning values to them in a Halo2 circuit.
 pub mod circuit;
 /// CLI commands.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod commands;
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(missing_docs, reason = "abigen doesn't generate docs for this module")]
@@ -38,6 +44,7 @@ pub mod commands;
 pub mod eth;
 /// Command execution
 ///
+#[cfg(not(target_arch = "wasm32"))]
 pub mod execute;
 /// Utilities for converting from Halo2 Field types to integers (and vice-versa).
 pub mod fieldutils;
@@ -46,6 +53,7 @@ pub mod fieldutils;
 #[cfg(feature = "onnx")]
 pub mod graph;
 /// beautiful logging
+#[cfg(not(target_arch = "wasm32"))]
 pub mod logger;
 /// Tools for proofs and verification used by cli
 pub mod pfsys;
@@ -57,3 +65,32 @@ pub mod tensor;
 /// wasm prover and verifier
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod wasm;
+
+/// Parameters specific to a proving run
+#[derive(Debug, Copy, Args, Deserialize, Serialize, Clone, Default, PartialEq, PartialOrd)]
+pub struct RunArgs {
+    /// The tolerance for error on model outputs
+    #[arg(short = 'T', long, default_value = "0")]
+    pub tolerance: Tolerance,
+    /// The denominator in the fixed point representation used when quantizing
+    #[arg(short = 'S', long, default_value = "7")]
+    pub scale: u32,
+    /// The number of bits used in lookup tables
+    #[arg(short = 'B', long, default_value = "16")]
+    pub bits: usize,
+    /// The log_2 number of rows
+    #[arg(short = 'K', long, default_value = "17")]
+    pub logrows: u32,
+    /// The number of batches to split the input data into
+    #[arg(long, default_value = "1")]
+    pub batch_size: usize,
+    /// Flags whether inputs are public, private, hashed
+    #[arg(long, default_value = "private")]
+    pub input_visibility: Visibility,
+    /// Flags whether outputs are public, private, hashed
+    #[arg(long, default_value = "public")]
+    pub output_visibility: Visibility,
+    /// Flags whether params are public, private, hashed
+    #[arg(long, default_value = "private")]
+    pub param_visibility: Visibility,
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,5 +1,5 @@
 use crate::circuit::{CheckMode, Tolerance};
-use crate::commands::{CalibrationTarget, RunArgs, StrategyType};
+use crate::commands::{CalibrationTarget, StrategyType};
 use crate::fieldutils::{felt_to_i128, i128_to_felt};
 use crate::graph::{
     quantize_float, scale_to_multiplier, GraphCircuit, GraphSettings, Model, Visibility,
@@ -8,6 +8,7 @@ use crate::pfsys::evm::aggregation::AggregationCircuit;
 use crate::pfsys::{
     load_pk, save_params, save_vk, srs::gen_srs as ezkl_gen_srs, Snark, TranscriptType,
 };
+use crate::RunArgs;
 use ethers::types::H160;
 use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
 use halo2curves::bn256::{Bn256, Fr};
@@ -583,7 +584,7 @@ fn deploy_evm(
     addr_path: PathBuf,
     sol_code_path: PathBuf,
     rpc_url: Option<String>,
-    optimizer_runs: Option<usize>
+    optimizer_runs: Option<usize>,
 ) -> Result<bool, PyErr> {
     Runtime::new()
         .unwrap()
@@ -615,7 +616,7 @@ fn deploy_da_evm(
     settings_path: PathBuf,
     sol_code_path: PathBuf,
     rpc_url: Option<String>,
-    optimizer_runs: Option<usize>
+    optimizer_runs: Option<usize>,
 ) -> Result<bool, PyErr> {
     Runtime::new()
         .unwrap()
@@ -625,7 +626,7 @@ fn deploy_da_evm(
             sol_code_path,
             rpc_url,
             addr_path,
-            optimizer_runs
+            optimizer_runs,
         ))
         .map_err(|e| {
             let err_str = format!("Failed to run deploy_da_evm: {}", e);

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -647,7 +647,8 @@ impl<T: Clone + TensorType> Tensor<T> {
     /// use ezkl::tensor::Tensor;
     /// let a = Tensor::<i32>::new(Some(&[1, 2, 3, 4, 5, 6]), &[6]).unwrap();
     /// let expected = Tensor::<i32>::new(Some(&[1, 2, 3, 6]), &[4]).unwrap();
-    /// assert_eq!(a.remove_indices(&[3, 4], true).unwrap(), expected);
+    /// let mut indices = vec![3, 4];
+    /// assert_eq!(a.remove_indices(&mut indices, true).unwrap(), expected);
     /// ```
     pub fn remove_indices(
         &self,

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -6,7 +6,10 @@ pub mod val;
 pub mod var;
 
 use halo2curves::ff::PrimeField;
-use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
+use rayon::{
+    prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+    slice::ParallelSliceMut,
+};
 use serde::{Deserialize, Serialize};
 pub use val::*;
 pub use var::*;
@@ -635,6 +638,32 @@ impl<T: Clone + TensorType> Tensor<T> {
                 inner.push(elem.clone());
             }
         }
+        Tensor::new(Some(&inner), &[inner.len()])
+    }
+
+    /// Remove indices
+    /// WARN: assumes indices are in ascending order for speed
+    /// ```
+    /// use ezkl::tensor::Tensor;
+    /// let a = Tensor::<i32>::new(Some(&[1, 2, 3, 4, 5, 6]), &[6]).unwrap();
+    /// let expected = Tensor::<i32>::new(Some(&[1, 2, 3, 6]), &[4]).unwrap();
+    /// assert_eq!(a.remove_indices(&[3, 4], true).unwrap(), expected);
+    /// ```
+    pub fn remove_indices(
+        &self,
+        indices: &mut [usize],
+        is_sorted: bool,
+    ) -> Result<Tensor<T>, TensorError> {
+        let mut inner: Vec<T> = self.inner.clone();
+        // time it
+        if !is_sorted {
+            indices.par_sort_unstable();
+        }
+        // remove indices
+        for elem in indices.iter().rev() {
+            inner.swap_remove(*elem);
+        }
+
         Tensor::new(Some(&inner), &[inner.len()])
     }
 

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -483,18 +483,18 @@ impl<F: PrimeField + TensorType + PartialOrd> ValTensor<F> {
         }
     }
 
-    /// removes constants with inner value 0
-    pub fn remove_indices(&mut self, indices: &[usize]) -> Result<(), TensorError> {
+    /// calls `remove_indices` on the inner [Tensor].
+    pub fn remove_indices(
+        &mut self,
+        indices: &mut [usize],
+        is_sorted: bool,
+    ) -> Result<(), TensorError> {
         match self {
             ValTensor::Value {
                 inner: v, dims: d, ..
             } => {
-                *v = v
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, _)| !indices.contains(i))
-                    .map(|x| x.1.clone())
-                    .collect();
+                // this is very slow how can we speed this up ?
+                *v = v.remove_indices(indices, is_sorted)?;
                 *d = v.dims().to_vec();
             }
             ValTensor::Instance { .. } => {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -28,8 +28,8 @@ pub fn init_panic_hook() {
     console_error_panic_hook::set_once();
 }
 
-use crate::execute::{create_proof_circuit_kzg, verify_proof_circuit_kzg};
 use crate::graph::{GraphCircuit, GraphSettings};
+use crate::pfsys::{create_proof_circuit_kzg, verify_proof_circuit_kzg};
 
 /// Generate a poseidon hash in browser. Input message
 #[wasm_bindgen]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -823,7 +823,7 @@ mod native_tests {
     fn model_serialization(test_dir: &str, example_name: String) {
         let model_path = format!("{}/{}/network.onnx", test_dir, example_name);
         let serialization_path = format!("{}/{}/network.ezkl", test_dir, example_name);
-        let run_args = ezkl::commands::RunArgs {
+        let run_args = ezkl::RunArgs {
             param_visibility: Visibility::Public,
             batch_size: 1,
             ..Default::default()


### PR DESCRIPTION
Improves layout speed by a factor of 20 for dummy layouts and by a factor of 10 for "real" layouts. 

Prior setup phase: 

```bash 
[T] [1s, ezkl::circuit::ops::layouts] - filtering const zero indices took: 1.154125ms
[T] [1s, ezkl::circuit::ops::layouts] - assigning inputs took: 53.292µs
[T] [1s, ezkl::circuit::ops::layouts] - calculating accumulated dot took: 2.208µs
[T] [1s, ezkl::circuit::ops::layouts] - assigning output took: 23.167µs
[T] [1s, ezkl::circuit::ops::layouts] - dot layout took: 1.280833ms
```

New setup phase:  

```bash
[T] [1s, ezkl::circuit::ops::layouts] - filtering const zero indices took: 18.708µs
[T] [1s, ezkl::circuit::ops::layouts] - assigning inputs took: 66.917µs
[T] [1s, ezkl::circuit::ops::layouts] - calculating accumulated dot took: 3.833µs
[T] [1s, ezkl::circuit::ops::layouts] - assigning output took: 20.5µs
[T] [1s, ezkl::circuit::ops::layouts] - dot layout took: 154.041µs
```