### PR TITLE
docs: remove consecutive duplicate words

### DIFF
--- a/src/circuit/ops/errors.rs
+++ b/src/circuit/ops/errors.rs
@@ -19,7 +19,7 @@ pub enum CircuitError {
     /// Error when instantiating lookup tables
     #[error("failed to instantiate lookup tables")]
     LookupInstantiation,
-    /// A lookup table was was already assigned
+    /// A lookup table was already assigned
     #[error("attempting to initialize an already instantiated lookup table")]
     TableAlreadyAssigned,
     /// This operation is unsupported


### PR DESCRIPTION
hey team! I found duplicate words and fixed them.