### PR TITLE
Fix for linking issue 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "icicle"
 version = "0.1.0"
-source = "git+https://github.com/ingonyama-zk/icicle?rev=f8610dd?rev=f8610dd5b617d11832418ce0f683c54b0ae3e3b2#f8610dd5b617d11832418ce0f683c54b0ae3e3b2"
+source = "git+https://github.com/ingonyama-zk/icicle?rev=45b00fb?branch=fix/vhnat/ezkl-build-fix#45b00fb1966cb236979f03f9068f6db9bf59f41e"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["profile-rustflags"]
+
 [package]
 name = "ezkl"
 version = "0.0.0"
@@ -159,4 +161,7 @@ icicle = ["halo2_proofs/icicle_gpu"]
 
 # icicle patch to 0.1.0 if feature icicle is enabled
 [patch.'https://github.com/ingonyama-zk/icicle']
-icicle = { git = "https://github.com/ingonyama-zk/icicle?rev=f8610dd", rev="f8610dd5b617d11832418ce0f683c54b0ae3e3b2", package = "icicle" }
+icicle = { git = "https://github.com/ingonyama-zk/icicle?rev=45b00fb", rev="45b00fb1966cb236979f03f9068f6db9bf59f41e", package = "icicle", branch = "fix/vhnat/ezkl-build-fix"}
+
+[profile.release]
+rustflags = [ "-C", "relocation-model=pic" ]


### PR DESCRIPTION
fix for icicle being static and non-PIC, 

strange but only [`set(CMAKE_POSITION_INDEPENDENT_CODE ON)`](https://github.com/ingonyama-zk/icicle/blob/45b00fb1966cb236979f03f9068f6db9bf59f41e/icicle/CMakeLists.txt#L57C17-L57C17) seems working while other options and flags should work as well
