### PR TITLE
fix: use venv on musl linux

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -302,6 +302,8 @@ jobs:
             apk add py3-pip
             pip3 install -U pip
           run: |
+            apk add py3-pip
+            pip3 install -U pip
             python3 -m venv .venv
             source .venv/bin/activate
             pip3 install ezkl --no-index --find-links dist/ --force-reinstall

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -248,6 +248,8 @@ jobs:
           run: |
             apk add py3-pip
             pip3 install -U pip
+            python3 -m venv .venv
+            source .venv/bin/activate            
             pip3 install ezkl --no-index --find-links /io/dist/ --force-reinstall
             python3 -c "import ezkl"
 
@@ -300,6 +302,8 @@ jobs:
             apk add py3-pip
             pip3 install -U pip
           run: |
+            python3 -m venv .venv
+            source .venv/bin/activate
             pip3 install ezkl --no-index --find-links dist/ --force-reinstall
             python3 -c "import ezkl"
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -300,9 +300,9 @@ jobs:
           githubToken: ${{ github.token }}
           run: |
             apk add py3-pip
-            pip3 install -U pip
             python3 -m venv .venv
             source .venv/bin/activate
+            pip3 install -U pip
             pip3 install ezkl --no-index --find-links dist/ --force-reinstall
             python3 -c "import ezkl"
 


### PR DESCRIPTION
Changes:
1. Uses virtualenv on musl. This is to comply with (PEP-668)[https://peps.python.org/pep-0668/], which will prevent users from installing into the system python environment so as to not break system packages.