### PR TITLE
feat: serialize/deserialize ezkljs/engine helper methods

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,7 +294,7 @@ jobs:
         with:
           crate: cargo-nextest
           locked: true
-      - name: Build wasm files for both web and nodejs compilation targets
+      - name: Build wasm package for nodejs target.
         run: |
             wasm-pack build --release --target nodejs --out-dir ./tests/wasm/nodejs . -- -Z build-std="panic_abort,std"
       - name: Replace memory definition in nodejs

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -134,7 +134,6 @@ jobs:
           sed -i '1i\
           export declare function serialize(data: object | string): Uint8ClampedArray;\
           export declare function deserialize(buffer: Uint8ClampedArray | Uint8Array): any;' pkg/web/ezkl.d.ts
-          - name: Create README.md in pkg folder
 
       - name: Create README.md in pkg folder
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           sed -i '51i\
           // import serialize and deserialize from utils.js\
-          import { serialize, deserialize } from '\''./utils.js'\'';\
+          import { serialize, deserialize } from '\''../utils.js'\'';\
           export { serialize, deserialize };' pkg/web/ezkl.js
       - name: Add serialize and deserialize imports to nodejs ezkl.d.ts
         run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -47,6 +47,10 @@ jobs:
           echo '{
             "name": "@ezkljs/engine",
             "version": "${{ github.ref_name }}",
+            "dependencies": {
+              "@types/json-bigint": "^1.0.1",
+              "json-bigint": "^1.0.0"
+            },
             "files": [
               "nodejs/ezkl_bg.wasm",
               "nodejs/ezkl.js",
@@ -57,7 +61,8 @@ jobs:
               "web/ezkl.d.ts",
               "web/snippets/wasm-bindgen-rayon-7afa899f36665473/src/workerHelpers.js",
               "web/package.json",
-              "ezkl.d.ts"
+              "ezkl.d.ts",
+              "utils.js"
             ],
             "main": "nodejs/ezkl.js",
             "module": "web/ezkl.js",
@@ -66,16 +71,69 @@ jobs:
               "web/snippets/*"
             ]
           }' > pkg/package.json
-
+    
       - name: Create ezkl.d.ts in pkg folder
         run: |
-          echo "export const nodejs: typeof import('./nodejs/ezkl');" >> pkg/ezkl.d.ts
-          echo "export const web: typeof import('./web/ezkl');" >> pkg/ezkl.d.ts
+          echo '
+            export const nodejs: typeof import("./nodejs/ezkl");
+            export const web: typeof import("./web/ezkl");
+          ' > pkg/ezkl.d.ts
 
       - name: Replace memory definition in nodejs
         run: |
           sed -i "3s|.*|imports['env'] = {memory: new WebAssembly.Memory({initial:20,maximum:65536,shared:true})}|" pkg/nodejs/ezkl.js
 
+      - name: Add serialize and deserialize methods
+        run: |
+          echo '
+          const JSONBig = require("json-bigint");
+
+          function deserialize(buffer) { // buffer is a Uint8ClampedArray | Uint8Array // return a JSON object
+            if (buffer instanceof Uint8ClampedArray) {
+                buffer = new Uint8Array(buffer.buffer);
+            }
+            const string = new TextDecoder().decode(buffer);
+            const jsonObject = JSONBig.parse(string);
+            return jsonObject;
+          }
+          
+          function serialize(data) { // data is an object // return a Uint8ClampedArray
+            // Step 1: Stringify the Object with BigInt support
+            if (typeof data === "object") {
+                data = JSONBig.stringify(data);
+            }
+            // Step 2: Encode the JSON String
+            const uint8Array = new TextEncoder().encode(data);
+          
+            // Step 3: Convert to Uint8ClampedArray
+            return new Uint8ClampedArray(uint8Array.buffer);
+          }
+          
+          module.exports = {
+            deserialize,
+            serialize
+          };
+          ' > pkg/utils.js
+      - name: Add serialize and deserialize imports to nodejs target
+        run: |
+          sed -i '53i// import serialize and deserialize from utils.js\nconst { serialize, deserialize } = require(`../utils.js`);\nmodule.exports.serialize = serialize;\nmodule.exports.deserialize = deserialize;' pkg/nodejs/ezkl.js
+      - name: Add serialize and deserialize imports to web target
+        run: |
+          sed -i '51i\
+          // import serialize and deserialize from utils.js\
+          import { serialize, deserialize } from '\''./utils.js'\'';\
+          export { serialize, deserialize };' pkg/web/ezkl.js
+      - name: Add serialize and deserialize imports to nodejs ezkl.d.ts
+        run: |
+          sed -i '1i\
+          export declare function serialize(data: object | string): Uint8ClampedArray;\
+          export declare function deserialize(buffer: Uint8ClampedArray | Uint8Array): any;' pkg/nodejs/ezkl.d.ts
+
+      - name: Add serialize and deserialize imports to web ezkl.d.ts
+        run: |
+          sed -i '1i\
+          export declare function serialize(data: object | string): Uint8ClampedArray;\
+          export declare function deserialize(buffer: Uint8ClampedArray | Uint8Array): any;' pkg/web/ezkl.d.ts
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -134,6 +134,12 @@ jobs:
           sed -i '1i\
           export declare function serialize(data: object | string): Uint8ClampedArray;\
           export declare function deserialize(buffer: Uint8ClampedArray | Uint8Array): any;' pkg/web/ezkl.d.ts
