### PR TITLE
docs: fixed typo in technical post disclaimer

### DIFF
--- a/docs/advanced_security/public_commitments.md
+++ b/docs/advanced_security/public_commitments.md
@@ -1,6 +1,6 @@
 ## EZKL Security Note: Public Commitments and Low-Entropy Data
 
-> **Disclaimer:** this a more technical post that requires some prior knowledge of how ZK proving systems like Halo2 operate, and in particular in how these APIs are constructed. For background reading we highly recommend the [Halo2 book](https://zcash.github.io/halo2/) and [Halo2 Club](https://halo2.club/).
+> **Disclaimer:** this is a more technical post that requires some prior knowledge of how ZK proving systems like Halo2 operate, and in particular in how these APIs are constructed. For background reading we highly recommend the [Halo2 book](https://zcash.github.io/halo2/) and [Halo2 Club](https://halo2.club/).
 
 ## Overview of commitments in EZKL
 


### PR DESCRIPTION
I corrected a typo in the disclaimer section where "this a more technical post" was used.
It has now been updated to "this is a more technical post" for clarity and correctness.