### PR TITLE
fix: eager exec of `ok_or` error prints

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,17 +6,6 @@ on:
         description: "Test scenario tags"
 
 jobs:
-  bench_elgamal:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-06-27
-          override: true
-          components: rustfmt, clippy
-      - name: Bench elgamal
-        run: cargo bench --verbose --bench elgamal
 
   bench_poseidon:
     runs-on: self-hosted

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -281,7 +281,7 @@ impl GraphWitness {
 
         let reader = std::io::BufReader::with_capacity(*EZKL_BUF_CAPACITY, file);
         let witness: GraphWitness =
-            serde_json::from_reader(reader).map_err(|e| Into::<GraphError>::into(e))?;
+            serde_json::from_reader(reader).map_err(Into::<GraphError>::into)?;
 
         // check versions match
         crate::check_version_string_matches(witness.version.as_deref().unwrap_or(""));

--- a/src/graph/model.rs
+++ b/src/graph/model.rs
@@ -630,9 +630,7 @@ impl Model {
         let mut model = tract_onnx::onnx().model_for_read(reader)?;
 
         let variables: std::collections::HashMap<String, usize> =
-            std::collections::HashMap::from_iter(
-                variables.into_iter().map(|(k, v)| (k.clone(), *v)),
-            );
+            std::collections::HashMap::from_iter(variables.iter().map(|(k, v)| (k.clone(), *v)));
 
         for (i, id) in model.clone().inputs.iter().enumerate() {
             let input = model.node_mut(id.node);


### PR DESCRIPTION
`ok_or` can eagerly execute printouts without actually returning an error value, making it seem like a process has failed (when it hasnt) 