### PR TITLE
chore: allow for boolean inputs

### DIFF
--- a/examples/onnx/boolean/gen.py
+++ b/examples/onnx/boolean/gen.py
@@ -1,0 +1,48 @@
+from torch import nn
+import torch
+import json
+import numpy as np
+
+
+class MyModel(nn.Module):
+    def __init__(self):
+        super(MyModel, self).__init__()
+
+    def forward(self, w, x, y, z):
+        return [((x & y)) == (x & (y | (z ^ w)))]
+
+
+circuit = MyModel()
+
+a = torch.empty(1, 3).uniform_(0, 1)
+
+w = torch.bernoulli(a).to(torch.bool)
+x = torch.bernoulli(a).to(torch.bool)
+y = torch.bernoulli(a).to(torch.bool)
+z = torch.bernoulli(a).to(torch.bool)
+
+torch.onnx.export(circuit, (w, x, y, z), "network.onnx",
+                  export_params=True,        # store the trained parameter weights inside the model file
+                  opset_version=15,          # the ONNX version to export the model to
+                  do_constant_folding=True,  # whether to execute constant folding for optimization
+                  input_names=['input', 'input1', 'input2',
+                               'input3'],   # the model's input names
+                  output_names=['output'],  # the model's output names
+                  dynamic_axes={'input': {0: 'batch_size'},  # variable length axes
+                                'input1': {0: 'batch_size'},
+                                'input2': {0: 'batch_size'},
+                                'input3': {0: 'batch_size'},
+                                'output': {0: 'batch_size'}})
+
+
+d = ((w).detach().numpy()).reshape([-1]).tolist()
+d1 = ((x).detach().numpy()).reshape([-1]).tolist()
+d2 = ((y).detach().numpy()).reshape([-1]).tolist()
+d3 = ((z).detach().numpy()).reshape([-1]).tolist()
+
+data = dict(
+    input_data=[d, d1, d2, d3],
+)
+
+# Serialize data into file:
+json.dump(data, open("input.json", 'w'))

--- a/examples/onnx/boolean/input.json
+++ b/examples/onnx/boolean/input.json
@@ -1,0 +1,1 @@
+{"input_data": [[false, true, false], [true, false, false], [true, false, false], [false, false, false]]}

--- a/examples/onnx/boolean/network.onnx
+++ b/examples/onnx/boolean/network.onnx
@@ -1,0 +1,43 @@
+pytorch1.12.1:«
++
+input1
+input2onnx::Equal_4And_0"And
+'
+input3
+input
+onnx::Or_5Xor_1"Xor
++
+input2
+
+onnx::Or_5onnx::And_6Or_2"Or
+0
+input1
+onnx::And_6onnx::Equal_7And_3"And
+6
+onnx::Equal_4
+onnx::Equal_7outputEqual_4"Equal	torch_jitZ!
+input
+	
+
+batch_size
+Z"
+input1
+	
+
+batch_size
+Z"
+input2
+	
+
+batch_size
+Z"
+input3
+	
+
+batch_size
+b"
+output
+	
+
+batch_size
+B

--- a/src/circuit/ops/hybrid.rs
+++ b/src/circuit/ops/hybrid.rs
@@ -35,6 +35,7 @@ pub enum HybridOp {
     Less {
         scales: (usize, usize),
     },
+    Equals,
 }
 
 impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
@@ -71,6 +72,10 @@ impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
                 let y = inputs[1].clone().map(|x| felt_to_i128(x));
                 tensor::ops::less(&x, &y, scales)?
             }
+            HybridOp::Equals => {
+                let y = inputs[1].clone().map(|x| felt_to_i128(x));
+                tensor::ops::equals(&x, &y)?
+            }
         };
 
         // convert back to felt
@@ -92,6 +97,7 @@ impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
             HybridOp::RangeCheck(..) => "RANGECHECK",
             HybridOp::Greater { .. } => "GREATER",
             HybridOp::Less { .. } => "LESS",
