### PR TITLE
fix: num groups for conv operations should be specified at load time

### DIFF
--- a/benches/accum_conv.rs
+++ b/benches/accum_conv.rs
@@ -72,6 +72,7 @@ impl Circuit<Fr> for MyCircuit {
                         Box::new(PolyOp::Conv {
                             padding: vec![(0, 0)],
                             stride: vec![1; 2],
+                            group: 1,
                         }),
                     )
                     .unwrap();

--- a/examples/conv2d_mnist/main.rs
+++ b/examples/conv2d_mnist/main.rs
@@ -205,6 +205,7 @@ where
                     let op = PolyOp::Conv {
                         padding: vec![(PADDING, PADDING); 2],
                         stride: vec![STRIDE; 2],
+                        group: 1,
                     };
                     let x = config
                         .layer_config

--- a/src/circuit/ops/layouts.rs
+++ b/src/circuit/ops/layouts.rs
@@ -3484,7 +3484,7 @@ pub fn conv<
     }
 
     // if image is 3d add a dummy batch dimension
-    if image.dims().len() == 3 && kernel.dims().len() == 4 {
+    if image.dims().len() == kernel.dims().len() - 1 {
         image.reshape(&[1, image.dims()[0], image.dims()[1], image.dims()[2]])?;
     }
 

--- a/src/circuit/tests.rs
+++ b/src/circuit/tests.rs
@@ -1050,6 +1050,7 @@ mod conv {
                                 Box::new(PolyOp::Conv {
                                     padding: vec![(1, 1); 2],
                                     stride: vec![2; 2],
+                                    group: 1,
                                 }),
                             )
                             .map_err(|_| Error::Synthesis)
@@ -1200,6 +1201,7 @@ mod conv_col_ultra_overflow {
                                 Box::new(PolyOp::Conv {
                                     padding: vec![(1, 1); 2],
                                     stride: vec![2; 2],
+                                    group: 1,
                                 }),
                             )
                             .map_err(|_| Error::Synthesis)
@@ -1345,6 +1347,7 @@ mod conv_relu_col_ultra_overflow {
                                 Box::new(PolyOp::Conv {
                                     padding: vec![(1, 1); 2],
                                     stride: vec![2; 2],
+                                    group: 1,
                                 }),
                             )
                             .map_err(|_| Error::Synthesis);

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -283,10 +283,7 @@ pub fn new_op_from_onnx(
         .flat_map(|x| x.out_scales())
         .collect::<Vec<_>>();
 
-    let input_dims = inputs
-        .iter()
-        .flat_map(|x| x.out_dims())
-        .collect::<Vec<_>>();
+    let input_dims = inputs.iter().flat_map(|x| x.out_dims()).collect::<Vec<_>>();
 
     let mut replace_const = |scale: crate::Scale,
                              index: usize,
@@ -1192,7 +1189,13 @@ pub fn new_op_from_onnx(
                 }
             }
 
-            SupportedOp::Linear(PolyOp::Conv { padding, stride })
+            let group = conv_node.group;
+
+            SupportedOp::Linear(PolyOp::Conv {
+                padding,
+                stride,
+                group,
+            })
         }
         "Not" => SupportedOp::Linear(PolyOp::Not),
         "And" => SupportedOp::Linear(PolyOp::And),
@@ -1247,6 +1250,7 @@ pub fn new_op_from_onnx(
                 padding,
                 output_padding: deconv_node.adjustments.to_vec(),
                 stride,
+                group: deconv_node.group,
             })
         }
         "Downsample" => {


### PR DESCRIPTION
Number of groups is currently inferred from the image dims (which as all things has edge cases). 

Here we explicitly specify the groups at load time (saves on 1 calc) and make sure that underspecified convs (off by 1 dim)  now have a solution (eg. kernel dims > image dims) 

