### PR TITLE
fix: install script fails silently when a release has no asset for this platform

### DIFF
--- a/install_ezkl_cli.sh
+++ b/install_ezkl_cli.sh
@@ -103,10 +103,35 @@ echo "Removing old ezkl binary if it exists"
 echo "Platform: $PLATFORM"
 echo "Architecture: $ARCHITECTURE"
 
+# Resolve the download URL for the given asset name from the release JSON in
+# $JSON_RESPONSE, and fail with an actionable message when the release has no
+# such asset. Without this check, `set -e` aborts the script at the failing
+# grep with no output at all (e.g. on macOS, where releases after v23.0.3 do
+# not ship prebuilt binaries). Matching on the unprefixed asset name keeps
+# both naming schemes working: releases up to v23.0.3 prefix every asset with
+# "build-artifacts.", v23.0.5+ do not.
+get_file_url() {
+    ASSET_NAME="$1"
+    FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "$ASSET_NAME" || true)
+    if [ -z "$FILE_URL" ]; then
+        echo "Error: this release has no $ASSET_NAME asset, so there is no prebuilt binary for your platform (${PLATFORM}, ${ARCHITECTURE})."
+        API_MESSAGE=$(echo "$JSON_RESPONSE" | grep -o '"message": *"[^"]*"' | head -1 || true)
+        AVAILABLE=$(echo "$JSON_RESPONSE" | grep -o '"name": *"[^"]*\.tar\.gz"' | sed 's/.*: *"//; s/"$//' | sort -u || true)
+        if [ -n "$AVAILABLE" ]; then
+            echo "Assets available in this release:"
+            echo "$AVAILABLE" | sed 's/^/  - /'
+        elif [ -n "$API_MESSAGE" ]; then
+            echo "GitHub API response: $API_MESSAGE"
+        fi
+        echo "You can install a specific version by passing its tag to this script, e.g.: v23.0.3 (the last release with macOS binaries)."
+        exit 1
+    fi
+}
+
 # download the release and unpack the right tarball
 if [ "$PLATFORM" == "windows-msvc" ]; then
     JSON_RESPONSE=$(curl -s "$RELEASE_URL")
-    FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "build-artifacts.ezkl-windows-msvc.tar.gz")
+    get_file_url "ezkl-windows-msvc.tar.gz"
 
     echo "Downloading package"
     curl -L "$FILE_URL" -o "$EZKL_DIR/build-artifacts.ezkl-windows-msvc.tar.gz"
@@ -120,7 +145,7 @@ if [ "$PLATFORM" == "windows-msvc" ]; then
 elif [ "$PLATFORM" == "macos" ]; then
     if [ "$ARCHITECTURE" == "aarch64" ] || [ "$ARCHITECTURE" == "arm64" ]; then
         JSON_RESPONSE=$(curl -s "$RELEASE_URL")
-        FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "build-artifacts.ezkl-macos-aarch64.tar.gz")
+        get_file_url "ezkl-macos-aarch64.tar.gz"
 
         echo "Downloading package"
         curl -L "$FILE_URL" -o "$EZKL_DIR/build-artifacts.ezkl-macos-aarch64.tar.gz"
@@ -132,7 +157,7 @@ elif [ "$PLATFORM" == "macos" ]; then
         rm "$EZKL_DIR/build-artifacts.ezkl-macos-aarch64.tar.gz"
     else
         JSON_RESPONSE=$(curl -s "$RELEASE_URL")
-        FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "build-artifacts.ezkl-macos.tar.gz")
+        get_file_url "ezkl-macos.tar.gz"
 
         echo "Downloading package"
         curl -L "$FILE_URL" -o "$EZKL_DIR/build-artifacts.ezkl-macos.tar.gz"
@@ -148,7 +173,7 @@ elif [ "$PLATFORM" == "macos" ]; then
 elif [ "$PLATFORM" == "linux" ]; then
     if [ "$ARCHITECTURE" == "amd64" ]; then
         JSON_RESPONSE=$(curl -s "$RELEASE_URL")
-        FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "build-artifacts.ezkl-linux-gnu.tar.gz")
+        get_file_url "ezkl-linux-gnu.tar.gz"
 
         echo "Downloading package"
         curl -L "$FILE_URL" -o "$EZKL_DIR/build-artifacts.ezkl-linux-gnu.tar.gz"
@@ -160,7 +185,7 @@ elif [ "$PLATFORM" == "linux" ]; then
         rm "$EZKL_DIR/build-artifacts.ezkl-linux-gnu.tar.gz"
     elif [ "$ARCHITECTURE" == "aarch64" ]; then
         JSON_RESPONSE=$(curl -s "$RELEASE_URL")
-        FILE_URL=$(echo "$JSON_RESPONSE" | grep -o 'https://github.com[^"]*' | grep "build-artifacts.ezkl-linux-aarch64.tar.gz")
+        get_file_url "ezkl-linux-aarch64.tar.gz"
 
         echo "Downloading package"
         curl -L "$FILE_URL" -o "$EZKL_DIR/build-artifacts.ezkl-linux-aarch64.tar.gz"


### PR DESCRIPTION
## Problem

`install_ezkl_cli.sh` currently dies with **no output at all** in two common situations, because `set -e` aborts at the failing `grep` inside the `FILE_URL=$(...)` assignment:

1. **Installing `latest` is broken on every platform.** Release asset naming changed in v23.0.5 (`build-artifacts.ezkl-linux-gnu.tar.gz` → `ezkl-linux-gnu.tar.gz`), and the script still greps for the old prefixed names — so the URL lookup matches nothing on Linux and Windows too, not just macOS.
2. **macOS binaries stopped shipping after v23.0.3**, so macOS users hit the same silent death regardless.

What a user sees today (macOS arm64, but Linux behaves identically on `latest`):

```
No version tags provided, installing the latest ezkl version
Removing old ezkl binary if it exists
Platform: macos
Architecture: aarch64
```
…then exit code 1, an empty `~/.ezkl`, and nothing to explain why.

## Fix

- Extract the URL lookup into `get_file_url()`, which fails loudly: names the missing asset, lists the assets the release **does** have (or surfaces the GitHub API error, e.g. `"Not Found"` for a bad tag), and points at the pass-a-version-tag escape hatch.
- Match assets by **unprefixed** name — grep's substring matching then resolves both naming schemes (≤ v23.0.3 prefixed, v23.0.5+ unprefixed), so `latest` works again on Linux/Windows and older tags keep working.

## Testing (macOS arm64)

- `latest` → clean error, lists the release's 5 linux/windows assets, exit 1 *(was: silent exit 1)*
- bogus tag `v99.99.99` → clean error + `"message": "Not Found"`, exit 1 *(was: silent exit 1)*
- `v23.0.3` → installs normally; `ezkl --version` → `ezkl 23.0.3` *(old naming still resolves)*
- URL resolution for `ezkl-linux-gnu.tar.gz` against `latest` → resolves to the v23.0.5 asset URL *(new naming resolves; couldn't execute the Linux binary on this machine)*
- `bash -n` passes

New failure output:

```
Error: this release has no ezkl-macos-aarch64.tar.gz asset, so there is no prebuilt binary for your platform (macos, aarch64).
Assets available in this release:
  - ezkl-linux-aarch64.tar.gz
  - ezkl-linux-gnu.tar.gz
  - ezkl-linux-gpu.tar.gz
  - ezkl-linux-musl.tar.gz
  - ezkl-windows-msvc.tar.gz
You can install a specific version by passing its tag to this script, e.g.: v23.0.3 (the last release with macOS binaries).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)