### PR TITLE
chore: fix typos in comments

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -313,7 +313,7 @@ pub enum Commands {
         /// The path to samples of snarks that will be aggregated over
         #[arg(long)]
         sample_snarks: Vec<PathBuf>,
-        /// The path to save the desired verfication key file
+        /// The path to save the desired verification key file
         #[arg(long, default_value = "vk_aggr.key")]
         vk_path: PathBuf,
         /// The path to save the desired proving key file
@@ -378,7 +378,7 @@ pub enum Commands {
         /// The srs path
         #[arg(long)]
         srs_path: PathBuf,
-        /// The path to output the verfication key file
+        /// The path to output the verification key file
         #[arg(long, default_value = "vk.key")]
         vk_path: PathBuf,
         /// The path to output the proving key file
@@ -499,7 +499,7 @@ pub enum Commands {
         /// The path to load circuit settings from
         #[arg(short = 'S', long)]
         settings_path: PathBuf,
-        /// The path to load the desired verfication key file
+        /// The path to load the desired verification key file
         #[arg(long)]
         vk_path: PathBuf,
         /// The path to output the Solidity code
@@ -519,7 +519,7 @@ pub enum Commands {
         /// The path to load circuit settings from
         #[arg(short = 'S', long)]
         settings_path: PathBuf,
-        /// The path to load the desired verfication key file
+        /// The path to load the desired verification key file
         #[arg(long)]
         vk_path: PathBuf,
         /// The path to output the Solidity code
@@ -545,7 +545,7 @@ pub enum Commands {
         /// The path to load the desired srs file from
         #[arg(long)]
         srs_path: PathBuf,
-        /// The path to output to load the desired verfication key file
+        /// The path to output to load the desired verification key file
         #[arg(long)]
         vk_path: PathBuf,
         /// The path to the Solidity code
@@ -567,7 +567,7 @@ pub enum Commands {
         /// The path to the proof file
         #[arg(long)]
         proof_path: PathBuf,
-        /// The path to output the desired verfication key file (optional)
+        /// The path to output the desired verification key file (optional)
         #[arg(long)]
         vk_path: PathBuf,
         /// The kzg srs path
@@ -580,7 +580,7 @@ pub enum Commands {
         /// The path to the proof file
         #[arg(long)]
         proof_path: PathBuf,
-        /// The path to output the desired verfication key file (optional)
+        /// The path to output the desired verification key file (optional)
         #[arg(long)]
         vk_path: PathBuf,
         /// The srs path

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -722,7 +722,7 @@ pub fn fix_da_sol(
     let mut accounts_len = 0;
     let mut contract = ATTESTDATA_SOL.to_string();
     let load_instances = LOADINSTANCES_SOL.to_string();
-    // replace the import statment with the load_instances contract, not including the
+    // replace the import statement with the load_instances contract, not including the
     // `SPDX-License-Identifier: MIT pragma solidity ^0.8.20;` at the top of the file
     contract = contract.replace(
         "import './LoadInstances.sol';",


### PR DESCRIPTION
fix typos in comments