### PR TITLE
fix: allow float values for `PyRunArgs` tolerance field

### DIFF
--- a/src/circuit/ops/chip.rs
+++ b/src/circuit/ops/chip.rs
@@ -92,6 +92,15 @@ impl FromStr for Tolerance {
     }
 }
 
+impl From<f32> for Tolerance {
+    fn from(value: f32) -> Self {
+        Tolerance {
+            val: value,
+            scales: (1, 1),
+        }
+    }
+}
+
 #[cfg(feature = "python-bindings")]
 /// Converts CheckMode into a PyObject (Required for CheckMode to be compatible with Python)
 impl IntoPy<PyObject> for CheckMode {

--- a/src/python.rs
+++ b/src/python.rs
@@ -25,7 +25,7 @@ use tokio::runtime::Runtime;
 #[derive(Clone)]
 struct PyRunArgs {
     #[pyo3(get, set)]
-    pub tolerance: Tolerance,
+    pub tolerance: f32,
     #[pyo3(get, set)]
     pub scale: u32,
     #[pyo3(get, set)]
@@ -50,7 +50,7 @@ impl PyRunArgs {
     #[new]
     fn new() -> Self {
         PyRunArgs {
-            tolerance: Tolerance::default(),
+            tolerance: 0.0,
             scale: 7,
             bits: 16,
             logrows: 17,
@@ -67,7 +67,7 @@ impl PyRunArgs {
 impl From<PyRunArgs> for RunArgs {
     fn from(py_run_args: PyRunArgs) -> Self {
         RunArgs {
-            tolerance: py_run_args.tolerance,
+            tolerance: Tolerance::from(py_run_args.tolerance),
             scale: py_run_args.scale,
             bits: py_run_args.bits,
             logrows: py_run_args.logrows,

--- a/tests/python/binding_tests.py
+++ b/tests/python/binding_tests.py
@@ -42,6 +42,16 @@ def teardown_module(module):
     proc.terminate()
 
 
+def test_py_run_args():
+    """
+    Test for PyRunArgs
+    """
+    run_args = ezkl.PyRunArgs()
+    run_args.input_visibility = "hashed"
+    run_args.output_visibility = "hashed"
+    run_args.tolerance = 1.5
+
+
 def test_field_serialization():
     """
     Test field element serialization


### PR DESCRIPTION
Currently expects a `dict`, should get behaviour to match rust cli, where struct / dict get auto-initialized from the provided f32 val. 