### PR TITLE
chore: lookup overflow benches

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,6 +56,19 @@ jobs:
       - name: Bench accum matmul relu
         run: cargo bench --verbose --bench accum_matmul_relu
 
+  bench_accum_matmul_relu_overflow:
+    runs-on: self-hosted
+    needs: [bench_poseidon]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2023-06-27
+          override: true
+          components: rustfmt, clippy
+      - name: Bench accum matmul relu
+        run: cargo bench --verbose --bench accum_matmul_relu_overflow
+
   bench_relu:
     runs-on: self-hosted
     needs: [bench_poseidon]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,11 @@ harness = false
 name = "accum_matmul_relu"
 harness = false
 
+
+[[bench]]
+name = "accum_matmul_relu_overflow"
+harness = false
+
 [[bin]]
 name = "ezkl"
 test = false

--- a/benches/accum_matmul_relu_overflow.rs
+++ b/benches/accum_matmul_relu_overflow.rs
@@ -16,7 +16,7 @@ use halo2_proofs::{
 use halo2curves::bn256::{Bn256, Fr};
 use std::marker::PhantomData;
 
-const BITS: (i128, i128) = (-8192, 8192);
+const BITS: (i128, i128) = (-8180, 8180);
 static mut LEN: usize = 4;
 static mut K: usize = 16;
 

--- a/benches/accum_matmul_relu_overflow.rs
+++ b/benches/accum_matmul_relu_overflow.rs
@@ -1,0 +1,149 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ezkl::circuit::*;
+
+use ezkl::circuit::lookup::LookupOp;
+use ezkl::circuit::poly::PolyOp;
+use ezkl::pfsys::create_proof_circuit_kzg;
+use ezkl::pfsys::TranscriptType;
+use ezkl::pfsys::{create_keys, srs::gen_srs};
+use ezkl::tensor::*;
+use halo2_proofs::poly::kzg::commitment::KZGCommitmentScheme;
+use halo2_proofs::poly::kzg::strategy::SingleStrategy;
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+use halo2curves::bn256::{Bn256, Fr};
+use std::marker::PhantomData;
+
+const BITS: (i128, i128) = (-8192, 8192);
+static mut LEN: usize = 4;
+static mut K: usize = 16;
+
+#[derive(Clone)]
+struct MyCircuit {
+    inputs: [ValTensor<Fr>; 2],
+    _marker: PhantomData<Fr>,
+}
+
+// A columnar ReLu MLP
+#[derive(Clone)]
+struct MyConfig {
+    base_config: BaseConfig<Fr>,
+}
+
+impl Circuit<Fr> for MyCircuit {
+    type Config = MyConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
+
+    fn without_witnesses(&self) -> Self {
+        self.clone()
+    }
+
+    fn configure(cs: &mut ConstraintSystem<Fr>) -> Self::Config {
+        let len = unsafe { LEN };
+        let k = unsafe { K };
+
+        let a = VarTensor::new_advice(cs, k, len);
+        let b = VarTensor::new_advice(cs, k, len);
+        let output = VarTensor::new_advice(cs, k, len);
+
+        let mut base_config =
+            BaseConfig::configure(cs, &[a.clone(), b.clone()], &output, CheckMode::UNSAFE);
+
+        // sets up a new relu table
+        base_config
+            .configure_lookup(cs, &b, &output, &a, BITS, k, &LookupOp::ReLU)
+            .unwrap();
+
+        MyConfig { base_config }
+    }
+
+    fn synthesize(
+        &self,
+        mut config: Self::Config,
+        mut layouter: impl Layouter<Fr>,
+    ) -> Result<(), Error> {
+        config.base_config.layout_tables(&mut layouter).unwrap();
+        layouter.assign_region(
+            || "",
+            |region| {
+                let op = PolyOp::Einsum {
+                    equation: "ij,jk->ik".to_string(),
+                };
+                let mut region = region::RegionCtx::new(region, 0);
+                let output = config
+                    .base_config
+                    .layout(&mut region, &self.inputs, Box::new(op))
+                    .unwrap();
+                let _output = config
+                    .base_config
+                    .layout(&mut region, &[output.unwrap()], Box::new(LookupOp::ReLU))
+                    .unwrap();
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+}
+
+fn runmatmul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("accum_matmul");
+
+    for &k in [8, 10, 12, 14].iter() {
+        let len = unsafe { LEN };
+        unsafe {
+            K = k;
+        };
+        let params = gen_srs::<KZGCommitmentScheme<_>>(k as u32);
+
+        let mut a = Tensor::from((0..len * len).map(|_| Value::known(Fr::from(1))));
+        a.reshape(&[len, len]);
+
+        // parameters
+        let mut b = Tensor::from((0..len).map(|_| Value::known(Fr::from(1))));
+        b.reshape(&[len, 1]);
+
+        let circuit = MyCircuit {
+            inputs: [ValTensor::from(a), ValTensor::from(b)],
+            _marker: PhantomData,
+        };
+
+        group.throughput(Throughput::Elements(k as u64));
+        group.bench_with_input(BenchmarkId::new("pk", k), &k, |b, &_| {
+            b.iter(|| {
+                create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params)
+                    .unwrap();
+            });
+        });
+
+        let pk =
+            create_keys::<KZGCommitmentScheme<Bn256>, Fr, MyCircuit>(&circuit, &params).unwrap();
+
+        group.throughput(Throughput::Elements(k as u64));
+        group.bench_with_input(BenchmarkId::new("prove", k), &k, |b, &_| {
+            b.iter(|| {
+                let prover = create_proof_circuit_kzg(
+                    circuit.clone(),
+                    &params,
+                    vec![],
+                    &pk,
+                    TranscriptType::EVM,
+                    SingleStrategy::new(&params),
+                    CheckMode::SAFE,
+                );
+                prover.unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_plots().sample_size(10);
+  targets = runmatmul
+}
+criterion_main!(benches);


### PR DESCRIPTION
```javascript

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.0s.
accum_matmul/pk/8       time:   [1.4004 s 1.4526 s 1.5087 s]                               
                        thrpt:  [5.3024  elem/s 5.5075  elem/s 5.7126  elem/s]
Benchmarking accum_matmul/prove/8: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 122.0s.
accum_matmul/prove/8    time:   [11.936 s 11.987 s 12.044 s]                                  
                        thrpt:  [0.6642  elem/s 0.6674  elem/s 0.6703  elem/s]
Benchmarking accum_matmul/pk/10: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s.
accum_matmul/pk/10      time:   [533.47 ms 548.48 ms 564.56 ms]                             
                        thrpt:  [17.713  elem/s 18.232  elem/s 18.745  elem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking accum_matmul/prove/10: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 17.4s.
accum_matmul/prove/10   time:   [1.6965 s 1.7074 s 1.7178 s]                                   
                        thrpt:  [5.8215  elem/s 5.8567  elem/s 5.8946  elem/s]
accum_matmul/pk/12      time:   [452.25 ms 471.55 ms 504.93 ms]                             
                        thrpt:  [23.766  elem/s 25.448  elem/s 26.534  elem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking accum_matmul/prove/12: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.3s.
accum_matmul/prove/12   time:   [765.25 ms 779.00 ms 792.69 ms]                                
                        thrpt:  [15.138  elem/s 15.404  elem/s 15.681  elem/s]
Benchmarking accum_matmul/pk/14: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s.
accum_matmul/pk/14      time:   [515.34 ms 520.66 ms 526.01 ms]                             
                        thrpt:  [26.616  elem/s 26.889  elem/s 27.166  elem/s]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking accum_matmul/prove/14: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.0s.
accum_matmul/prove/14   time:   [740.22 ms 752.68 ms 766.79 ms]                                
                        thrpt:  [18.258  elem/s 18.600  elem/s 18.913  elem/s]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
```

lookup was selected to fit in 1 col in K=14. It seems like we can tolerate quite a bit of overflow (K=12, so 4 columns) before performance degrades. 


