### PR TITLE
fix: revert pypi to 1.11.0

### DIFF
--- a/.github/workflows/pypi-gpu.yml
+++ b/.github/workflows/pypi-gpu.yml
@@ -98,14 +98,14 @@ jobs:
       # publishes to PyPI
       - name: Publish package distributions to PyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.11.0
         with:
           packages-dir: ./
 
       # publishes to TestPyPI
       - name: Publish package distribution to TestPyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.11.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ./

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -355,7 +355,7 @@ jobs:
       # publishes to TestPyPI
       - name: Publish package distribution to TestPyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1.110
+        uses: pypa/gh-action-pypi-publish@release/v1.11.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ./

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -348,14 +348,14 @@ jobs:
       # publishes to PyPI
       - name: Publish package distributions to PyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.11.0
         with:
           packages-dir: ./
 
       # publishes to TestPyPI
       - name: Publish package distribution to TestPyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.110
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ./


### PR DESCRIPTION
Changes:
1. Reduce non-determinism in builds by specifying major and minor versions in `/pypa/gh-action-pypi-publish`