### PR TITLE
chore: fix typos

### DIFF
--- a/contracts/AttestData.sol
+++ b/contracts/AttestData.sol
@@ -182,8 +182,8 @@ contract DataAttestationSingle is LoadInstances, SwapProofCommitments {
 
     /**
      * @notice EZKL P value
-     * @dev In order to prevent the verifier from accepting two version of the same pubInput, n and the quantity (n + P),  where n + P <= 2^256, we require that all instances are stricly less than P. a
-     * @dev The reason for this is that the assmebly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P.
+     * @dev In order to prevent the verifier from accepting two versions of the same pubInput, n and the quantity (n + P), where n + P <= 2^256, we require that all instances are strictly less than P.
+     * @dev The reason for this is that the assembly code of the verifier performs all arithmetic operations modulo P and as a consequence can't distinguish between n and n + P.
      */
     uint256 constant ORDER =
         uint256(


### PR DESCRIPTION
I noticed a few typos in the comments that could cause confusion. Here are the corrections:  

- Changed "two version" to "two versions".  
- Fixed "stricly" to "strictly".  
- Corrected "assmebly" to "assembly".  