+            HybridOp::Equals => "EQUALS",
         };
         name.into()
     }
@@ -143,6 +149,7 @@ impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
             HybridOp::Less { scales } => {
                 layouts::less(config, region, values[..].try_into()?, scales)?
             }
+            HybridOp::Equals => layouts::equals(config, region, values[..].try_into()?)?,
         }))
     }
 
@@ -213,9 +220,11 @@ impl<F: PrimeField + TensorType + PartialOrd> Op<F> for HybridOp {
                 }
                 lookups
             }
-            HybridOp::Greater { .. } | HybridOp::Less { .. } => vec![LookupOp::GreaterThan {
-                a: circuit::utils::F32(0.),
-            }],
+            HybridOp::Greater { .. } | HybridOp::Less { .. } | HybridOp::Equals => {
+                vec![LookupOp::GreaterThan {
+                    a: circuit::utils::F32(0.),
+                }]
+            }
         }
     }
 

--- a/src/circuit/ops/lookup.rs
+++ b/src/circuit/ops/lookup.rs
@@ -113,12 +113,10 @@ impl LookupOp {
     /// Returns the range of values that can be represented by the table
     pub fn bit_range(&self, allocated_bits: usize) -> (i128, i128) {
         let base = 2i128;
-        match self {
-            _ => (
-                -base.pow(allocated_bits as u32 - 1),
-                base.pow(allocated_bits as u32 - 1),
-            ),
-        }
+        (
+            -base.pow(allocated_bits as u32 - 1),
+            base.pow(allocated_bits as u32 - 1),
+        )
     }
 }
 

--- a/src/circuit/ops/poly.rs
+++ b/src/circuit/ops/poly.rs
@@ -70,6 +70,9 @@ pub enum PolyOp<F: PrimeField + TensorType + PartialOrd> {
         scale_factor: Vec<usize>,
     },
     Not,
+    And,
+    Or,
+    Xor,
 }
 
 impl<F: PrimeField + TensorType + PartialOrd> PolyOp<F> {}
@@ -108,6 +111,9 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
             PolyOp::Slice { .. } => "SLICE".into(),
             PolyOp::Neg => "NEG".into(),
             PolyOp::Not => "NOT".into(),
+            PolyOp::And => "AND".into(),
+            PolyOp::Or => "OR".into(),
+            PolyOp::Xor => "XOR".into(),
         }
     }
 