+          - name: Create README.md in pkg folder
+
+      - name: Create README.md in pkg folder
+        run: |
+          curl -s "https://raw.githubusercontent.com/zkonduit/ezkljs-engine/main/README.md" > ./pkg/README.md
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/tests/wasm/testWasm.test.ts
+++ b/tests/wasm/testWasm.test.ts
@@ -41,10 +41,13 @@ describe('Generate witness, prove and verify', () => {
         const endTimeProve = Date.now();
         proof_ser = new Uint8ClampedArray(result.buffer);
         // test serialization/deserialization methods
-        const proof_ser_ref = serialize(deserialize(proof_ser));
-        const test = serialize("text");
-        console.log(test);
-        expect(proof_ser_ref).toEqual(proof_ser);
+        const proof = deserialize(proof_ser);
+        const proof_ser_ref = serialize(proof);
+        if (example === "prelu_gmm") {
+            expect(proof_ser_ref.length).toEqual(proof_ser.length);
+        } else {
+            expect(proof_ser_ref).toEqual(proof_ser);
+        }
         proveTime = endTimeProve - startTimeProve;
         expect(result).toBeInstanceOf(Uint8Array);
     });

--- a/tests/wasm/testWasm.test.ts
+++ b/tests/wasm/testWasm.test.ts
@@ -19,6 +19,7 @@ const timingData: {
 describe('Generate witness, prove and verify', () => {
 
     let proof_ser: Uint8ClampedArray
+    let proof_ser_ref: Uint8ClampedArray
     let circuit_settings_ser: Uint8ClampedArray;
     let params_ser: Uint8ClampedArray;
 
@@ -42,12 +43,7 @@ describe('Generate witness, prove and verify', () => {
         proof_ser = new Uint8ClampedArray(result.buffer);
         // test serialization/deserialization methods
         const proof = deserialize(proof_ser);
-        const proof_ser_ref = serialize(proof);
-        if (example === "prelu_gmm") {
-            expect(proof_ser_ref.length).toEqual(proof_ser.length);
-        } else {
-            expect(proof_ser_ref).toEqual(proof_ser);
-        }
+        proof_ser_ref = serialize(proof);
         proveTime = endTimeProve - startTimeProve;
         expect(result).toBeInstanceOf(Uint8Array);
     });
@@ -57,12 +53,14 @@ describe('Generate witness, prove and verify', () => {
         const vk = await readEzklArtifactsFile(path, example, 'key.vk');
         const startTimeVerify = Date.now();
         result = wasmFunctions.verify(proof_ser, vk, circuit_settings_ser, params_ser);
+        const result_ref = wasmFunctions.verify(proof_ser_ref, vk, circuit_settings_ser, params_ser);
         const endTimeVerify = Date.now();
         verifyTime = endTimeVerify - startTimeVerify;
         verifyResult = result;
         // test serialization/deserialization methods
         expect(typeof result).toBe('boolean');
         expect(result).toBe(true);
+        expect(result_ref).toBe(true);
     });
 
     afterAll(() => {

--- a/tests/wasm/testWasm.test.ts
+++ b/tests/wasm/testWasm.test.ts
@@ -1,7 +1,9 @@
 import * as wasmFunctions from './nodejs/ezkl'
 import {
     readEzklArtifactsFile,
-    readEzklSrsFile
+    readEzklSrsFile,
+    serialize,
+    deserialize
 } from './utils';
 import fs from 'fs';
 exports.USER_NAME = require("minimist")(process.argv.slice(2))["example"];
@@ -38,6 +40,11 @@ describe('Generate witness, prove and verify', () => {
         result = wasmFunctions.prove(witness, pk, circuit_ser, params_ser);
         const endTimeProve = Date.now();
         proof_ser = new Uint8ClampedArray(result.buffer);
+        // test serialization/deserialization methods
+        const proof_ser_ref = serialize(deserialize(proof_ser));
+        const test = serialize("text");
+        console.log(test);
+        expect(proof_ser_ref).toEqual(proof_ser);
         proveTime = endTimeProve - startTimeProve;
         expect(result).toBeInstanceOf(Uint8Array);
     });
@@ -50,6 +57,7 @@ describe('Generate witness, prove and verify', () => {
         const endTimeVerify = Date.now();
         verifyTime = endTimeVerify - startTimeVerify;
         verifyResult = result;
+        // test serialization/deserialization methods
         expect(typeof result).toBe('boolean');
         expect(result).toBe(true);
     });

--- a/tests/wasm/utils.ts
+++ b/tests/wasm/utils.ts
@@ -1,23 +1,5 @@
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import JSONBig from 'json-bigint';
-
-// HELPERS FOR ALL TESTS
-
-// Function to convert the return buffer elgamalGenRandom into a JSON object
-export function uint8ArrayToJsonObject(uint8Array: Uint8Array) {
-    let string = new TextDecoder().decode(uint8Array);
-    let jsonObject = JSONBig.parse(string);
-    return jsonObject;
-}
-
-// HELPERS FOR PROVE AND VERIFY TESTS
-
-export async function readDataFile(filename: string): Promise<Uint8ClampedArray> {
-    const filePath = path.join(__dirname, '..', 'public', 'data', filename);
-    const buffer = await fs.readFile(filePath);
-    return new Uint8ClampedArray(buffer.buffer);
-}
 
 export async function readEzklArtifactsFile(path: string, example: string, filename: string): Promise<Uint8ClampedArray> {
     //const filePath = path.join(__dirname, '..', '..', 'ezkl', 'examples', 'onnx', example, filename);
@@ -38,45 +20,23 @@ export async function readEzklSrsFile(path: string, example: string): Promise<Ui
     return new Uint8ClampedArray(buffer.buffer);
 }
 
-export function deserialize(filename: string): any {
-    return readDataFile(filename).then((uint8Array) => {
-        const string = new TextDecoder().decode(uint8Array);
-        const jsonObject = JSONBig.parse(string);
-        return jsonObject;
-    });
+export function deserialize(buffer: Uint8Array | Uint8ClampedArray): object { // buffer is a Uint8ClampedArray | Uint8Array // return a JSON object
+    if (buffer instanceof Uint8ClampedArray) {
+        buffer = new Uint8Array(buffer.buffer);
+    }
+    const string = new TextDecoder().decode(buffer);
+    const jsonObject = JSONBig.parse(string);
+    return jsonObject;
 }
 
-export function serialize(data: any): Uint8ClampedArray {
+export function serialize(data: object | string): Uint8ClampedArray { // data is an object // return a Uint8ClampedArray
     // Step 1: Stringify the Object with BigInt support
-    const jsonString = JSONBig.stringify(data);
-
+    if (typeof data === "object") {
+        data = JSONBig.stringify(data);
+    }
     // Step 2: Encode the JSON String
-    const uint8Array = new TextEncoder().encode(jsonString);
+    const uint8Array = new TextEncoder().encode(data as string);
 
     // Step 3: Convert to Uint8ClampedArray
     return new Uint8ClampedArray(uint8Array.buffer);
-}
-
-/// HELPERS FOR FIELD ELEMENT UTILS TESTS
-
-// Convert an integer value in a field element
-export const intToFieldElement = (int: bigint): bigint => {
-    const primeFieldHex = "0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001";
-    const prime = BigInt(primeFieldHex);
-    return (BigInt(int) + BigInt(prime)) % BigInt(prime);
-};
-
-// Meant to simulate random input tensor values. 
-export function randomZScore() {
-    let u1, u2;
-    do {
-        u1 = Math.random();  // Uniform random number between 0 and 1
-        u2 = Math.random();  // Uniform random number between 0 and 1
-    } while (u1 <= Number.EPSILON);  // Avoid getting u1 as 0
-
-    // Box-Muller transform
-    const z0 = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
-    // const z1 = Math.sqrt(-2.0 * Math.log(u1)) * Math.sin(2.0 * Math.PI * u2);  // Another independent value if needed
-
-    return z0;  // z0 is a random value from a standard normal distribution (z-score)
 }


### PR DESCRIPTION
Added JS based serialize/deserialize helper methods to ezkljs engine package. These helper methods are meant to replicate the `serde_json::from_slice` and `serde_json::to_vec` methods used in the rust based wasm tests [here](https://github.com/zkonduit/ezkl/blob/main/tests/wasm.rs)

To convert a JS object or string representation of an engine input, (e.i. proof, witness, setting, message, e.t.c.) call the `serialized` method, then pass the results to the respective method. 

To convert an engine output to a JS object, pass it to the `deserialized` method