### PR TITLE
fix: update srs mirror

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -539,7 +539,7 @@ pub(crate) async fn get_srs_cmd(
 
     if !srs_exists_check(k, srs_path.clone()) {
         info!("SRS does not exist, downloading...");
-        let srs_uri = format!("{}{}", PUBLIC_SRS_URL, k);
+        let srs_uri = format!("{}{}.srs", PUBLIC_SRS_URL, k);
         let mut reader = Cursor::new(fetch_srs(&srs_uri).await?);
         // check the SRS
         let pb = init_spinner();

--- a/src/pfsys/srs.rs
+++ b/src/pfsys/srs.rs
@@ -7,8 +7,9 @@ use std::io::BufReader;
 use std::path::PathBuf;
 
 /// for now we use the urls of the powers of tau ceremony from <https://github.com/han0110/halo2-kzg-srs>
+/// A mirror is now hosted on https://kzg.ezkl.xyz
 pub const PUBLIC_SRS_URL: &str =
-    "https://trusted-setup-halo2kzg.s3.eu-central-1.amazonaws.com/perpetual-powers-of-tau-raw-";
+    "https://kzg.ezkl.xyz/kzg";
 
 /// Helper function for generating SRS. Only use for testing
 pub fn gen_srs<Scheme: CommitmentScheme>(k: u32) -> Scheme::ParamsProver {


### PR DESCRIPTION
Changes:
1. han0110 stopped hosting the SRS [issue](https://github.com/han0110/halo2-kzg-srs/issues/14)
2. New srs mirror is created at `https://kzg.ezkl.xyz/kzg{n}.srs` 
3. `get-srs` reflects this new mirror