### PR TITLE
fix: const filtering strat is size dependent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,10 @@ runner = 'wasm-bindgen-test-runner'
 
 
 [[bench]]
+name = "zero_finder"
+harness = false
+
+[[bench]]
 name = "accum_dot"
 harness = false
 

--- a/benches/zero_finder.rs
+++ b/benches/zero_finder.rs
@@ -1,0 +1,116 @@
+use std::thread;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use halo2curves::{bn256::Fr as F, ff::Field};
+use maybe_rayon::{
+    iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
+    slice::ParallelSlice,
+};
+use rand::Rng;
+
+// Assuming these are your types
+#[derive(Clone)]
+enum ValType {
+    Constant(F),
+    AssignedConstant(usize, F),
+    Other,
+}
+
+// Helper to generate test data
+fn generate_test_data(size: usize, zero_probability: f64) -> Vec<ValType> {
+    let mut rng = rand::thread_rng();
+    (0..size)
+        .map(|_i| {
+            if rng.gen::<f64>() < zero_probability {
+                ValType::Constant(F::ZERO)
+            } else {
+                ValType::Constant(F::ONE) // Or some other non-zero value
+            }
+        })
+        .collect()
+}
+
+fn bench_zero_finding(c: &mut Criterion) {
+    let sizes = [
+        1_000,         // 1K
+        10_000,        // 10K
+        100_000,       // 100K
+        256 * 256 * 2, // Our specific case
+        1_000_000,     // 1M
+        10_000_000,    // 10M
+    ];
+
+    let zero_probability = 0.1; // 10% zeros
+
+    let mut group = c.benchmark_group("zero_finding");
+    group.sample_size(10); // Adjust based on your needs
+
+    for &size in &sizes {
+        let data = generate_test_data(size, zero_probability);
+
+        // Benchmark sequential version
+        group.bench_function(format!("sequential_{}", size), |b| {
+            b.iter(|| {
+                let result = data
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, e)| match e {
+                        ValType::Constant(r) | ValType::AssignedConstant(_, r) => {
+                            (*r == F::ZERO).then_some(i)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                black_box(result)
+            })
+        });
+
+        // Benchmark parallel version
+        group.bench_function(format!("parallel_{}", size), |b| {
+            b.iter(|| {
+                let result = data
+                    .par_iter()
+                    .enumerate()
+                    .filter_map(|(i, e)| match e {
+                        ValType::Constant(r) | ValType::AssignedConstant(_, r) => {
+                            (*r == F::ZERO).then_some(i)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                black_box(result)
+            })
+        });
+
+        // Benchmark chunked parallel version
+        group.bench_function(format!("chunked_parallel_{}", size), |b| {
+            b.iter(|| {
+                let num_cores = thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1);
+                let chunk_size = (size / num_cores).max(100);
+
+                let result = data
+                    .par_chunks(chunk_size)
+                    .enumerate()
+                    .flat_map(|(chunk_idx, chunk)| {
+                        chunk
+                            .par_iter() // Make sure we use par_iter() here
+                            .enumerate()
+                            .filter_map(move |(i, e)| match e {
+                                ValType::Constant(r) | ValType::AssignedConstant(_, r) => {
+                                    (*r == F::ZERO).then_some(chunk_idx * chunk_size + i)
+                                }
+                                _ => None,
+                            })
+                    })
+                    .collect::<Vec<_>>();
+                black_box(result)
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_zero_finding);
+criterion_main!(benches);

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -488,7 +488,8 @@ pub async fn deploy_da_verifier_via_solidity(
         }
     }
 
-    let contract = match call_to_account {
+    
+    match call_to_account {
         Some(call) => {
             deploy_single_da_contract(
                 client,
@@ -514,8 +515,7 @@ pub async fn deploy_da_verifier_via_solidity(
             )
             .await
         }
-    };
-    return contract;
+    }
 }
 
 async fn deploy_multi_da_contract(
@@ -630,7 +630,7 @@ async fn deploy_single_da_contract(
             // bytes memory _callData,
             PackedSeqToken(call_data.as_ref()),
             // uint256 _decimals,
-            WordToken(B256::from(decimals).into()),
+            WordToken(B256::from(decimals)),
             // uint[] memory _scales,
             DynSeqToken(
                 scales

--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -1136,23 +1136,21 @@ pub fn new_op_from_onnx(
                         a: crate::circuit::utils::F32(exponent),
                     })
                 }
-            } else {
-                if let Some(c) = inputs[0].opkind().get_mutable_constant() {
-                    inputs[0].decrement_use();
-                    deleted_indices.push(0);
-                    if c.raw_values.len() > 1 {
-                        unimplemented!("only support scalar base")
-                    }
-
-                    let base = c.raw_values[0];
-
-                    SupportedOp::Nonlinear(LookupOp::Exp {
-                        scale: scale_to_multiplier(input_scales[1]).into(),
-                        base: base.into(),
-                    })
-                } else {
-                    unimplemented!("only support constant base or pow for now")
+            } else if let Some(c) = inputs[0].opkind().get_mutable_constant() {
+                inputs[0].decrement_use();
+                deleted_indices.push(0);
+                if c.raw_values.len() > 1 {
+                    unimplemented!("only support scalar base")
                 }
+
+                let base = c.raw_values[0];
+
+                SupportedOp::Nonlinear(LookupOp::Exp {
+                    scale: scale_to_multiplier(input_scales[1]).into(),
+                    base: base.into(),
+                })
+            } else {
+                unimplemented!("only support constant base or pow for now")
             }
         }
         "Div" => {


### PR DESCRIPTION
Currently constant filtering uses parallelism like a hammer _but_ for `einsum` operations where `dot` and `constant` filtering may be called repeatedly for MANY small arrays (eg. `einsum ijk,ijk->ij` where input dims are `[1024,1024,2]` we call it 1024*1024 times for arrays of size 2 which, induces terrible overhead from spinning up threads. 

Instead we should use sequential search methods for smaller arrays, lest we want to avoid this overhead. 

Here we also leverage benchmarks to get a rough threshold where we should switch from sequential to a parallel search for constants. On a M3 Max the results are below, giving us a rough crossover point of 1mil elements. 


```
zero_finding/sequential_1000
                        time:   [1.0408 µs 1.0438 µs 1.0495 µs]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
zero_finding/parallel_1000
                        time:   [73.068 µs 77.557 µs 83.013 µs]
zero_finding/chunked_parallel_1000
                        time:   [90.572 µs 94.148 µs 98.686 µs]
zero_finding/sequential_10000
                        time:   [9.1284 µs 9.1548 µs 9.1806 µs]
zero_finding/parallel_10000
                        time:   [189.68 µs 197.12 µs 204.70 µs]
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild
zero_finding/chunked_parallel_10000
                        time:   [205.38 µs 208.58 µs 212.23 µs]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high mild
zero_finding/sequential_100000
                        time:   [111.68 µs 113.21 µs 115.09 µs]
zero_finding/parallel_100000
                        time:   [533.02 µs 537.91 µs 543.24 µs]
zero_finding/chunked_parallel_100000
                        time:   [528.67 µs 533.78 µs 539.20 µs]
zero_finding/sequential_131072
                        time:   [154.65 µs 161.51 µs 166.73 µs]
zero_finding/parallel_131072
                        time:   [578.23 µs 582.05 µs 585.90 µs]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
zero_finding/chunked_parallel_131072
                        time:   [577.69 µs 581.33 µs 585.17 µs]
zero_finding/sequential_1000000
                        time:   [1.4908 ms 1.5081 ms 1.5198 ms]
zero_finding/parallel_1000000
                        time:   [1.1452 ms 1.1618 ms 1.1837 ms]
zero_finding/chunked_parallel_1000000
                        time:   [1.1548 ms 1.1711 ms 1.1889 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
zero_finding/sequential_10000000
                        time:   [15.812 ms 16.083 ms 16.453 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
zero_finding/parallel_10000000
                        time:   [6.0287 ms 6.1100 ms 6.1853 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
zero_finding/chunked_parallel_10000000
                        time:   [5.9212 ms 5.9562 ms 5.9955 ms]
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

```  