### PR TITLE
fix(python): initialize and expose ICICLE GPU runtime

### DIFF
--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -28,10 +28,70 @@ use pyo3_stub_gen::{
 };
 use snark_verifier::util::arithmetic::PrimeField;
 use std::collections::HashSet;
+#[cfg(all(target_os = "linux", feature = "gpu-accelerated"))]
+use std::ffi::{CStr, CString};
 use std::str::FromStr;
+#[cfg(all(target_os = "linux", feature = "gpu-accelerated"))]
+use std::os::raw::{c_char, c_int};
 use std::{fs::File, path::PathBuf};
 
 type PyFelt = String;
+
+#[cfg(all(target_os = "linux", feature = "gpu-accelerated"))]
+#[allow(unsafe_code)]
+fn promote_icicle_frontend_libs_global() -> Result<(), String> {
+    const ICICLE_FRONTEND_LIBS: [&str; 4] = [
+        "libicicle_device.so",
+        "libicicle_hash.so",
+        "libicicle_field_bn254.so",
+        "libicicle_curve_bn254.so",
+    ];
+    const RTLD_NOW: c_int = 2;
+    const RTLD_NOLOAD: c_int = 4;
+    const RTLD_GLOBAL: c_int = 0x100;
+
+    unsafe extern "C" {
+        fn dlopen(filename: *const c_char, flags: c_int) -> *mut core::ffi::c_void;
+        fn dlerror() -> *const c_char;
+    }
+
+    fn last_dl_error() -> String {
+        unsafe {
+            let err = dlerror();
+            if err.is_null() {
+                "unknown dlopen error".to_string()
+            } else {
+                CStr::from_ptr(err).to_string_lossy().into_owned()
+            }
+        }
+    }
+
+    for lib_name in ICICLE_FRONTEND_LIBS {
+        let lib_name = CString::new(lib_name).map_err(|e| e.to_string())?;
+        unsafe {
+            dlerror();
+            let mut handle = dlopen(
+                lib_name.as_ptr(),
+                RTLD_NOW | RTLD_NOLOAD | RTLD_GLOBAL,
+            );
+
+            if handle.is_null() {
+                dlerror();
+                handle = dlopen(lib_name.as_ptr(), RTLD_NOW | RTLD_GLOBAL);
+            }
+
+            if handle.is_null() {
+                return Err(format!(
+                    "failed to promote {} to RTLD_GLOBAL: {}",
+                    lib_name.to_string_lossy(),
+                    last_dl_error()
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
 
 /// pyclass representing an enum
 #[pyclass]
@@ -1474,6 +1534,10 @@ define_stub_info_gatherer!(stub_info);
 #[pymodule]
 fn ezkl(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init();
+    #[cfg(all(target_os = "linux", feature = "gpu-accelerated"))]
+    if let Err(err) = promote_icicle_frontend_libs_global() {
+        log::warn!("Failed to promote ICICLE frontend libraries to RTLD_GLOBAL: {err}");
+    }
     m.add_class::<PyRunArgs>()?;
     m.add_class::<PyG1Affine>()?;
     m.add_class::<PyG1>()?;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -60,6 +60,8 @@ use std::io::Cursor;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(feature = "gpu-accelerated")]
+use std::sync::Once;
 use std::time::Duration;
 use tabled::Tabled;
 use thiserror::Error;
@@ -80,20 +82,25 @@ lazy_static! {
 
 }
 
+#[cfg(feature = "gpu-accelerated")]
+static GPU_BACKEND_INIT: Once = Once::new();
+
 /// Set the device used for computation.
 #[cfg(feature = "gpu-accelerated")]
 pub fn set_device() {
-    if std::env::var("ICICLE_BACKEND_INSTALL_DIR").is_ok() {
-        info!("Running with ICICLE GPU");
-        try_load_and_set_backend_device("CUDA");
-        match warmup(&IcicleStream::default()) {
-            Ok(_) => info!("GPU warmed :)"),
-            Err(e) => log::error!("GPU warmup failed: {:?}", e),
+    GPU_BACKEND_INIT.call_once(|| {
+        if std::env::var("ICICLE_BACKEND_INSTALL_DIR").is_ok() {
+            info!("Running with ICICLE GPU");
+            try_load_and_set_backend_device("CUDA");
+            match warmup(&IcicleStream::default()) {
+                Ok(_) => info!("GPU warmed :)"),
+                Err(e) => log::error!("GPU warmup failed: {:?}", e),
+            }
+        } else {
+            info!("Running with CPU: 'ICICLE_BACKEND_INSTALL_DIR' not set");
+            try_load_and_set_backend_device("CPU");
         }
-    } else {
-        info!("Running with CPU: 'ICICLE_BACKEND_INSTALL_DIR' not set");
-        try_load_and_set_backend_device("CPU");
-    }
+    });
 }
 
 /// A wrapper for execution errors
@@ -452,6 +459,8 @@ fn srs_exists_check(logrows: u32, srs_path: Option<PathBuf>) -> bool {
 }
 
 pub(crate) fn gen_srs_cmd(srs_path: PathBuf, logrows: u32) -> Result<String, EZKLError> {
+    #[cfg(feature = "gpu-accelerated")]
+    set_device();
     let params = gen_srs::<KZGCommitmentScheme<Bn256>>(logrows);
     save_params::<KZGCommitmentScheme<Bn256>>(&srs_path, &params)?;
     Ok(String::new())
@@ -1548,6 +1557,9 @@ pub(crate) fn setup(
     witness: Option<PathBuf>,
     disable_selector_compression: bool,
 ) -> Result<String, EZKLError> {
+    #[cfg(feature = "gpu-accelerated")]
+    set_device();
+
     // these aren't real values so the sanity checks are mostly meaningless
 
     let mut circuit = GraphCircuit::load(compiled_circuit)?;
@@ -1580,6 +1592,9 @@ pub(crate) fn prove(
     srs_path: Option<PathBuf>,
     check_mode: CheckMode,
 ) -> Result<Snark<Fr, G1Affine>, EZKLError> {
+    #[cfg(feature = "gpu-accelerated")]
+    set_device();
+
     let data = GraphWitness::from_path(data_path)?;
     let mut circuit = GraphCircuit::load(compiled_circuit_path)?;
 


### PR DESCRIPTION
# Summary

This fixes the Linux Python GPU path for `ezkl`.

Before this patch:

- the CLI path initialized the ICICLE backend/device through `run()`
- Python `gen_srs`, `setup`, and `prove` bypassed that path
- with `ICICLE_BACKEND_INSTALL_DIR` set, Python could still stay on CPU
- once Python was forced onto the CUDA path, backend loading could still fail because the ICICLE frontend shared libraries were not globally visible to later `dlopen` calls

After this patch:

- `gen_srs`, `setup`, and `prove` all initialize the GPU backend/device through the shared execution path
- Python module initialization promotes the required ICICLE frontend shared libraries to `RTLD_GLOBAL` on Linux GPU builds
- CUDA backend loading can resolve ICICLE symbols correctly

# Root Cause

There were two linked issues.

1. Control-flow gap

- `set_device()` existed, but only the CLI `run()` path called it
- Python reached GPU-sensitive halo2 / ICICLE code directly

2. Dynamic-linking gap

- after fixing the control-flow issue, CUDA backend loading still depended on symbols exported by:
  - `libicicle_device.so`
  - `libicicle_hash.so`
  - `libicicle_field_bn254.so`
  - `libicicle_curve_bn254.so`
- in Python, those frontend libraries were not globally visible by default
- later backend `dlopen` calls could fail to resolve symbols like `register_deviceAPI`

# Changes

## `src/execute.rs`

- make `set_device()` idempotent with `Once`
- call `set_device()` from:
  - `gen_srs_cmd`
  - `setup`
  - `prove`

## `src/bindings/python.rs`

- on Linux GPU builds, promote the ICICLE frontend shared libraries to `RTLD_GLOBAL` during module initialization

# Local Validation

Validated locally on `2026-05-17` in WSL on an RTX 5090.

## Build

```text
cargo check --lib --no-default-features --features python-bindings,gpu-accelerated,ezkl
maturin develop --no-default-features --features python-bindings,gpu-accelerated,ezkl
```

## Python repro

Minimal Python chain:

1. `gen_settings`
2. `compile_circuit`
3. `gen_witness`
4. `setup`
5. `prove`

Observed behavior:

- before patch:
  - Python logged only `Registering DEVICE: device=CPU`
- after only the execution-path fix:
  - Python entered CUDA setup, but backend loading still depended on global ICICLE symbols
- after the full patch:
  - Python logs `Registering DEVICE: device=CUDA`
  - backend loads successfully
  - `setup` and `prove` both succeed

# Scope

This is intentionally narrow:

- no algorithmic proving changes
- no non-Linux Python linker changes
- no unrelated build-system or dependency changes