@@ -115,6 +121,9 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
     fn f(&self, inputs: &[Tensor<F>]) -> Result<ForwardResult<F>, TensorError> {
         let mut inputs = inputs.to_vec();
         let res = match &self {
+            PolyOp::And => tensor::ops::and(&inputs[0], &inputs[1]),
+            PolyOp::Or => tensor::ops::or(&inputs[0], &inputs[1]),
+            PolyOp::Xor => tensor::ops::xor(&inputs[0], &inputs[1]),
             PolyOp::Not => tensor::ops::not(&inputs[0]),
             PolyOp::Downsample {
                 axis,
@@ -229,6 +238,9 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
         let mut values = values.to_vec();
 
         Ok(Some(match self {
+            PolyOp::Xor => layouts::xor(config, region, values[..].try_into()?)?,
+            PolyOp::Or => layouts::or(config, region, values[..].try_into()?)?,
+            PolyOp::And => layouts::and(config, region, values[..].try_into()?)?,
             PolyOp::Not => layouts::not(config, region, values[..].try_into()?)?,
             PolyOp::MoveAxis {
                 source,
@@ -243,7 +255,7 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
                 layouts::resize(config, region, values[..].try_into()?, scale_factor)?
             }
             PolyOp::Neg => layouts::neg(config, region, values[..].try_into()?)?,
-            PolyOp::Iff => layouts::iff(config, region, values[..].try_into()?)?,
+            PolyOp::Iff => layouts::iff(config, region, values[..].try_into()?, false)?,
             PolyOp::Einsum { equation } => layouts::einsum(config, region, &mut values, equation)?,
             PolyOp::Gather { dim, index } => {
                 tensor::ops::gather(&values[0].get_inner_tensor()?, *dim, index)?.into()
@@ -295,10 +307,14 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
                 *stride,
                 *kernel_shape,
             )?,
-            PolyOp::Add => layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Add)?,
-            PolyOp::Sub => layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Sub)?,
+            PolyOp::Add => {
+                layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Add, false)?
+            }
+            PolyOp::Sub => {
+                layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Sub, false)?
+            }
             PolyOp::Mult => {
-                layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Mult)?
+                layouts::pairwise(config, region, values[..].try_into()?, BaseOp::Mult, false)?
             }
             PolyOp::Identity => layouts::identity(config, region, values[..].try_into()?)?,
             PolyOp::Reshape(d) | PolyOp::Flatten(d) => layouts::reshape(values[..].try_into()?, d)?,
@@ -329,7 +345,7 @@ impl<F: PrimeField + TensorType + PartialOrd + Serialize + for<'de> Deserialize<
 
     fn out_scale(&self, in_scales: Vec<u32>, _g: u32) -> u32 {
         match self {
-            PolyOp::Not => in_scales[0],
+            PolyOp::Xor | PolyOp::Or | PolyOp::And | PolyOp::Not => 0,
             PolyOp::Neg => in_scales[0],
             PolyOp::MoveAxis { .. } => in_scales[0],
             PolyOp::Downsample { .. } => in_scales[0],

--- a/src/graph/input.rs
+++ b/src/graph/input.rs
@@ -62,13 +62,12 @@ impl<'de> Deserialize<'de> for FileSourceInner {
         if let Ok(t) = bool_try {
             return Ok(FileSourceInner::Bool(t));
         }
-
-        let first_try: Result<f64, _> = serde_json::from_str(this_json.get());
-        if let Ok(t) = first_try {
+        let float_try: Result<f64, _> = serde_json::from_str(this_json.get());
+        if let Ok(t) = float_try {
             return Ok(FileSourceInner::Float(t));
         }
-        let second_try: Result<Fp, _> = serde_json::from_str(this_json.get());
-        if let Ok(t) = second_try {
+        let field_try: Result<Fp, _> = serde_json::from_str(this_json.get());
+        if let Ok(t) = field_try {
             return Ok(FileSourceInner::Field(t));
         }
 
@@ -90,7 +89,6 @@ impl FileSourceInner {
     pub fn new_field(f: Fp) -> Self {
         FileSourceInner::Field(f)
     }
-
     /// Create a new FileSourceInner
     pub fn new_bool(f: bool) -> Self {
         FileSourceInner::Bool(f)
@@ -546,6 +544,7 @@ impl ToPyObject for FileSourceInner {
     fn to_object(&self, py: Python) -> PyObject {
         match self {
             FileSourceInner::Field(data) => field_to_vecu64_montgomery(data).to_object(py),
+            FileSourceInner::Bool(data) => data.to_object(py),
             FileSourceInner::Float(data) => data.to_object(py),
         }
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -126,8 +126,8 @@ impl GraphWitness {
     ///
     pub fn new(inputs: Vec<Vec<Fp>>, outputs: Vec<Vec<Fp>>) -> Self {
         GraphWitness {
-            inputs: inputs,
-            outputs: outputs,
+            inputs,
+            outputs,
             processed_inputs: None,
             processed_params: None,
             processed_outputs: None,
@@ -544,7 +544,7 @@ impl GraphCircuit {
         data: &GraphData,
     ) -> Result<Vec<Tensor<Fp>>, Box<dyn std::error::Error>> {
         let shapes = self.model.graph.input_shapes();
-        let scales = vec![self.settings.run_args.scale; shapes.len()];
+        let scales = self.model.graph.get_input_scales();
         self.process_data_source(&data.input_data, shapes, scales)
     }
 
@@ -555,7 +555,8 @@ impl GraphCircuit {
         data: &GraphData,
     ) -> Result<Vec<Tensor<Fp>>, Box<dyn std::error::Error>> {
         let shapes = self.model.graph.input_shapes();
-        let scales = vec![self.settings.run_args.scale; shapes.len()];
+        let scales = self.model.graph.get_input_scales();
+        info!("input scales: {:?}", scales);
         self.process_data_source(&data.input_data, shapes, scales)
             .await
     }
@@ -764,14 +765,12 @@ impl GraphCircuit {
                 .to_vec()
                 .iter()
                 .map(|t| t.deref().to_vec())
-                .collect_vec()
-                .into(),
+                .collect_vec(),
             outputs: model_results
                 .outputs
                 .iter()
                 .map(|t| t.deref().to_vec())
-                .collect_vec()
-                .into(),
+                .collect_vec(),
             processed_inputs,
             processed_params,
             processed_outputs,

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -442,9 +442,6 @@ impl Model {
         let set: HashSet<_> = lookup_ops.drain(..).collect(); // dedup
         lookup_ops.extend(set.into_iter().sorted());
 
-        let batch_size = self.graph.input_shapes()[0][0];
-        assert!(self.graph.input_shapes().iter().all(|x| x[0] == batch_size));
-
         Ok(GraphSettings {
             run_args,
             model_instance_shapes: instance_shapes,

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -663,7 +663,23 @@ pub fn new_op_from_onnx(
                 stride,
             })
         }
-        "Not" => SupportedOp::Linear(PolyOp::Not),
+        "Not" => {
+            change_all_input_scales(inputs, 0);
+            SupportedOp::Linear(PolyOp::Not)
+        }
+        "And" => {
+            change_all_input_scales(inputs, 0);
+            SupportedOp::Linear(PolyOp::And)
+        }
+        "Or" => {
+            change_all_input_scales(inputs, 0);
+            SupportedOp::Linear(PolyOp::Or)
+        }
+        "Xor" => {
+            change_all_input_scales(inputs, 0);
+            SupportedOp::Linear(PolyOp::Xor)
+        }
+        "Equals" => SupportedOp::Hybrid(HybridOp::Equals),
         "DeconvUnary" => {
             let deconv_node: &DeconvUnary = match node.op().downcast_ref::<DeconvUnary>() {
                 Some(b) => b,
@@ -947,6 +963,14 @@ pub(crate) fn split_valtensor(
         start = end;
     }
     Ok(tensors)
+}
+
+fn change_all_input_scales(inputs: &mut [super::NodeType], new_scale: u32) {
+    for input in inputs {
+        if input.is_input() {
+            input.bump_scale(new_scale);
+        }
+    }
 }
 
 ///

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -965,6 +965,7 @@ pub(crate) fn split_valtensor(
     Ok(tensors)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn change_all_input_scales(inputs: &mut [super::NodeType], new_scale: u32) {
     for input in inputs {
         if input.is_input() {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -129,6 +129,7 @@ impl TensorType for f64 {
     }
 }
 
+tensor_type!(bool, Bool, true, false);
 tensor_type!(i128, Int128, 0, 1);
 tensor_type!(i32, Int32, 0, 1);
 tensor_type!(usize, USize, 0, 1);

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -54,6 +54,7 @@ pub fn iff<
     );
 
     let masked_a = (mask.clone() * a.clone())?;
+
     let masked_b = ((Tensor::from(vec![T::one().ok_or(TensorError::DimError)?].into_iter())
         - mask.clone())?
         * b.clone())?;
@@ -92,6 +93,190 @@ pub fn not<
         &Tensor::from(vec![T::one().unwrap()].into_iter()),
         &Tensor::from(vec![T::zero().unwrap()].into_iter()),
     )
+}
+
+/// Elementwise applies or to two tensors of integers.
+/// # Arguments
+/// * `a` - Tensor
+/// * `b` - Tensor
+/// # Examples
+/// ```
+/// use ezkl::tensor::Tensor;
+/// use ezkl::tensor::ops::or;
+/// let a = Tensor::<i128>::new(
+///   Some(&[1, 1, 1, 1, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let b = Tensor::<i128>::new(
+///  Some(&[1, 0, 1, 0, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let result = or(&a, &b).unwrap();
+/// let expected = Tensor::<i128>::new(Some(&[1, 1, 1, 1, 1, 0]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
+/// ```
+pub fn or<
+    T: TensorType
+        + Add<Output = T>
+        + Mul<Output = T>
+        + Sub<Output = T>
+        + std::marker::Send
+        + std::marker::Sync
+        + std::cmp::PartialEq,
+>(
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<Tensor<T>, TensorError> {
+    // assert is boolean
+    assert!(
+        b.iter()
+            .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap()),
+        "or() only works on boolean mask"
+    );
+
+    iff(a, b, &Tensor::from(vec![T::one().unwrap()].into_iter()))
+}
+
+/// Elementwise applies xor to two tensors
+/// # Arguments
+/// * `a` - Tensor
+/// * `b` - Tensor
+/// # Examples
+/// ```
+/// use ezkl::tensor::Tensor;
+/// use ezkl::tensor::ops::xor;
+/// let a = Tensor::<i128>::new(
+///  Some(&[1, 1, 1, 1, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let b = Tensor::<i128>::new(
+/// Some(&[1, 0, 1, 0, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let result = xor(&a, &b).unwrap();
+/// let expected = Tensor::<i128>::new(Some(&[0, 1, 0, 1, 0, 0]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
+/// ```
+///
+pub fn xor<
+    T: TensorType
+        + Add<Output = T>
+        + Mul<Output = T>
+        + Sub<Output = T>
+        + std::marker::Send
+        + std::marker::Sync
+        + std::cmp::PartialEq,
+>(
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<Tensor<T>, TensorError> {
+    let a_not_b = (a.clone() * not(b)?)?;
+    let b_not_a = (b.clone() * not(a)?)?;
+    a_not_b + b_not_a
+}
+
+/// Elementwise applies and to two tensors
+/// # Arguments
+/// * `a` - Tensor
+/// * `b` - Tensor
+/// # Examples
+/// ```
+/// use ezkl::tensor::Tensor;
+/// use ezkl::tensor::ops::and;
+/// let a = Tensor::<i128>::new(
+///  Some(&[1, 1, 1, 1, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let b = Tensor::<i128>::new(
+/// Some(&[1, 0, 1, 0, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let result = and(&a, &b).unwrap();
+/// let expected = Tensor::<i128>::new(Some(&[1, 0, 1, 0, 1, 0]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
+/// ```
+pub fn and<
+    T: TensorType
+        + Add<Output = T>
+        + Mul<Output = T>
+        + Sub<Output = T>
+        + std::marker::Send
+        + std::marker::Sync
+        + std::cmp::PartialEq,
+>(
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<Tensor<T>, TensorError> {
+    // assert is boolean
+    assert!(
+        b.iter()
+            .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap()),
+        "and() only works on boolean values"
+    );
+
+    assert!(
+        a.iter()
+            .all(|x| *x == T::one().unwrap() || *x == T::zero().unwrap()),
+        "and() only works on boolean values"
+    );
+
+    a.clone() * b.clone()
+}
+
+/// Elementwise applies equals to two tensors of integers.
+/// # Arguments
+/// * `a` - Tensor
+/// * `b` - Tensor
+/// # Examples
+/// ```
+/// use ezkl::tensor::Tensor;
+/// use ezkl::tensor::ops::equals;
+/// let a = Tensor::<i128>::new(
+/// Some(&[1, 1, 1, 1, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let b = Tensor::<i128>::new(
+/// Some(&[1, 0, 1, 0, 1, 0]),
+/// &[2, 3],
+/// ).unwrap();
+/// let result = equals(&a, &b).unwrap();
+/// let expected = Tensor::<i128>::new(Some(&[1, 0, 1, 0, 1, 1]), &[2, 3]).unwrap();
+/// assert_eq!(result, expected);
+/// ```
+
+pub fn equals<
+    T: TensorType
+        + std::marker::Send
+        + std::marker::Sync
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Add<Output = T>
+        + std::cmp::PartialEq
+        + std::cmp::PartialOrd
+        + std::convert::From<u64>,
+>(
+    a: &Tensor<T>,
+    b: &Tensor<T>,
+) -> Result<(Tensor<T>, Vec<Tensor<T>>), TensorError> {
+    let a = a.clone();
+    let b = b.clone();
+
+    if a.dims() != b.dims() {
+        return Err(TensorError::DimError);
+    }
+
+    let diff = (a - b)?;
+
+    let zero_tensor = Tensor::<T>::from(vec![T::zero().ok_or(TensorError::DimError)?].into_iter());
+
+    let (greater_than_zero, mut inter) = greater(&diff, &zero_tensor, &(1, 1))?;
+    let (less_than_zero, inter_2) = less(&diff, &zero_tensor, &(1, 1))?;
+    inter.extend(inter_2);
+
+    let result = or(&greater_than_zero, &less_than_zero)?;
+    let result = not(&result)?;
+
+    Ok((result, inter))
 }
 
 /// Greater than operation.

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -239,7 +239,7 @@ pub fn and<
 /// Some(&[1, 0, 1, 0, 1, 0]),
 /// &[2, 3],
 /// ).unwrap();
-/// let result = equals(&a, &b).unwrap();
+/// let result = equals(&a, &b).unwrap().0;
 /// let expected = Tensor::<i128>::new(Some(&[1, 0, 1, 0, 1, 1]), &[2, 3]).unwrap();
 /// assert_eq!(result, expected);
 /// ```

--- a/src/tensor/val.rs
+++ b/src/tensor/val.rs
@@ -276,7 +276,8 @@ impl<F: PrimeField + TensorType + PartialOrd> ValTensor<F> {
             _ => return Err(Box::new(TensorError::WrongMethod)),
         };
 
-        let res: Tensor<F> = felt_evals.into_iter().into();
+        let mut res: Tensor<F> = felt_evals.into_iter().into();
+        res.reshape(self.dims());
         Ok(res)
     }
 

--- a/src/tensor/var.rs
+++ b/src/tensor/var.rs
@@ -14,7 +14,6 @@ pub enum VarTensor {
         /// Number of rows available to be used in each column of the storage
         col_size: usize,
     },
-
     /// Dummy var
     Dummy {
         /// Number of rows available to be used in each column of the storage

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -141,7 +141,7 @@ mod native_tests {
         "mnist_gan",
     ];
 
-    const TESTS: [&str; 44] = [
+    const TESTS: [&str; 45] = [
         "1l_mlp",
         "1l_slice",
         "1l_concat",
@@ -188,6 +188,7 @@ mod native_tests {
         "rnn",
         "quantize_dequantize",
         "1l_where",
+        "boolean",
     ];
 
     const TESTS_AGGR: [&str; 20] = [
@@ -332,7 +333,7 @@ mod native_tests {
 
 
 
-            seq!(N in 0..=43 {
+            seq!(N in 0..=44 {
 
             #(#[test_case(TESTS[N])])*
             fn model_serialization_(test: &str) {


### PR DESCRIPTION
Unlocks `AND, OR, XOR, EQUALS, NOT` over inputs