### PR TITLE
feat: expose print proof hex in wasm

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -444,10 +444,10 @@ pub fn prove(
 
 /// print hex representation of a proof
 #[wasm_bindgen]
-pub fn printProofHex(proof_path: PathBuf) -> Result<String, JsError> {
-    let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path)
-        .map_err(|_| PyIOError::new_err("Failed to load proof"))?;
-
+#[allow(non_snake_case)]
+pub fn printProofHex(proof: wasm_bindgen::Clamped<Vec<u8>>) -> Result<String, JsError> {
+    let proof: crate::pfsys::Snark<Fr, G1Affine> = serde_json::from_slice(&proof[..])
+        .map_err(|e| JsError::new(&format!("Failed to deserialize proof: {}", e)))?;
     Ok(hex::encode(proof.proof))
 }
 // VALIDATION FUNCTIONS

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -442,6 +442,14 @@ pub fn prove(
         .into_bytes())
 }
 
+/// print hex representation of a proof
+#[wasm_bindgen]
+pub fn printProofHex(proof_path: PathBuf) -> Result<String, JsError> {
+    let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path)
+        .map_err(|_| PyIOError::new_err("Failed to load proof"))?;
+
+    Ok(hex::encode(proof.proof))
+}
 // VALIDATION FUNCTIONS
 
 /// Witness file validation

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -12,9 +12,9 @@ mod wasm32 {
     use ezkl::wasm::{
         bufferToVecOfVecU64, compiledCircuitValidation, elgamalDecrypt, elgamalEncrypt,
         elgamalGenRandom, encodeVerifierCalldata, genPk, genVk, genWitness, inputValidation,
-        pkValidation, poseidonHash, proofValidation, prove, settingsValidation, srsValidation,
-        u8_array_to_u128_le, vecU64ToFelt, vecU64ToFloat, vecU64ToInt, verify, vkValidation,
-        witnessValidation,
+        pkValidation, poseidonHash, printProofHex, proofValidation, prove, settingsValidation,
+        srsValidation, u8_array_to_u128_le, vecU64ToFelt, vecU64ToFloat, vecU64ToInt, verify,
+        vkValidation, witnessValidation,
     };
     use halo2_solidity_verifier::encode_calldata;
     use halo2curves::bn256::{Fr, G1Affine};
@@ -314,6 +314,15 @@ mod wasm32 {
 
         // should not fail
         assert!(value);
+    }
+
+    #[wasm_bindgen_test]
+    async fn print_proof_hex_test() {
+        let proof = printProofHex(wasm_bindgen::Clamped(PROOF.to_vec()))
+            .map_err(|_| "failed")
+            .unwrap();
+
+        assert!(proof.len() > 0);
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
We should be able to print the `proof.proof` of a proof files content as a hex string instead of a uint 8 array on the client. 