### PR TITLE
feat: generic symbol <> dimension size matching

### DIFF
--- a/examples/notebooks/data_attest.ipynb
+++ b/examples/notebooks/data_attest.ipynb
@@ -351,6 +351,7 @@
                 "run_args.input_visibility = \"public\"\n",
                 "run_args.param_visibility = \"private\"\n",
                 "run_args.output_visibility = \"public\"\n",
+                "run_args.variables = [(\"batch_size\", 1)]\n",
                 "\n",
                 "\n",
                 "\n"

--- a/examples/notebooks/data_attest.ipynb
+++ b/examples/notebooks/data_attest.ipynb
@@ -394,7 +394,7 @@
                 "with open(cal_path, \"w\") as f:\n",
                 "    json.dump(cal_data, f)\n",
                 "\n",
-                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\")"
+                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\", num_batches=2)"
             ]
         },
         {

--- a/examples/notebooks/encrypted_vis.ipynb
+++ b/examples/notebooks/encrypted_vis.ipynb
@@ -230,6 +230,7 @@
                 "run_args.input_visibility = \"encrypted\"\n",
                 "run_args.param_visibility = \"public\"\n",
                 "run_args.output_visibility = \"public\"\n",
+                "run_args.variables = [(\"batch_size\", 1)]\n",
                 "\n",
                 "\n",
                 "\n"
@@ -256,6 +257,13 @@
                 "res = ezkl.gen_settings(model_path, settings_path, py_run_args=run_args)\n",
                 "assert res == True"
             ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
         },
         {
             "cell_type": "code",

--- a/examples/notebooks/encrypted_vis.ipynb
+++ b/examples/notebooks/encrypted_vis.ipynb
@@ -273,7 +273,7 @@
                 "with open(cal_path, \"w\") as f:\n",
                 "    json.dump(cal_data, f)\n",
                 "\n",
-                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\")"
+                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\", num_batches=10)"
             ]
         },
         {

--- a/examples/notebooks/hashed_vis.ipynb
+++ b/examples/notebooks/hashed_vis.ipynb
@@ -263,7 +263,7 @@
                 "with open(cal_path, \"w\") as f:\n",
                 "    json.dump(cal_data, f)\n",
                 "\n",
-                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\")"
+                "res = await ezkl.calibrate_settings(cal_path, model_path, settings_path, \"resources\", num_batches=10)"
             ]
         },
         {

--- a/examples/notebooks/hashed_vis.ipynb
+++ b/examples/notebooks/hashed_vis.ipynb
@@ -198,6 +198,7 @@
                 "run_args.input_visibility = \"hashed\"\n",
                 "run_args.param_visibility = \"hashed\"\n",
                 "run_args.output_visibility = \"public\"\n",
+                "run_args.variables = [(\"batch_size\", 1)]\n",
                 "\n",
                 "\n",
                 "\n"

--- a/examples/notebooks/lstm.ipynb
+++ b/examples/notebooks/lstm.ipynb
@@ -131,7 +131,7 @@
                 "\n",
                 "\n",
                 "run_args = ezkl.PyRunArgs()\n",
-                "run_args.batch_size = SEQ_LEN\n",
+                "run_args.variables = [(\"batch_size\", SEQ_LEN)]\n",
                 "\n",
                 "# TODO: Dictionary outputs\n",
                 "res = ezkl.gen_settings(model_path, settings_path, py_run_args=run_args)\n",

--- a/examples/notebooks/voice_judge.ipynb
+++ b/examples/notebooks/voice_judge.ipynb
@@ -615,7 +615,7 @@
     "res = ezkl.gen_settings(model_path, settings_path, py_run_args=run_args)\n",
     "assert res == True\n",
     "\n",
-    "res = await ezkl.calibrate_settings(val_data, model_path, settings_path, \"resources\")\n",
+    "res = await ezkl.calibrate_settings(val_data, model_path, settings_path, \"resources\", num_batches=len(val))\n",
     "assert res == True\n",
     "print(\"verified\")\n"
    ]

--- a/examples/notebooks/voice_judge.ipynb
+++ b/examples/notebooks/voice_judge.ipynb
@@ -590,7 +590,7 @@
     "run_args.input_visibility = \"private\"\n",
     "run_args.param_visibility = \"public\"\n",
     "run_args.output_visibility = \"public\"\n",
