### PR TITLE
fix: typo in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub fn version() -> &'static str {
     }
 }
 
-/// Bindings managment
+/// Bindings management
 #[cfg(any(
     feature = "ios-bindings",
     all(target_arch = "wasm32", target_os = "unknown"),


### PR DESCRIPTION
<img width="318" alt="Снимок экрана 2024-12-01 в 13 47 12" src="https://github.com/user-attachments/assets/fa0fdfb9-29b6-4c72-87e8-39f75b92b93b">

- **"Bindings managment"** should be **"Bindings management"**.

"Managment" is a common misspelling of "management."

Fixed.