### PR TITLE
feat: gen witness wasm binding

### DIFF
--- a/src/circuit/modules/elgamal.rs
+++ b/src/circuit/modules/elgamal.rs
@@ -159,7 +159,7 @@ impl ElGamalChip {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 /// The variables used in the ElGamal circuit.
 pub struct ElGamalVariables {
     /// The randomness used in the encryption.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -108,7 +108,7 @@ const ASSUMED_BLINDING_FACTORS: usize = 7;
 const MAX_PUBLIC_SRS: u32 = bn256::Fr::S - 2;
 
 /// Result from a forward pass
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GraphWitness {
     /// The inputs of the forward pass
     pub inputs: Vec<Vec<Fp>>,

--- a/src/graph/modules.rs
+++ b/src/graph/modules.rs
@@ -128,7 +128,7 @@ impl From<&GraphWitness> for ModuleSettings {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 /// Result from ElGamal
 pub struct ElGamalResult {
     /// ElGamal variables
@@ -140,7 +140,7 @@ pub struct ElGamalResult {
 }
 
 /// Result from a forward pass
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModuleForwardResult {
     /// The inputs of the forward pass for poseidon
     pub poseidon_hash: Option<Vec<Fp>>,

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -6,6 +6,7 @@ mod wasm32 {
     use ezkl::circuit::modules::poseidon::spec::{PoseidonSpec, POSEIDON_RATE, POSEIDON_WIDTH};
     use ezkl::circuit::modules::poseidon::PoseidonChip;
     use ezkl::circuit::modules::Module;
+    use ezkl::graph::GraphWitness;
     use ezkl::graph::modules::POSEIDON_LEN_GRAPH;
     use ezkl::pfsys::Snark;
     use ezkl::wasm::{
@@ -131,24 +132,11 @@ mod wasm32 {
             wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
         );
 
-        // prove
-        let proof = prove(
-            wasm_bindgen::Clamped(witness.to_vec()),
-            wasm_bindgen::Clamped(PK.to_vec()),
-            wasm_bindgen::Clamped(NETWORK.to_vec()),
-            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
-            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
-        );
-        assert!(proof.len() > 0);
+        let witness: GraphWitness = serde_json::from_slice(&witness[..]).unwrap();
 
-        let value = verify(
-            wasm_bindgen::Clamped(proof.to_vec()),
-            wasm_bindgen::Clamped(VK.to_vec()),
-            wasm_bindgen::Clamped(CIRCUIT_PARAMS.to_vec()),
-            wasm_bindgen::Clamped(KZG_PARAMS.to_vec()),
-        );
+        let reference_witness: GraphWitness = serde_json::from_slice(&WITNESS).unwrap();
         // should not fail
-        assert!(value);
+        assert_eq!(witness, reference_witness);
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
To prove locally in the browser we need a way to generate a witness file, as the prove method can only accept the quantized format of the raw model inputs stored in a witness file. The setup step (pk and vk generation) will be handled in python. 