### PR TITLE
Fix function name mismatch in kzg_evm_on_chain_output_prove_and_verify_

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1048,7 +1048,7 @@ mod native_tests {
                     let test_dir = TempDir::new(test).unwrap();
                     let path = test_dir.path().to_str().unwrap(); crate::native_tests::mv_test_(path, test);
                     let _anvil_child = crate::native_tests::start_anvil(true, Hardfork::Latest);
-                    kzg_evm_on_chain_input_prove_and_verify(path, test.to_string(), "file", "on-chain", "private", "public", "private");
+                    kzg_evm_on_chain_output_prove_and_verify(path, test.to_string(), "file", "on-chain", "private", "public", "private");
                     // test_dir.close().unwrap();
                 }
 


### PR DESCRIPTION
Description:
Fixed inconsistency in function call where kzg_evm_on_chain_input_prove_and_verify was incorrectly used inside kzg_evm_on_chain_output_prove_and_verify_ function. Changed to kzg_evm_on_chain_output_prove_and_verify to match the function's purpose and maintain consistency.