### PR TITLE
chore: python implementations of module functions

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -245,16 +245,6 @@ fn insert_poseidon_hash_pydict(pydict: &PyDict, poseidon_hash: &Vec<Fp>) {
 }
 
 #[cfg(feature = "python-bindings")]
-use halo2curves::bn256::G1Affine;
-#[cfg(feature = "python-bindings")]
-fn g1affine_to_pydict(g1affine_dict: &PyDict, g1affine: &G1Affine) {
-    let g1affine_x = field_to_vecu64_montgomery(&g1affine.x);
-    let g1affine_y = field_to_vecu64_montgomery(&g1affine.y);
-    g1affine_dict.set_item("x", g1affine_x).unwrap();
-    g1affine_dict.set_item("y", g1affine_y).unwrap();
-}
-
-#[cfg(feature = "python-bindings")]
 use modules::ElGamalResult;
 #[cfg(feature = "python-bindings")]
 fn insert_elgamal_results_pydict(py: Python, pydict: &PyDict, elgamal_results: &ElGamalResult) {
@@ -283,33 +273,9 @@ fn insert_elgamal_results_pydict(py: Python, pydict: &PyDict, elgamal_results: &
         .set_item("encrypted_messages", encrypted_messages)
         .unwrap();
 
-    let variables_dict = PyDict::new(py);
-    let variables = &elgamal_results.variables;
+    let variables: crate::python::PyElGamalVariables = elgamal_results.variables.clone().into();
 
-    let r = field_to_vecu64_montgomery(&variables.r);
-    variables_dict.set_item("r", r).unwrap();
-    // elgamal secret key
-    let sk = field_to_vecu64_montgomery(&variables.sk);
-    variables_dict.set_item("sk", sk).unwrap();
-
-    let pk_dict = PyDict::new(py);
-    // elgamal public key
-    g1affine_to_pydict(pk_dict, &variables.pk);
-    variables_dict.set_item("pk", pk_dict).unwrap();
-
-    let aux_generator_dict = PyDict::new(py);
-    // elgamal aux generator used in ecc chip
-    g1affine_to_pydict(aux_generator_dict, &variables.aux_generator);
-    variables_dict
-        .set_item("aux_generator", aux_generator_dict)
-        .unwrap();
-
-    // elgamal window size used in ecc chip
-    variables_dict
-        .set_item("window_size", variables.window_size)
-        .unwrap();
-
-    results_dict.set_item("variables", variables_dict).unwrap();
+    results_dict.set_item("variables", variables).unwrap();
 
     pydict.set_item("elgamal", results_dict).unwrap();
 

--- a/src/pfsys/mod.rs
+++ b/src/pfsys/mod.rs
@@ -71,6 +71,28 @@ impl ToPyObject for TranscriptType {
     }
 }
 
+#[cfg(feature = "python-bindings")]
+///
+pub fn g1affine_to_pydict(g1affine_dict: &PyDict, g1affine: &G1Affine) {
+    let g1affine_x = field_to_vecu64_montgomery(&g1affine.x);
+    let g1affine_y = field_to_vecu64_montgomery(&g1affine.y);
+    g1affine_dict.set_item("x", g1affine_x).unwrap();
+    g1affine_dict.set_item("y", g1affine_y).unwrap();
+}
+
+#[cfg(feature = "python-bindings")]
+use halo2curves::bn256::G1;
+#[cfg(feature = "python-bindings")]
+///
+pub fn g1_to_pydict(g1_dict: &PyDict, g1: &G1) {
+    let g1_x = field_to_vecu64_montgomery(&g1.x);
+    let g1_y = field_to_vecu64_montgomery(&g1.y);
+    let g1_z = field_to_vecu64_montgomery(&g1.z);
+    g1_dict.set_item("x", g1_x).unwrap();
+    g1_dict.set_item("y", g1_y).unwrap();
+    g1_dict.set_item("z", g1_z).unwrap();
+}
+
 /// converts fp into `Vec<u64>` in Montgomery form
 pub fn field_to_vecu64_montgomery<F: PrimeField + SerdeObject + Serialize>(fp: &F) -> [u64; 4] {
     let repr = serde_json::to_string(&fp).unwrap();

--- a/tests/python/binding_tests.py
+++ b/tests/python/binding_tests.py
@@ -65,7 +65,7 @@ def test_poseidon_hash():
 
 def test_elgamal():
     """
-    Test for poseidon_hash
+    Test for elgamal encryption and decryption
     """
     message = [1.0, 2.0, 3.0, 4.0]
     felt_message = [ezkl.float_to_vecu64(x, 7) for x in message]

--- a/tests/python/binding_tests.py
+++ b/tests/python/binding_tests.py
@@ -52,6 +52,37 @@ def test_py_run_args():
     run_args.tolerance = 1.5
 
 
+def test_poseidon_hash():
+    """
+    Test for poseidon_hash
+    """
+    message = [1.0, 2.0, 3.0, 4.0]
+    message = [ezkl.float_to_vecu64(x, 7) for x in message]
+    res = ezkl.poseidon_hash(message)
+    assert ezkl.vecu64_to_felt(
+        res[0]) == "0x0da7e5e5c8877242fa699f586baf770d731defd54f952d4adeb85047a0e32f45"
+
+
+def test_elgamal():
+    """
+    Test for poseidon_hash
+    """
+    message = [1.0, 2.0, 3.0, 4.0]
+    felt_message = [ezkl.float_to_vecu64(x, 7) for x in message]
+
+    # list of len 32
+    rng = [0 for _ in range(32)]
+
+    variables = ezkl.elgamal_gen_random(rng)
+    encrypted_message = ezkl.elgamal_encrypt(
+        variables.pk, felt_message, variables.r)
+    decrypted_message = ezkl.elgamal_decrypt(encrypted_message, variables.sk)
+    assert decrypted_message == felt_message
+
+    recovered_message = [ezkl.vecu64_to_float(x, 7) for x in decrypted_message]
+    assert recovered_message == message
+
+
 def test_field_serialization():
     """
     Test field element serialization


### PR DESCRIPTION
Implements python function for poseidon hashing. 
Example usage: 

```python
message = [1.0, 2.0, 3.0, 4.0]
message = [ezkl.float_to_vecu64(x, 7) for x in message]
res = ezkl.poseidon_hash(message)
assert ezkl.vecu64_to_felt(
        res[0]) == "0x0da7e5e5c8877242fa699f586baf770d731defd54f952d4adeb85047a0e32f45"

```


Implements python function for elgamal encryption and decryption. 
Example usage: 

```python

message = [1.0, 2.0, 3.0, 4.0]
felt_message = [ezkl.float_to_vecu64(x, 7) for x in message]

 # list of len 32
 rng = [0 for _ in range(32)]

variables = ezkl.elgamal_gen_random(rng)
encrypted_message = ezkl.elgamal_encrypt(
variables.pk, felt_message, variables.r)
decrypted_message = ezkl.elgamal_decrypt(encrypted_message, variables.sk)
assert decrypted_message == felt_message

recovered_message = [ezkl.vecu64_to_float(x, 7) for x in decrypted_message]
assert recovered_message == message

```