### PR TITLE
Prevent multiple additions of `EZKL_DIR` to `PATH` in install_ezkl_cli.sh

### DIFF
--- a/install_ezkl_cli.sh
+++ b/install_ezkl_cli.sh
@@ -36,7 +36,7 @@ if  [ "$(which ezkl)s" != "s" ] && [ "$(which ezkl)" != "$EZKL_DIR/ezkl" ] ; the
     exit 1
 fi
 
-if [[ ":$PATH:" != *":${EZKl_DIR}:"* ]]; then
+if [[ ":$PATH:" != *":${EZKL_DIR}:"* ]]; then
     # Add the ezkl directory to the path and ensure the old PATH variables remain.
     echo >> $PROFILE && echo "export PATH=\"\$PATH:$EZKL_DIR\"" >> $PROFILE
 fi


### PR DESCRIPTION
## Description
The install_ezkl_cli.sh script is supposed to add the `EZKL_DIR` to the `PATH` if it's not already present. However, due to a typo in the variable name (`EZKl_DIR` instead of `EZKL_DIR`), the script fails to correctly check if the directory is already in the PATH, and consequently, it always adds the directory to the `PATH` even if it's already there.

So this PR just fixes the typo.