### PR TITLE
fix: correct commitment type in ipa_commit function

### DIFF
--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -680,7 +680,7 @@ fn ipa_commit(
         .map_err(|_| PyIOError::new_err("Failed to load circuit settings"))?;
 
     let srs_path =
-        crate::execute::get_srs_path(settings.run_args.logrows, srs_path, Commitments::KZG);
+        crate::execute::get_srs_path(settings.run_args.logrows, srs_path, Commitments::IPA);
 
     let srs = load_srs_prover::<IPACommitmentScheme<G1Affine>>(srs_path)
         .map_err(|_| PyIOError::new_err("Failed to load srs"))?;


### PR DESCRIPTION
Fix logical error in ipa_commit function - use Commitments::IPA instead of Commitments::KZG when getting SRS path to ensure correct SRS file type is used for IPA commitments.