### PR TITLE
docs: set `max_logrows` for `calibrate_settings` in ezkl_demo

### DIFF
--- a/examples/notebooks/ezkl_demo.ipynb
+++ b/examples/notebooks/ezkl_demo.ipynb
@@ -441,7 +441,9 @@
         "# Serialize calibration data into file:\n",
         "json.dump(data, open(cal_data_path, 'w'))\n",
         "\n",
-        "res = ezkl.calibrate_settings(cal_data_path, model_path, settings_path, \"resources\")  # Optimize for resources"
+        "# Optimize for resources, we cap logrows at 17 to reduce setup and proving time, at the expense of accuracy\n",
+        "# You may want to increase the max logrows if accuracy is a concern\n",
+        "res = ezkl.calibrate_settings(cal_data_path, model_path, settings_path, \"resources\", max_logrows = 17)"
       ]
     },
     {


### PR DESCRIPTION
Changes:
1. The default settings for ezkl will generally set logrows at a value such that it may overload google colab free tier. To make the `ezkl_demo.ipynb` setup step executable within google colab free tier, we cap the `max_logrows` at `17` within `calibrate-settings`.