### PR TITLE
fix: import wasm engine from mjs and cjs targets

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -52,23 +52,16 @@ jobs:
                   "web/ezkl.d.ts",
                   "web/snippets/wasm-bindgen-rayon-7afa899f36665473/src/workerHelpers.js",
                   "web/package.json",
-                  "ezkl.js",
                   "ezkl.d.ts"
                 ],
-                "main": "ezkl.js",
+                "main": "nodejs/ezkl.js",
+                "module": "web/ezkl.js",
                 "types": "ezkl.d.ts",
                 "sideEffects": [
                   "web/snippets/*"
                 ]
               }' > pkg/package.json
               
-          - name: Create ezkl.js in pkg folder
-            run: |
-              echo "const nodejsFunctions = require('./nodejs/ezkl.js');" >> pkg/ezkl.js
-              echo "const webFunctions = require('./web/ezkl.js');" >> pkg/ezkl.js
-              echo "exports.nodejs = nodejsFunctions;" >> pkg/ezkl.js
-              echo "exports.web = webFunctions;" >> pkg/ezkl.js
-
           - name: Create ezkl.d.ts in pkg folder
             run: |
               echo "export const nodejs: typeof import('./nodejs/ezkl');" >> pkg/ezkl.d.ts


### PR DESCRIPTION
in nodejs/commonjs import from: `"main": "nodejs/ezkl.js"`
in browser/ejs import from `"module": "web/ezkl.js"`