### PR TITLE
fix: swift pm ci issue with updating testing files

### DIFF
--- a/.github/workflows/swift-pm.yml
+++ b/.github/workflows/swift-pm.yml
@@ -47,7 +47,8 @@ jobs:
 
       - name: Copy Test Files
         run: |
-          rm -rf ezkl-swift-package/Tests/EzklAssets/*
+          rm -rf ezkl-swift-package/Tests/EzklAssets/
+          mkdir -p ezkl-swift-package/Tests/EzklAssets/
           cp tests/assets/kzg ezkl-swift-package/Tests/EzklAssets/kzg.srs
           cp tests/assets/input.json ezkl-swift-package/Tests/EzklAssets/input.json
           cp tests/assets/model.compiled ezkl-swift-package/Tests/EzklAssets/network.ezkl


### PR DESCRIPTION
This PR resolves an issue in the CI pipeline where `zsh` would prompt the user for confirmation (`y`) during the file deletion step (`rm -rf *`), which was not handled by the script. This caused subsequent tests to fail due to missing files.

### Changes:
- Replaced `rm -rf *` with a safer approach that deletes the entire directory (`rm -rf`) and recreates it (`mkdir -p`).
- Ensured all required testing files are copied into the recreated directory.
