### PR TITLE
docs: fixed typo: "commiting" → "committing"

### DIFF
--- a/docs/advanced_security/public_commitments.md
+++ b/docs/advanced_security/public_commitments.md
@@ -20,7 +20,7 @@ You can also implement such a pattern using Halo2's `Fixed` columns _if the priv
 
 The annoyance in using `Fixed` columns comes from the fact that they require generating a new verifying key every time a new set of commitments is generated.
 
-> **Example:** Say for instance an application leverages a zero-knowledge circuit to prove the correct execution of a neural network. Every week the neural network is finetuned or retrained on new data. If the architecture remains the same then commiting to the new network parameters, along with a new proof of performance on a test set, would be an ideal setup. If we leverage `Fixed` columns to commit to the model parameters, each new commitment will require re-generating a  verifying key and sharing the new key with the verifier(s). This is not-ideal UX and can become expensive if the verifier is deployed on-chain. 
+> **Example:** Say for instance an application leverages a zero-knowledge circuit to prove the correct execution of a neural network. Every week the neural network is finetuned or retrained on new data. If the architecture remains the same then committing to the new network parameters, along with a new proof of performance on a test set, would be an ideal setup. If we leverage `Fixed` columns to commit to the model parameters, each new commitment will require re-generating a  verifying key and sharing the new key with the verifier(s). This is not-ideal UX and can become expensive if the verifier is deployed on-chain. 
 
 An ideal commitment would thus have the low cost of a `Fixed`  column but wouldn't require regenerating a new verifying key for each new commitment.
 


### PR DESCRIPTION
I noticed a typo in the documentation where "commiting" was used instead of the correct spelling "committing."