### PR TITLE
chore: add hardfork test for kzg_evm_kzg_input_prove_and_verify

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -960,12 +960,16 @@ mod native_tests {
             ];
 
             seq!(N in 0..=16 {
-                #(#[test_case(TESTS_ON_CHAIN_INPUT[N])])*
-                fn kzg_evm_on_chain_input_prove_and_verify_(test: &str) {
+                #(#[test_case((TESTS_ON_CHAIN_INPUT[N],Hardfork::Latest))])*
+                #(#[test_case((TESTS_ON_CHAIN_INPUT[N],Hardfork::Paris))])*
+                #(#[test_case((TESTS_ON_CHAIN_INPUT[N],Hardfork::London))])*
+                #(#[test_case((TESTS_ON_CHAIN_INPUT[N],Hardfork::Shanghai))])*
+                fn kzg_evm_on_chain_input_prove_and_verify_(test: (&str,Hardfork)) {
+                    let (test,hardfork) = test;
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(true,Hardfork::Latest);
+                    let _anvil_child = crate::native_tests::start_anvil(true,hardfork);
                     kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "on-chain", "file", "public", "private");
                     // test_dir.close().unwrap();
                 }
@@ -1075,6 +1079,7 @@ mod native_tests {
                 #(#[test_case((TESTS_EVM[N], Hardfork::Latest))])*
                 #(#[test_case((TESTS_EVM[N], Hardfork::Paris))])*
                 #(#[test_case((TESTS_EVM[N], Hardfork::London))])*
+                #(#[test_case((TESTS_EVM[N], Hardfork::Shanghai))])*
                 fn kzg_evm_kzg_input_prove_and_verify_(test: (&str, Hardfork)) {
                     let (test,hardfork) = test;
                     crate::native_tests::init_binary();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,7 +18,15 @@ mod native_tests {
     static ENV_SETUP: Once = Once::new();
 
     //Sure to run this once
-
+    #[derive(Debug)]
+    enum Hardfork {
+        London,
+        ArrowGlacier,
+        GrayGlacier,
+        Paris,
+        Shanghai,
+        Latest,
+    }
     lazy_static! {
         static ref CARGO_TARGET_DIR: String =
             var("CARGO_TARGET_DIR").unwrap_or_else(|_| "./target".to_string());
@@ -28,7 +36,7 @@ mod native_tests {
             "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();
     }
 
-    fn start_anvil(limitless: bool) -> Child {
+    fn start_anvil(limitless: bool, hardfork: Hardfork) -> Child {
         let mut args = vec!["-p"];
         if limitless {
             args.push("8545");
@@ -37,12 +45,20 @@ mod native_tests {
         } else {
             args.push("3030");
         }
+        match hardfork {
+            Hardfork::Paris => args.push("--hardfork=paris"),
+            Hardfork::London => args.push("--hardfork=london"),
+            Hardfork::Latest => {}
+            Hardfork::Shanghai => args.push("--hardfork=shanghai"),
+            Hardfork::ArrowGlacier => args.push("--hardfork=arrowGlacier"),
+            Hardfork::GrayGlacier => args.push("--hardfork=grayGlacier"),
+        }
+        // panic!("{}", args.join(" "));
         let child = Command::new("anvil")
             .args(args)
-            // .stdout(Stdio::piped())
+            // .stdout(std::process::Stdio::piped())
             .spawn()
             .expect("failed to start anvil process");
-
         std::thread::sleep(std::time::Duration::from_secs(3));
         child
     }
@@ -920,6 +936,7 @@ mod native_tests {
             use crate::native_tests::kzg_evm_aggr_prove_and_verify;
             use crate::native_tests::kzg_fuzz;
             use tempdir::TempDir;
+            use crate::native_tests::Hardfork;
 
             /// Currently only on chain inputs that return a non-negative value are supported.
             const TESTS_ON_CHAIN_INPUT: [&str; 17] = [
@@ -948,7 +965,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(true);
+                    let _anvil_child = crate::native_tests::start_anvil(true,Hardfork::Latest);
                     kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "on-chain", "file", "public", "private");
                     // test_dir.close().unwrap();
                 }
@@ -958,7 +975,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(true);
+                    let _anvil_child = crate::native_tests::start_anvil(true,Hardfork::Latest);
                     kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "file", "on-chain", "private", "public");
                     // test_dir.close().unwrap();
                 }
@@ -968,7 +985,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(true);
+                    let _anvil_child = crate::native_tests::start_anvil(true,Hardfork::Latest);
                     kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "on-chain", "on-chain", "public", "public");
                     test_dir.close().unwrap();
                 }
@@ -978,7 +995,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(true);
+                    let _anvil_child = crate::native_tests::start_anvil(true,Hardfork::Latest);
                     kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "on-chain", "on-chain", "hashed", "hashed");
                     test_dir.close().unwrap();
                 }
@@ -993,7 +1010,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_aggr_prove_and_verify(path, test.to_string(), "private", "private", "public");
                     test_dir.close().unwrap();
                 }
@@ -1006,7 +1023,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_aggr_prove_and_verify(path, test.to_string(), "encrypted", "private", "public");
                     test_dir.close().unwrap();
                 }
@@ -1020,7 +1037,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "private", "private", "public");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1035,7 +1052,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "encrypted", "private", "public");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1047,7 +1064,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let mut _anvil_child = crate::native_tests::start_anvil(false);
+                    let mut _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "hashed", "private", "private");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1055,12 +1072,15 @@ mod native_tests {
                 }
 
 
-                #(#[test_case(TESTS_EVM[N])])*
-                fn kzg_evm_kzg_input_prove_and_verify_(test: &str) {
+                #(#[test_case((TESTS_EVM[N], Hardfork::Latest))])*
+                #(#[test_case((TESTS_EVM[N], Hardfork::Paris))])*
+                #(#[test_case((TESTS_EVM[N], Hardfork::London))])*
+                fn kzg_evm_kzg_input_prove_and_verify_(test: (&str, Hardfork)) {
+                    let (test,hardfork) = test;
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let mut _anvil_child = crate::native_tests::start_anvil(false);
+                    let mut _anvil_child = crate::native_tests::start_anvil(false,hardfork);
                     kzg_evm_prove_and_verify(path, test.to_string(), "kzgcommit", "private", "public");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1073,7 +1093,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "private", "hashed", "public");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1086,7 +1106,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "private", "private", "hashed");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1099,7 +1119,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "private", "kzgcommit", "public");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1112,7 +1132,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_evm_prove_and_verify(path, test.to_string(), "private", "private", "kzgcommit");
                     #[cfg(not(feature = "icicle"))]
                     run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
@@ -1126,7 +1146,7 @@ mod native_tests {
                     crate::native_tests::init_binary();
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
-                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    let _anvil_child = crate::native_tests::start_anvil(false,Hardfork::Latest);
                     kzg_fuzz(path, test.to_string(), "evm");
                     test_dir.close().unwrap();
 


### PR DESCRIPTION
#364 

This is a sample implementation for only kzg_evm_kzg_input_prove_and_verify_ for now. Let me know what you think.

Approach:
* Add a hardfork enum
* Add a hardfork parameter for start_anvil and each test function.
* Use macro to make sure test run on each hardfork. Currently, we run London, Paris and latest blockchain fork.

![Screenshot 2023-11-18 at 21 51 02](https://github.com/zkonduit/ezkl/assets/22890026/1a6035f6-15ee-4c5b-9d2c-8e1ed5c2f9fc)
