### PR TITLE
refactor: increase contract code limit to 1gb and disable block gas on anvil

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -60,7 +60,7 @@ pub async fn setup_eth_backend(
 ) -> Result<(AnvilInstance, EthersClient), Box<dyn Error>> {
     // Launch anvil
     let anvil = Anvil::new().args([
-        "--code-size-limit=1048576",
+        "--code-size-limit=41943040",
         "--disable-block-gas-limit"
     ]).spawn();
 


### PR DESCRIPTION
In order to test verifiers that are above the spurious dragon 24.5 kb size limit, I have increased the contract code size limit to 1gb and disabled the block gas limit. Hopefully we never need to test an evm verifier above 1gb. 