-    "run_args.batch_size = 1\n",
+    "run_args.variables = [(\"batch_size\", 1)]\n",
     "\n",
     "\n",
     "\n"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -251,6 +251,9 @@ pub enum Commands {
         #[arg(long = "target", default_value = "resources")]
         /// Target for calibration.
         target: CalibrationTarget,
+        /// Number of calibration batches to run.
+        #[arg(long = "num-batches", default_value = "1")]
+        num_batches: usize,
     },
 
     /// Generates a dummy SRS

--- a/src/graph/input.rs
+++ b/src/graph/input.rs
@@ -464,7 +464,7 @@ impl GraphData {
         };
 
         for (i, input) in iterable.iter().enumerate() {
-            // ensure the input is devenly divisible by batch_size
+            // ensure the input is evenly divisible by batch_size
             if input.len() % batch_size != 0 {
                 return Err(Box::new(GraphError::InvalidDims(
                     0,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -418,7 +418,7 @@ impl GraphCircuit {
     ///
     pub fn new(
         model: Model,
-        run_args: RunArgs,
+        run_args: &RunArgs,
     ) -> Result<GraphCircuit, Box<dyn std::error::Error>> {
         // // placeholder dummy inputs - must call prepare_public_inputs to load data afterwards
         let mut inputs: Vec<Vec<Fp>> = vec![];
@@ -430,7 +430,7 @@ impl GraphCircuit {
         // dummy module settings, must load from GraphData after
         let module_settings = ModuleSettings::default();
 
-        let mut settings = model.gen_params(run_args, CheckMode::UNSAFE)?;
+        let mut settings = model.gen_params(&run_args, CheckMode::UNSAFE)?;
 
         let mut num_params = 0;
         if !model.const_shapes().is_empty() {
@@ -443,7 +443,7 @@ impl GraphCircuit {
             model.graph.input_shapes(),
             vec![vec![num_params]],
             model.graph.output_shapes(),
-            VarVisibility::from_args(run_args).unwrap(),
+            VarVisibility::from_args(&run_args).unwrap(),
         );
 
         // number of instances used by modules
@@ -528,7 +528,7 @@ impl GraphCircuit {
             .collect::<Vec<Vec<Fp>>>();
 
         let module_instances =
-            GraphModules::public_inputs(data, VarVisibility::from_args(self.settings.run_args)?);
+            GraphModules::public_inputs(data, VarVisibility::from_args(&self.settings.run_args)?);
 
         if !module_instances.is_empty() {
             pi_inner.extend(module_instances);
@@ -716,7 +716,7 @@ impl GraphCircuit {
             self.settings.run_args.logrows = logrows as u32;
         }
 
-        self.settings = GraphCircuit::new(self.model.clone(), self.settings.run_args)?.settings;
+        self.settings = GraphCircuit::new(self.model.clone(), &self.settings.run_args)?.settings;
 
         let total_const_len = self.settings.total_const_size;
         let const_len_logrows = (total_const_len as f64).log2().ceil() as u32 + 1;
@@ -731,7 +731,7 @@ impl GraphCircuit {
         &self,
         inputs: &[Tensor<Fp>],
     ) -> Result<GraphWitness, Box<dyn std::error::Error>> {
-        let visibility = VarVisibility::from_args(self.settings.run_args)?;
+        let visibility = VarVisibility::from_args(&self.settings.run_args)?;
         let mut processed_inputs = None;
         let mut processed_params = None;
         let mut processed_outputs = None;
@@ -785,7 +785,7 @@ impl GraphCircuit {
         model_path: &std::path::PathBuf,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let model = Model::from_run_args(run_args, model_path)?;
-        Self::new(model, *run_args)
+        Self::new(model, run_args)
     }
 
     ///
@@ -797,7 +797,7 @@ impl GraphCircuit {
             error!("failed to deserialize compiled model. have you called compile-model ?");
             e
         })?;
-        Self::new(model, *run_args)
+        Self::new(model, run_args)
     }
 
     /// Create a new circuit from a set of input data and [GraphSettings].
@@ -908,7 +908,7 @@ impl Circuit<Fp> for GraphCircuit {
     }
 
     fn configure_with_params(cs: &mut ConstraintSystem<Fp>, params: Self::Params) -> Self::Config {
-        let visibility = VarVisibility::from_args(params.run_args).unwrap();
+        let visibility = VarVisibility::from_args(&params.run_args).unwrap();
 
         let mut vars = ModelVars::new(
             cs,

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -24,7 +24,6 @@ use halo2_proofs::{
     plonk::ConstraintSystem,
 };
 use itertools::Itertools;
-use log::warn;
 use serde::Deserialize;
 use serde::Serialize;
 #[cfg(not(target_arch = "wasm32"))]
@@ -529,7 +528,7 @@ impl Model {
                     let input_dims = inputs.iter().map(|inp| inp.dims());
                     let num_iter = number_of_iterations(input_mappings, input_dims.collect());
 
-                    warn!(
+                    debug!(
                         "{} iteration(s) in a subgraph with inputs {:?}",
                         num_iter, input_tuple
                     );
@@ -1089,7 +1088,7 @@ impl Model {
                         .map(|inp| results.get(&inp.0).unwrap()[inp.1].dims());
                     let num_iter = number_of_iterations(input_mappings, input_dims.collect());
 
-                    warn!(
+                    debug!(
                         "{} iteration(s) in a subgraph with inputs {:?}",
                         num_iter, inputs
                     );

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -362,10 +362,10 @@ impl Model {
     /// * `reader` - A reader for an Onnx file.
     /// * `run_args` - [RunArgs]
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(reader: &mut dyn std::io::Read, run_args: RunArgs) -> Result<Self, Box<dyn Error>> {
+    pub fn new(reader: &mut dyn std::io::Read, run_args: &RunArgs) -> Result<Self, Box<dyn Error>> {
         let visibility = VarVisibility::from_args(run_args)?;
 
-        let graph = Self::load_onnx_model(reader, &run_args, &visibility)?;
+        let graph = Self::load_onnx_model(reader, run_args, &visibility)?;
 
         let om = Model { graph, visibility };
 
@@ -396,7 +396,7 @@ impl Model {
     /// Generate model parameters for the circuit
     pub fn gen_params(
         &self,
-        run_args: RunArgs,
+        run_args: &RunArgs,
         check_mode: CheckMode,
     ) -> Result<GraphSettings, Box<dyn Error>> {
         let instance_shapes = self.instance_shapes();
@@ -443,7 +443,7 @@ impl Model {
         lookup_ops.extend(set.into_iter().sorted());
 
         Ok(GraphSettings {
-            run_args,
+            run_args: run_args.clone(),
             model_instance_shapes: instance_shapes,
             module_sizes: crate::graph::modules::ModuleSizes::default(),
             num_constraints,
@@ -646,6 +646,9 @@ impl Model {
             GraphError::ModelLoad
         })?;
 
+        let variables: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::from_iter(run_args.variables.clone().into_iter());
+
         for (i, id) in model.clone().inputs.iter().enumerate() {
             let input = model.node(id.node);
 
@@ -657,13 +660,13 @@ impl Model {
                 .filter_map(tract_onnx::tract_hir::internal::Factoid::concretize)
                 .map(|x| match x.to_i64() {
                     Ok(x) => x as usize,
-                    Err(_e) => {
-                        if x.to_string() == "batch_size" {
-                            run_args.batch_size
-                        } else {
-                            panic!("Unknown dimension {}: {:?}", x.to_string(), x)
-                        }
-                    }
+                    Err(_e) => *variables.get(&x.to_string()).unwrap_or_else(|| {
+                        panic!(
+                            "Unknown dimension {}: {:?} in model inputs",
+                            x.to_string(),
+                            x
+                        )
+                    }),
                 })
                 .collect();
 
@@ -679,16 +682,12 @@ impl Model {
             model.set_output_fact(i, InferenceFact::default()).unwrap();
         }
         // Note: do not optimize the model, as the layout will depend on underlying hardware
-        let model = model.into_typed()?.into_decluttered()?;
-        let batch_size_sym = model.symbol_table.sym("batch_size");
-        let seq_len_sym = model.symbol_table.sym("sequence_length");
-        let model = model
-            .concretize_dims(
-                &SymbolValues::default().with(&batch_size_sym, run_args.batch_size as i64),
-            )?
-            .concretize_dims(&SymbolValues::default().with(&seq_len_sym, 1))?;
-
-        info!("set batch size to {}", run_args.batch_size);
+        let mut model = model.into_typed()?.into_decluttered()?;
+        for (symbol, value) in run_args.variables.iter() {
+            let symbol = model.symbol_table.sym(&symbol);
+            model = model.concretize_dims(&SymbolValues::default().with(&symbol, *value as i64))?;
+            info!("set {} to {}", symbol, value);
+        }
 
         let nodes = Self::nodes_from_graph(&model, run_args, visibility, None)?;
 
@@ -897,7 +896,7 @@ impl Model {
         run_args: &RunArgs,
         model: &std::path::PathBuf,
     ) -> Result<Self, Box<dyn Error>> {
-        Model::new(&mut std::fs::File::open(model)?, *run_args)
+        Model::new(&mut std::fs::File::open(model)?, run_args)
     }
 
     /// Configures a model for the circuit

--- a/src/graph/vars.rs
+++ b/src/graph/vars.rs
@@ -123,7 +123,7 @@ impl std::fmt::Display for VarVisibility {
 impl VarVisibility {
     /// Read from cli args whether the model input, model parameters, and model output are Public or Private to the prover.
     /// Place in [VarVisibility] struct.
-    pub fn from_args(args: RunArgs) -> Result<Self, Box<dyn Error>> {
+    pub fn from_args(args: &RunArgs) -> Result<Self, Box<dyn Error>> {
         let input_vis = args.input_visibility;
         let params_vis = args.param_visibility;
         let output_vis = args.output_visibility;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub struct RunArgs {
     #[arg(short = 'K', long, default_value = "17")]
     pub logrows: u32,
     /// Hand-written parser for graph variables, eg. batch_size=1
-    #[arg(short = 'V', long, value_parser = parse_key_val::<String, usize>, default_value = "[(batch_size, 1)]", value_delimiter = ',')]
+    #[arg(short = 'V', long, value_parser = parse_key_val::<String, usize>, default_value = "batch_size=1", value_delimiter = ',')]
     pub variables: Vec<(String, usize)>,
     /// Flags whether inputs are public, private, hashed
     #[arg(long, default_value = "private")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod tensor;
 pub mod wasm;
 
 /// Parameters specific to a proving run
-#[derive(Debug, Copy, Args, Deserialize, Serialize, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Debug, Args, Deserialize, Serialize, Clone, Default, PartialEq, PartialOrd)]
 pub struct RunArgs {
     /// The tolerance for error on model outputs
     #[arg(short = 'T', long, default_value = "0")]
@@ -81,9 +81,9 @@ pub struct RunArgs {
     /// The log_2 number of rows
     #[arg(short = 'K', long, default_value = "17")]
     pub logrows: u32,
-    /// The number of batches to split the input data into
-    #[arg(long, default_value = "1")]
-    pub batch_size: usize,
+    /// Hand-written parser for graph variables, eg. batch_size=1
+    #[arg(short = 'V', long, value_parser = parse_key_val::<String, usize>, default_value = "[(batch_size, 1)]", value_delimiter = ',')]
+    pub variables: Vec<(String, usize)>,
     /// Flags whether inputs are public, private, hashed
     #[arg(long, default_value = "private")]
     pub input_visibility: Visibility,
@@ -93,4 +93,20 @@ pub struct RunArgs {
     /// Flags whether params are public, private, hashed
     #[arg(long, default_value = "private")]
     pub param_visibility: Visibility,
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(
+    s: &str,
+) -> Result<(T, U), Box<dyn std::error::Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: std::error::Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -200,7 +200,7 @@ pub fn prove(
     // read in circuit
     let model: crate::graph::Model = bincode::deserialize(&circuit_ser[..]).unwrap();
 
-    let mut circuit = GraphCircuit::new(model, circuit_settings.run_args).unwrap();
+    let mut circuit = GraphCircuit::new(model, &circuit_settings.run_args).unwrap();
 
     // prep public inputs
     circuit.load_graph_witness(&data).unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -827,12 +827,12 @@ mod native_tests {
         let serialization_path = format!("{}/{}/network.ezkl", test_dir, example_name);
         let run_args = ezkl::RunArgs {
             param_visibility: Visibility::Public,
-            batch_size: 1,
+            variables: vec![("batch_size".to_string(), 1)],
             ..Default::default()
         };
 
         let model =
-            ezkl::graph::Model::new(&mut std::fs::File::open(model_path).unwrap(), run_args)
+            ezkl::graph::Model::new(&mut std::fs::File::open(model_path).unwrap(), &run_args)
                 .unwrap();
 
         model.save(serialization_path.clone().into()).unwrap();
@@ -1045,7 +1045,7 @@ mod native_tests {
                     "--settings-path={}/{}/settings.json",
                     test_dir, example_name
                 ),
-                &format!("--batch-size={}", batch_size),
+                &format!("--variables=batch_size={}", batch_size),
                 &format!("--input-visibility={}", input_visibility),
                 &format!("--param-visibility={}", param_visibility),
                 &format!("--output-visibility={}", output_visibility),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1850,7 +1850,6 @@ mod native_tests {
                 "-O",
                 format!("{}/{}/settings_fuzz.json", test_dir, example_name).as_str(),
                 &format!("--scale={}", scale),
-                "--batch-size=1",
             ])
             .status()
             .expect("failed to execute process");

--- a/tests/wasm/settings.json
+++ b/tests/wasm/settings.json
@@ -10,7 +10,12 @@
         "scale": 0,
         "bits": 5,
         "logrows": 7,
-        "batch_size": 1,
+        "variables": [
+            [
+                "batch_size",
+                1
+            ]
+        ],
         "input_visibility": "Private",
         "output_visibility": "Public",
         "param_visibility": "Private"


### PR DESCRIPTION
Currently we only matched the `batch_size` symbol -- which means the cli fails when multiple symbols are present. 

Here we replace the `batch_size` argument in `RunArgs` with a generic `variables` argument: 

```rust

pub struct RunArgs {
    /// The tolerance for error on model outputs
    #[arg(short = 'T', long, default_value = "0")]
    pub tolerance: Tolerance,
    /// The denominator in the fixed point representation used when quantizing
    #[arg(short = 'S', long, default_value = "7")]
    pub scale: u32,
    /// The number of bits used in lookup tables
    #[arg(short = 'B', long, default_value = "16")]
    pub bits: usize,
    /// The log_2 number of rows
    #[arg(short = 'K', long, default_value = "17")]
    pub logrows: u32,
    /// Hand-written parser for graph variables, eg. batch_size=1
    #[arg(short = 'V', long, value_parser = parse_key_val::<String, usize>, default_value = "batch_size=1", value_delimiter = ',')]
    pub variables: Vec<(String, usize)>,
    /// Flags whether inputs are public, private, hashed
    #[arg(long, default_value = "private")]
    pub input_visibility: Visibility,
    /// Flags whether outputs are public, private, hashed
    #[arg(long, default_value = "public")]
    pub output_visibility: Visibility,
    /// Flags whether params are public, private, hashed
    #[arg(long, default_value = "private")]
    pub param_visibility: Visibility,
}

```

This allows means users can name variable dimensions something other than `batch_size`. For eg. when exporting to onnx in pytorch you could do something akin to: 


```python 

# Export the model
torch.onnx.export(model,               # model being run
                  # model input (or a tuple for multiple inputs)
                  x,
                  # where to save the model (can be a file or file-like object)
                  "network.onnx",
                  export_params=True,        # store the trained parameter weights inside the model file
                  opset_version=10,          # the ONNX version to export the model to
                  do_constant_folding=True,  # whether to execute constant folding for optimization
                  input_names=['input'],   # the model's input names
                  output_names=['output'],  # the model's output names
                  dynamic_axes={'input': {0: 'foo'},    # variable length axes
                                'output': {0: 'unk__6'}})

```
we now have two symbols `foo` and `unk__6` which we can infill with specific values when generating settings. 

Usage is as such: 


```bash
ezkl gen-settings -M network.onnx --variables foo=1,unk__6=2
```

or in shorthand 


```bash
ezkl gen-settings -M network.onnx -V foo=1,unk__6=2
```
