### PR TITLE
fix: allow for 0 instance evm verifier

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,6 +294,8 @@ jobs:
         run: (hash svm 2>/dev/null || cargo install svm-rs) && svm install 0.8.20 && solc --version
       - name: Install Anvil
         run: cargo install --git https://github.com/foundry-rs/foundry --rev 95a93cd397f25f3f8d49d2851eb52bc2d52dd983 --profile local --locked anvil --force
+      - name: KZG prove and verify tests (EVM + kzg all)
+        run: cargo nextest run --release --verbose tests_evm::kzg_evm_kzg_all_prove_and_verify --test-threads 1
       - name: KZG prove and verify tests (EVM + kzg inputs)
         run: cargo nextest run --release --verbose tests_evm::kzg_evm_kzg_input_prove_and_verify --test-threads 1
       - name: KZG prove and verify tests (EVM + kzg params)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "halo2_solidity_verifier"
 version = "0.1.0"
-source = "git+https://github.com/alexander-camuto/halo2-solidity-verifier?branch=ac/chunked-lookup-verifier#b5885027bae560391334f8b63a14c5d377ce6e0e"
+source = "git+https://github.com/alexander-camuto/halo2-solidity-verifier#de1326d837ac2fd97363793e30d0639a95bdc0e9"
 dependencies = [
  "askama",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = { version = "1.0.38", default_features = false }
 hex = { version = "0.4.3", default_features = false }
 halo2_wrong_ecc = { git = "https://github.com/zkonduit/halo2wrong", branch = "ac/chunked-mv-lookup", package = "ecc" }
 snark-verifier = { git = "https://github.com/zkonduit/snark-verifier", branch = "ac/chunked-mv-lookup", features=["derive_serde"]}
-halo2_solidity_verifier = { git = "https://github.com/alexander-camuto/halo2-solidity-verifier", branch= "ac/chunked-lookup-verifier" }
+halo2_solidity_verifier = { git = "https://github.com/alexander-camuto/halo2-solidity-verifier", ref = "de1326d837ac2fd97363793e30d0639a95bdc0e9" }
 rayon = { version = "1.7.0",  default_features = false }
 bincode = { version = "1.3.3", default_features = false }
 ark-std = { version = "^0.3.0", default-features = false }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1119,6 +1119,18 @@ mod native_tests {
                     test_dir.close().unwrap();
                 }
 
+                #(#[test_case(TESTS_EVM[N])])*
+                fn kzg_evm_kzg_all_prove_and_verify_(test: &str) {
+                    crate::native_tests::init_binary();
+                    let test_dir = TempDir::new(test).unwrap();
+                    let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
+                    let _anvil_child = crate::native_tests::start_anvil(false);
+                    kzg_evm_prove_and_verify(path, test.to_string(), "kzgcommit", "kzgcommit", "kzgcommit");
+                    #[cfg(not(feature = "icicle"))]
+                    run_js_tests(path, test.to_string(), "testBrowserEvmVerify");
+                    test_dir.close().unwrap();
+                }
+
 
 
                 #(#[test_case(TESTS_EVM[N])])*


### PR DESCRIPTION
allows for the  "all kzgcommit" settings to be verifiable on-chain. 