### PR TITLE
chore: fix typos in comments and docs

### DIFF
--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -597,7 +597,7 @@ fn poseidon_hash(message: Vec<PyFelt>) -> PyResult<Vec<PyFelt>> {
 /// Arguments
 /// -------
 /// message: list[str]
-///     List of field elements represnted as strings
+///     List of field elements represented as strings
 ///
 /// vk_path: str
 ///     Path to the verification key
@@ -656,7 +656,7 @@ fn kzg_commit(
 /// Arguments
 /// -------
 /// message: list[str]
-///     List of field elements represnted as strings
+///     List of field elements represented as strings
 ///
 /// vk_path: str
 ///     Path to the verification key
@@ -1950,7 +1950,7 @@ fn deploy_da_evm(
 ///     does the verifier use data attestation ?
 ///
 /// addr_vk: str
-///     The addess of the separate VK contract (if the verifier key is rendered as a separate contract)
+///     The address of the separate VK contract (if the verifier key is rendered as a separate contract)
 /// Returns
 /// -------
 /// bool

--- a/src/circuit/ops/layouts.rs
+++ b/src/circuit/ops/layouts.rs
@@ -349,7 +349,7 @@ pub fn sqrt<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>(
         .into()
     };
     claimed_output.reshape(input_dims)?;
-    // force the output to be positive or zero, also implicitly checks that the ouput is in range
+    // force the output to be positive or zero, also implicitly checks that the output is in range
     let claimed_output = abs(config, region, &[claimed_output.clone()])?;
     // rescaled input
     let rescaled_input = pairwise(config, region, &[input.clone(), unit_scale], BaseOp::Mult)?;
@@ -1841,7 +1841,7 @@ pub(crate) fn get_missing_set_elements<
 
         // get the difference between the two vectors
         for eval in input_evals.iter() {
-            // delete first occurence of that value
+            // delete first occurrence of that value
             if let Some(pos) = fullset_evals.iter().position(|x| x == eval) {
                 fullset_evals.remove(pos);
             }
@@ -1869,7 +1869,7 @@ pub(crate) fn get_missing_set_elements<
     region.increment(claimed_output.len());
 
     // input and claimed output should be the shuffles of fullset
-    // concatentate input and claimed output
+    // concatenate input and claimed output
     let input_and_claimed_output = input.concat(claimed_output.clone())?;
 
     // assert that this is a permutation/shuffle
@@ -3396,7 +3396,7 @@ pub fn max_pool<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>(
 /// Performs a deconvolution on the given input tensor.
 /// # Examples
 /// ```
-// // expected ouputs are taken from pytorch torch.nn.functional.conv_transpose2d
+// // expected outputs are taken from pytorch torch.nn.functional.conv_transpose2d
 ///
 /// use ezkl::tensor::Tensor;
 /// use ezkl::fieldutils::IntegerRep;
@@ -3624,7 +3624,7 @@ pub fn deconv<
 
 /// Applies convolution over a ND tensor of shape C x H x D1...DN (and adds a bias).
 /// ```
-/// // expected ouputs are taken from pytorch torch.nn.functional.conv2d
+/// // expected outputs are taken from pytorch torch.nn.functional.conv2d
 ///
 /// use ezkl::tensor::Tensor;
 /// use ezkl::fieldutils::IntegerRep;
@@ -3908,7 +3908,7 @@ pub(crate) fn rescale<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>
     Ok(rescaled_inputs)
 }
 
-/// Dummy (no contraints) reshape layout
+/// Dummy (no constraints) reshape layout
 pub(crate) fn reshape<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>(
     values: &[ValTensor<F>; 1],
     new_dims: &[usize],
@@ -3918,7 +3918,7 @@ pub(crate) fn reshape<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>
     Ok(t)
 }
 
-/// Dummy (no contraints) move_axis layout
+/// Dummy (no constraints) move_axis layout
 pub(crate) fn move_axis<F: PrimeField + TensorType + PartialOrd + std::hash::Hash>(
     values: &[ValTensor<F>; 1],
     source: usize,

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -337,7 +337,7 @@ mod wasm32 {
         // Run compiled circuit validation on onnx network (should fail)
         let circuit = compiledCircuitValidation(wasm_bindgen::Clamped(NETWORK.to_vec()));
         assert!(circuit.is_err());
-        // Run compiled circuit validation on comiled network (should pass)
+        // Run compiled circuit validation on compiled network (should pass)
         let circuit = compiledCircuitValidation(wasm_bindgen::Clamped(NETWORK_COMPILED.to_vec()));
         assert!(circuit.is_ok());
         // Run input validation on witness (should fail)


### PR DESCRIPTION
Hi! I stumbled upon a few typos in the comments and documentation, and they were bugging me. Here's what I fixed:  

- In `python.rs`, **"represnted"** and **"addess"** are now **"represented"** and **"address."**  
- In `layouts.rs**, there were some weird words like **"ouput,"** **"occurence,"** and **"contraints"** — now they're all correct.  
- In `wasm.rs`, someone wrote **"comiled"** instead of **"compiled"** — fixed that too.  

No magic here, just small tweaks for clarity and order.