### PR TITLE
feat: create encode-evm-calldata in cli and python

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,6 +52,8 @@ pub const DEFAULT_VERIFIER_AGGREGATED_ABI: &str = "verifier_aggr_abi.json";
 pub const DEFAULT_VERIFIER_DA_ABI: &str = "verifier_da_abi.json";
 /// Default solidity code
 pub const DEFAULT_SOL_CODE: &str = "evm_deploy.sol";
+/// Default calldata path
+pub const DEFAULT_CALLDATA: &str = "calldata.bytes";
 /// Default solidity code for aggregated proofs
 pub const DEFAULT_SOL_CODE_AGGREGATED: &str = "evm_deploy_aggr.sol";
 /// Default solidity code for data attestation
@@ -593,6 +595,20 @@ pub enum Commands {
         /// run sanity checks during calculations (safe or unsafe)
         #[arg(long, default_value = DEFAULT_CHECKMODE)]
         check_mode: Option<CheckMode>,
+    },
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Encodes a proof into evm calldata
+    #[command(name = "encode-evm-calldata")]
+    EncodeEvmCalldata {
+        /// The path to the proof file (generated using the prove command)
+        #[arg(long, default_value = DEFAULT_PROOF)]
+        proof_path: Option<PathBuf>,
+        /// The path to the Solidity code
+        #[arg(long, default_value = DEFAULT_CALLDATA)]
+        calldata_path: Option<PathBuf>,
+        /// The path to the verification key address (only used if the vk is rendered as a separate contract)
+        #[arg(long)]
+        addr_vk: Option<H160Flag>,
     },
     #[cfg(not(target_arch = "wasm32"))]
     /// Creates an Evm verifier for a single proof

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -922,7 +922,7 @@ pub async fn get_contract_artifacts(
         return Err(format!("file not found: {:#?}", sol_code_path).into());
     }
 
