### PR TITLE
chore: pass in raw data for gen-witness from file

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -176,7 +176,7 @@ pub async fn run(command: Commands) -> Result<String, EZKLError> {
             srs_path,
         } => gen_witness(
             compiled_circuit.unwrap_or(DEFAULT_COMPILED_CIRCUIT.into()),
-            data.unwrap_or(DEFAULT_DATA.into()),
+            data.unwrap_or(DataField(DEFAULT_DATA.into())).to_string(),
             Some(output.unwrap_or(DEFAULT_WITNESS.into())),
             vk_path,
             srs_path,


### PR DESCRIPTION
You can now pass data as a raw string to gen-witness using @<file_path> as an argument to data: 

```bash
ezkl gen-witness -D @input.json
```