### PR TITLE
Fix division by zero vulnerability in graph utilities multiplication optimization

### DIFF
--- a/src/graph/utilities.rs
+++ b/src/graph/utilities.rs
@@ -1050,7 +1050,7 @@ pub fn new_op_from_onnx(
                 }
 
                 if let Some(c) = inputs[const_idx].opkind().get_mutable_constant() {
-                    if c.raw_values.len() == 1 && c.raw_values[0] < 1. {
+                    if c.raw_values.len() == 1 && c.raw_values[0] < 1. && c.raw_values[0] != 0.0 {
                         // if not divisible by 2 then we need to add a range check
                         let raw_values = 1.0 / c.raw_values[0];
                         if raw_values.log2().fract() == 0.0 {


### PR DESCRIPTION
### Summary
This PR fixes a critical logical error that could cause runtime panics due to division by zero in the graph utilities module.

### Problem
In `src/graph/utilities.rs` at line 1055, the code performs division `1.0 / c.raw_values[0]` after only checking that `c.raw_values[0] < 1.0`. This condition allows `c.raw_values[0]` to be exactly `0.0`, which would cause a division by zero panic at runtime.

### Solution
Added an explicit check `&& c.raw_values[0] != 0.0` to the existing conditional to ensure the division operation is only performed when the divisor is guaranteed to be non-zero.

