### PR TITLE
feat: accept valid padding in conv node

### DIFF
--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -1161,7 +1161,8 @@ pub fn new_op_from_onnx(
             let padding = match &conv_node.pool_spec.padding {
                 PaddingSpec::Explicit(b, a) | PaddingSpec::ExplicitOnnxPool(b, a, _) => {
                     b.iter().zip(a.iter()).map(|(b, a)| (*b, *a)).collect()
-                }
+                },
+                PaddingSpec::Valid => vec![(0, 0); conv_node.pool_spec.input_channels],
                 _ => {
                     return Err(GraphError::MissingParams("padding".to_string()));
                 }

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -1162,7 +1162,7 @@ pub fn new_op_from_onnx(
                 PaddingSpec::Explicit(b, a) | PaddingSpec::ExplicitOnnxPool(b, a, _) => {
                     b.iter().zip(a.iter()).map(|(b, a)| (*b, *a)).collect()
                 },
-                PaddingSpec::Valid => vec![(0, 0); conv_node.pool_spec.input_channels],
+                PaddingSpec::Valid => vec![(0, 0); 4],
                 _ => {
                     return Err(GraphError::MissingParams("padding".to_string()));
                 }


### PR DESCRIPTION
`tract`'s representation allows no padding to be specified by setting the padding parameter explicitly to zero, or by passing `PaddingSpec::Valid`. Currently, only models defining it explicitly are supported, so this PR adds support for "valid" padding.

The original motivation behind this is adding support for [convolutional layers in Keras](https://keras.io/api/layers/convolution_layers/convolution2d/), which only allows padding to be `valid` or `same` and which, when configured to `valid`, exported to ONNX and parsed by `tract`, results in `PaddingSpec::Valid`.
