### PR TITLE
chore: hex encoded (optional) proof field

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1548,6 +1548,7 @@ pub(crate) fn fuzz(
             transcript_type: transcript,
             split: None,
             pretty_public_inputs: None,
+            hex_proof: None,
             timestamp: None,
         };
 
@@ -1581,6 +1582,7 @@ pub(crate) fn fuzz(
             protocol: proof.protocol.clone(),
             transcript_type: transcript,
             split: None,
+            hex_proof: None,
             pretty_public_inputs: None,
             timestamp: None,
         };

--- a/src/pfsys/mod.rs
+++ b/src/pfsys/mod.rs
@@ -234,6 +234,8 @@ where
     pub instances: Vec<Vec<F>>,
     /// the proof
     pub proof: Vec<u8>,
+    /// hex encoded proof
+    pub hex_proof: Option<String>,
     /// transcript type
     pub transcript_type: TranscriptType,
     /// the split proof
@@ -281,6 +283,7 @@ where
         protocol: Option<PlonkProtocol<C>>,
         instances: Vec<Vec<F>>,
         proof: Vec<u8>,
+        hex_proof: Option<String>,
         transcript_type: TranscriptType,
         split: Option<ProofSplitCommit>,
         pretty_public_inputs: Option<PrettyElements>,
@@ -289,6 +292,7 @@ where
             protocol,
             instances,
             proof,
+            hex_proof,
             transcript_type,
             split,
             pretty_public_inputs,
@@ -523,8 +527,17 @@ where
         &mut transcript,
     )?;
     let proof = transcript.finalize();
+    let hex_proof = hex::encode(&proof);
 
-    let checkable_pf = Snark::new(protocol, instances, proof, transcript_type, split, None);
+    let checkable_pf = Snark::new(
+        protocol,
+        instances,
+        proof,
+        Some(hex_proof),
+        transcript_type,
+        split,
+        None,
+    );
 
     // sanity check that the generated proof is valid
     if check_mode == CheckMode::SAFE {
@@ -894,6 +907,7 @@ mod tests {
             instances: vec![vec![Fr::from(1)], vec![Fr::from(2)]],
             transcript_type: TranscriptType::EVM,
             protocol: None,
+            hex_proof: None,
             split: None,
             pretty_public_inputs: None,
             timestamp: None,


### PR DESCRIPTION
```rust
/// An application snark with proof and instance variables ready for aggregation (raw field element)
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct Snark<F: PrimeField + SerdeObject, C: CurveAffine>
where
    C::Scalar: Serialize + DeserializeOwned,
    C::ScalarExt: Serialize + DeserializeOwned,
{
    /// the protocol
    pub protocol: Option<PlonkProtocol<C>>,
    /// public instances of the snark
    pub instances: Vec<Vec<F>>,
    /// the proof
    pub proof: Vec<u8>,
    /// hex encoded proof
    pub hex_proof: Option<String>,
    /// transcript type
    pub transcript_type: TranscriptType,
    /// the split proof
    pub split: Option<ProofSplitCommit>,
    /// the proof instances as rescaled floats
    pub pretty_public_inputs: Option<PrettyElements>,
    /// timestamp
    pub timestamp: Option<u128>,
}

```