### PR TITLE
Icicle PIC

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,6 @@
 runner = 'wasm-bindgen-test-runner'
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals","-C",
  "link-arg=--max-memory=4294967296"]
+
+[env]
+ICICLE_PIC = "ON"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "icicle"
 version = "0.1.0"
-source = "git+https://github.com/ingonyama-zk/icicle?rev=45b00fb?branch=fix/vhnat/ezkl-build-fix#45b00fb1966cb236979f03f9068f6db9bf59f41e"
+source = "git+https://github.com/ingonyama-zk/icicle?rev=3884ad6?rev=3884ad64112b4588f7071e598685ce1817eaef7e#3884ad64112b4588f7071e598685ce1817eaef7e"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["profile-rustflags"]
-
 [package]
 name = "ezkl"
 version = "0.0.0"
@@ -161,7 +159,4 @@ icicle = ["halo2_proofs/icicle_gpu"]
 
 # icicle patch to 0.1.0 if feature icicle is enabled
 [patch.'https://github.com/ingonyama-zk/icicle']
-icicle = { git = "https://github.com/ingonyama-zk/icicle?rev=45b00fb", package = "icicle", branch = "fix/vhnat/ezkl-build-fix"}
-
-[profile.release]
-rustflags = [ "-C", "relocation-model=pic" ]
+icicle = { git = "https://github.com/ingonyama-zk/icicle?rev=3884ad6", rev="3884ad64112b4588f7071e598685ce1817eaef7e", package = "icicle" }


### PR DESCRIPTION
optional pic  via ICICLE_PIC env var - Rust still doesn't allow enable features for patches and [env vars for dependencies from build.rs, only config.toml](https://github.com/rust-lang/cargo/issues/97#issuecomment-303533791)