### PR TITLE
ci: remove armv7 and remove `v0.0.0` from auto python docs

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Python Bindings
+t name: Build and Publish Python Bindings
 
 on:
   workflow_dispatch:
@@ -283,8 +283,6 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-musl
             arch: aarch64
-          - target: armv7-unknown-linux-musleabihf
-            arch: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/docs/python/requirements-docs.txt
+++ b/docs/python/requirements-docs.txt
@@ -1,4 +1,4 @@
-ezkl==0.0.0
+ezkl
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-napoleon


### PR DESCRIPTION
Changes:
1. Remove armv7, this is causing recent releases to fail. Also raspberry pi 4s are using aarch64 atm so it might not be very useful to support armv7 as it is dated and causing weird bugs.

2. Remove v0.0.0 from the requirements in sphinx docs to download the recent pypi release instead. 