-    let mut settings = SolcSettings {
+    let settings = SolcSettings {
         optimizer: Optimizer {
             enabled: Some(true),
             runs: Some(runs),

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -922,13 +922,15 @@ pub async fn get_contract_artifacts(
         return Err(format!("file not found: {:#?}", sol_code_path).into());
     }
 
-    let mut settings = SolcSettings::default();
-    settings.optimizer = Optimizer {
-        enabled: Some(true),
-        runs: Some(runs),
-        details: None,
+    let mut settings = SolcSettings {
+        optimizer: Optimizer {
+            enabled: Some(true),
+            runs: Some(runs),
+            details: None,
+        },
+        output_selection: OutputSelection::default_output_selection(),
+        ..Default::default()
     };
-    settings.output_selection = OutputSelection::default_output_selection();
 
     let input = SolcInput::build(
         std::collections::BTreeMap::from([(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1816,7 +1816,7 @@ mod native_tests {
 
         // create encoded calldata
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-            .args(&[
+            .args([
                 "encode-evm-calldata",
                 "--proof-path",
                 &format!("{}/{}/aggr.pf", test_dir, example_name),
@@ -2050,7 +2050,7 @@ mod native_tests {
 
         // create encoded calldata
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-            .args(&[
+            .args([
                 "encode-evm-calldata",
                 "--proof-path",
                 &format!("{}/{}/proof.pf", test_dir, example_name),
@@ -2231,7 +2231,7 @@ mod native_tests {
 
         // create encoded calldata
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-            .args(&[
+            .args([
                 "encode-evm-calldata",
                 "--proof-path",
                 &format!("{}/{}/proof.pf", test_dir, example_name),
@@ -2415,7 +2415,7 @@ mod native_tests {
 
         // create encoded calldata
         let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
-            .args(&[
+            .args([
                 "encode-evm-calldata",
                 "--proof-path",
                 &format!("{}/{}/proof.pf", test_dir, example_name),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1814,6 +1814,18 @@ mod native_tests {
         let settings_arg = format!("{}/{}/settings.json", test_dir, example_name);
         let private_key = format!("--private-key={}", *ANVIL_DEFAULT_PRIVATE_KEY);
 
+        // create encoded calldata
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args(&[
+                "encode-evm-calldata",
+                "--proof-path",
+                &format!("{}/{}/aggr.pf", test_dir, example_name),
+            ])
+            .status()
+            .expect("failed to execute process");
+
+        assert!(status.success());
+
         let base_args = vec![
             "create-evm-verifier-aggr",
             "--vk-path",
@@ -2036,6 +2048,18 @@ mod native_tests {
         let addr_path_arg = format!("--addr-path={}/{}/addr.txt", test_dir, example_name);
         let settings_arg = format!("--settings-path={}", settings_path);
 
+        // create encoded calldata
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args(&[
+                "encode-evm-calldata",
+                "--proof-path",
+                &format!("{}/{}/proof.pf", test_dir, example_name),
+            ])
+            .status()
+            .expect("failed to execute process");
+
+        assert!(status.success());
+
         // create the verifier
         let mut args = vec!["create-evm-verifier", "--vk-path", &vk_arg, &settings_arg];
 
@@ -2204,6 +2228,19 @@ mod native_tests {
             .expect("failed to read address file");
 
         let deployed_addr_arg_vk = format!("--addr-vk={}", addr_vk);
+
+        // create encoded calldata
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args(&[
+                "encode-evm-calldata",
+                "--proof-path",
+                &format!("{}/{}/proof.pf", test_dir, example_name),
+                &deployed_addr_arg_vk,
+            ])
+            .status()
+            .expect("failed to execute process");
+
+        assert!(status.success());
 
         // now verify the proof
         let pf_arg = format!("{}/{}/proof.pf", test_dir, example_name);
@@ -2375,6 +2412,18 @@ mod native_tests {
         let vk_arg = format!("{}/{}/key.vk", test_dir, example_name);
 
         let settings_arg = format!("--settings-path={}", settings_path);
+
+        // create encoded calldata
+        let status = Command::new(format!("{}/release/ezkl", *CARGO_TARGET_DIR))
+            .args(&[
+                "encode-evm-calldata",
+                "--proof-path",
+                &format!("{}/{}/proof.pf", test_dir, example_name),
+            ])
+            .status()
+            .expect("failed to execute process");
+
+        assert!(status.success());
 
         // create the verifier
         let mut args = vec!["create-evm-verifier", "--vk-path", &vk_arg, &settings_arg];

--- a/tests/python/binding_tests.py
+++ b/tests/python/binding_tests.py
@@ -402,6 +402,15 @@ async def test_create_evm_verifier():
     settings_path = os.path.join(folder_path, 'settings.json')
     sol_code_path = os.path.join(folder_path, 'test.sol')
     abi_path = os.path.join(folder_path, 'test.abi')
+    proof_path = os.path.join(folder_path, 'test_evm.pf')
+    calldata_path = os.path.join(folder_path, 'calldata.bytes')
+
+    # res is now a vector of bytes
+    res = ezkl.encode_evm_calldata(proof_path, calldata_path)
+
+    assert os.path.isfile(calldata_path)
+    assert len(res) > 0
+
 
     res = await ezkl.create_evm_verifier(
         vk_path,


### PR DESCRIPTION
Create an `encode-evm-calldata` helper function for folks that don't want to interact with contracts using ezkl tooling. 
Generally takes in: 
- proof path (we turn the proof into calldata) 
- calldata path (path to save the calldata) 
- vk_addr (optional vk addr if the vk is deployed as a separate contract) 

Usage in cli

```bash
ezkl encode-evm-calldata --proof-path <OPTIONAL_PATH_TO_PROOF> --calldata-path <OPTIONAL_PATH_TO_CALLDATA> --vk-addr <OPTIONAL_VK_ADDR>
```

In python the calldata is _also_ returned as an python object ... so you can use it directly in your python script 

```python
# res is now a vector of bytes
calldata = ezkl.encode_evm_calldata(proof_path, calldata_path)
assert os.path.isfile(calldata_path)
assert len(calldata) > 0

... do stuff with calldata
```
