### PR TITLE
fix: prepend 0x to proof

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -965,8 +965,8 @@ pub(crate) fn print_proof_hex(proof_path: PathBuf) -> Result<String, Box<dyn Err
         println!("{:?}", instance);
     }
     let hex_str = hex::encode(proof.proof);
-    info!("{}", hex_str);
-    Ok(hex_str)
+    info!("0x{}", hex_str);
+    Ok(format!("0x{}", hex_str))
 }
 
 #[cfg(feature = "render")]

--- a/src/pfsys/mod.rs
+++ b/src/pfsys/mod.rs
@@ -263,7 +263,7 @@ where
             .collect::<Vec<_>>();
         dict.set_item("instances", field_elems).unwrap();
         let hex_proof = hex::encode(&self.proof);
-        dict.set_item("proof", hex_proof).unwrap();
+        dict.set_item("proof", format!("0x{}", hex_proof)).unwrap();
         dict.set_item("transcript_type", self.transcript_type)
             .unwrap();
         dict.to_object(py)
@@ -527,7 +527,7 @@ where
         &mut transcript,
     )?;
     let proof = transcript.finalize();
-    let hex_proof = hex::encode(&proof);
+    let hex_proof = format!("0x{}", hex::encode(&proof));
 
     let checkable_pf = Snark::new(
         protocol,

--- a/src/python.rs
+++ b/src/python.rs
@@ -1015,7 +1015,8 @@ fn print_proof_hex(proof_path: PathBuf) -> Result<String, PyErr> {
     let proof = Snark::load::<KZGCommitmentScheme<Bn256>>(&proof_path)
         .map_err(|_| PyIOError::new_err("Failed to load proof"))?;
 
-    Ok(hex::encode(proof.proof))
+    let hex_str = hex::encode(proof.proof);
+    Ok(format!("0x{}", hex_str))
 }
 
 // Python Module

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -388,7 +388,8 @@ pub fn prove(
 pub fn printProofHex(proof: wasm_bindgen::Clamped<Vec<u8>>) -> Result<String, JsError> {
     let proof: crate::pfsys::Snark<Fr, G1Affine> = serde_json::from_slice(&proof[..])
         .map_err(|e| JsError::new(&format!("Failed to deserialize proof: {}", e)))?;
-    Ok(hex::encode(proof.proof))
+    let hex_str = hex::encode(proof.proof);
+    Ok(format!("0x{}", hex_str))
 }
 // VALIDATION FUNCTIONS
 


### PR DESCRIPTION
Changes:
1. prepend `0x` to the `hex_proof` for consistency and to match what the evm generally expects.