### PR TITLE
Fix grammatical errors and improve readability in documentation

### DIFF
--- a/docs/advanced_security/public_commitments.md
+++ b/docs/advanced_security/public_commitments.md
@@ -7,7 +7,7 @@
 A common design pattern in a zero knowledge (zk) application is thus:
 - A prover has some data which is used within a circuit.
 - This data, as it may be high-dimensional or somewhat private, is pre-committed to using some hash function.
-- The zk-circuit which forms the core of the application then proves (para-phrasing) a statement of the form:
+- The zk-circuit which forms the core of the application then proves (paraphrasing) a statement of the form:
 >"I know some data D which when hashed corresponds to the pre-committed to value H + whatever else the circuit is proving over D". 
 
 From our own experience, we've implemented such patterns using snark-friendly hash functions like [Poseidon](https://www.poseidon-hash.info/), for which there is a relatively well vetted [implementation](https://docs.rs/halo2_gadgets/latest/halo2_gadgets/poseidon/index.html) in Halo2. Even then these hash functions can introduce lots of overhead and can be very expensive to generate proofs for if the dimensionality of the data D is large. 

--- a/docs/advanced_security/quantization_backdoors.md
+++ b/docs/advanced_security/quantization_backdoors.md
@@ -1,6 +1,6 @@
 # EZKL Security Note: Quantization-Induced Model Backdoors
 
-> Note: this only affects a situation where a party separate to an application's developer has access to the model's weights and can modify them. This is a common scenario in adversarial machine learning research, but can be less common in real-world applications. If you're building your models in house and deploying them yourself, this is less of a concern. If you're building a permisionless system where anyone can submit models, this is more of a concern.
+> Note: this only affects a situation where a party separate to an application's developer has access to the model's weights and can modify them. This is a common scenario in adversarial machine learning research, but can be less common in real-world applications. If you're building your models in house and deploying them yourself, this is less of a concern. If you're building a permissionless system where anyone can submit models, this is more of a concern.
 
 Models processed through EZKL's quantization step can harbor backdoors that are dormant in the original full-precision model but activate during quantization. These backdoors force specific outputs when triggered, with impact varying by application.
 


### PR DESCRIPTION
1. src/pages/build/getting-started.mdx
Fixed incorrect hyphenation of "para-phrasing"
Before: "The zk-circuit which forms the core of the application then proves (para-phrasing) a statement of the form:"
After: "The zk-circuit which forms the core of the application then proves (paraphrasing) a statement of the form:"
Reason: "para-phrasing" is an incorrect split of the word. The correct spelling is "paraphrasing."
2. src/pages/security/quantization-backdoors.mdx
Fixed spelling error in "permisionless"
Before: "If you're building a permisionless system where anyone can submit models, this is more of a concern."
After: "If you're building a permissionless system where anyone can submit models, this is more of a concern."
Reason: The correct spelling is "permissionless."